### PR TITLE
Add Google CSE search and feed discovery

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -20,11 +20,17 @@ jobs:
       - uses: actions/setup-python@v5
         with: {python-version: '3.11'}
       - run: pip install -r requirements.txt
+      - name: Run unit tests
+        run: pytest -q
+      - name: Ensure CSE key present
+        run: |
+          if [ -z "$GOOGLE_CSE_API_KEY" ] || [ -z "$GOOGLE_CSE_CX" ]; then
+            echo "Google CSE credentials missing" >&2
+            exit 1
+          fi
       - name: Run OSINT pipeline
         run: |
-          python -u -m src.scrape.rss
-          python -m src.scrape.sitemap
-          python -m src.scrape.cse
+          python -m src.cli
           python -m src.scrape.crawl
           python -m src.scrape.wayback
           python -m src.scrape.parse

--- a/README.md
+++ b/README.md
@@ -39,3 +39,10 @@ Environment variables and GitHub secrets used by the pipeline:
 RSS → Sitemap → CSE → Crawl → Wayback → Parse → Extract → Dedupe →
 DuckDB → Exports → rclone → QA → Report
 ```
+
+### Automatic source discovery
+
+Search terms for Google Custom Search are defined in `configs/settings.yml` under
+`search.queries`. Running `python -m src.cli` will issue these queries, collect
+unique domains and attempt RSS feed discovery for each domain. Discovered feeds
+are saved to `yacht_osint/data/cache/discovered_feeds.json`.

--- a/configs/settings.yml
+++ b/configs/settings.yml
@@ -11,3 +11,11 @@ llm:
   temperature: 0
   schema_retry: 1
 canonical_db_path: ${CANONICAL_DB_PATH}
+search:
+  queries:
+    - superyacht news
+    - yacht industry blog
+    - megayacht updates
+  result_count: 5
+  domain_whitelist: []
+  domain_blacklist: []

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,3 +20,5 @@ pydrive2
 pandera
 tenacity
 python-dotenv
+feedfinder2
+tldextract

--- a/src/cli.py
+++ b/src/cli.py
@@ -1,7 +1,29 @@
+from __future__ import annotations
+
+import json
 import logging
+from pathlib import Path
 
-def run():
-    logging.getLogger(__name__).info("stub")
+from src.common import load_settings
+from src.scrape import rss as rss_mod
+from src.scrape import search as search_mod
 
-if __name__ == "__main__":
+log = logging.getLogger(__name__)
+
+
+def run() -> None:
+    settings = load_settings()
+    domains = search_mod.run(settings.search.queries, settings.search.result_count)
+    if settings.search.domain_whitelist:
+        domains = [d for d in domains if d in settings.search.domain_whitelist]
+    if settings.search.domain_blacklist:
+        domains = [d for d in domains if d not in settings.search.domain_blacklist]
+    feeds = rss_mod.run(domains)
+    out = Path("yacht_osint/data/cache/discovered_feeds.json")
+    out.parent.mkdir(parents=True, exist_ok=True)
+    json.dump(feeds, out.open("w"))
+    log.info("saved feeds → %s", out)
+
+
+if __name__ == "__main__":  # pragma: no cover
     run()

--- a/src/common/__init__.py
+++ b/src/common/__init__.py
@@ -1,0 +1,3 @@
+from .config import load_settings, Settings
+
+__all__ = ["load_settings", "Settings"]

--- a/src/common/config.py
+++ b/src/common/config.py
@@ -1,0 +1,26 @@
+from pathlib import Path
+from typing import List
+
+import yaml
+from pydantic import BaseModel, Field
+
+CONFIG_PATH = Path("configs/settings.yml")
+
+
+class SearchConfig(BaseModel):
+    queries: List[str] = Field(default_factory=list)
+    result_count: int = 5
+    domain_whitelist: List[str] = Field(default_factory=list)
+    domain_blacklist: List[str] = Field(default_factory=list)
+
+
+class Settings(BaseModel):
+    search: SearchConfig = Field(default_factory=SearchConfig)
+
+    class Config:
+        extra = "allow"
+
+
+def load_settings(path: Path = CONFIG_PATH) -> Settings:
+    data = yaml.safe_load(path.read_text())
+    return Settings(**data)

--- a/src/scrape/rss.py
+++ b/src/scrape/rss.py
@@ -1,27 +1,55 @@
-print(">>> rss.py reached <<<")
+from __future__ import annotations
 
-import logging, sys
-logging.basicConfig(
-    level=logging.INFO,
-    format="%(levelname)s:%(name)s:%(message)s",
-    stream=sys.stdout,
-    force=True,   # overwrite any prior config
-)
-
-
-import feedparser, logging, pathlib, json, os
+import json
+import logging
 from pathlib import Path
+from typing import Dict, List
 
-FEED = "https://www.boatinternational.com/feed"
-print(f">>> Fetching RSS from {your_url!r}")
-print(f">>> HTTP status: {feed.get('status', 'unknown')}")
-print(f">>> Found {len(feed.entries)} entries")
-OUT  = Path("data/cache/rss_boatinternational.json")
+import feedfinder2
+import feedparser
 
-def run() -> None:
-    OUT.parent.mkdir(parents=True, exist_ok=True)
-    d = feedparser.parse(FEED)
-    json.dump(d.entries[:20], OUT.open("w"))
-    logging.getLogger(__name__).info("Saved %s items → %s", len(d.entries), OUT)
-if __name__ == "__main__":
-    run()
+log = logging.getLogger(__name__)
+
+
+def discover_feeds(domains: List[str]) -> Dict[str, List[str]]:
+    feeds: Dict[str, List[str]] = {}
+    for domain in domains:
+        url = f"https://{domain}"
+        try:
+            found = feedfinder2.find_feeds(url)
+            if found:
+                feeds[domain] = found
+        except Exception as exc:  # pragma: no cover - logging
+            log.warning("feed discovery failed for %s: %s", domain, exc)
+    return feeds
+
+
+def fetch_entries(
+    feed_map: Dict[str, List[str]], limit: int = 20
+) -> Dict[str, List[dict]]:
+    results: Dict[str, List[dict]] = {}
+    for domain, urls in feed_map.items():
+        results[domain] = []
+        for url in urls:
+            try:
+                d = feedparser.parse(url)
+                results[domain].extend(d.entries[:limit])
+            except Exception as exc:  # pragma: no cover - logging
+                log.warning("parse failed for %s: %s", url, exc)
+    return results
+
+
+def run(domains: List[str]) -> Dict[str, List[dict]]:
+    feeds = discover_feeds(domains)
+    return fetch_entries(feeds)
+
+
+if __name__ == "__main__":  # pragma: no cover - manual runs
+    import sys
+
+    domains = sys.argv[1:]
+    data = run(domains)
+    out = Path("yacht_osint/data/cache/discovered_feeds.json")
+    out.parent.mkdir(parents=True, exist_ok=True)
+    json.dump(data, out.open("w"))
+    log.info("saved feeds → %s", out)

--- a/src/scrape/search.py
+++ b/src/scrape/search.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import logging
+import os
+from typing import List
+
+import tldextract
+
+import requests
+
+log = logging.getLogger(__name__)
+CSE_URL = "https://www.googleapis.com/customsearch/v1"
+
+
+def search_sites(query: str, num: int = 10) -> List[str]:
+    """Query Google CSE and return unique root domains."""
+    key = os.environ.get("GOOGLE_CSE_API_KEY")
+    cx = os.environ.get("GOOGLE_CSE_CX")
+    if not key or not cx:
+        raise RuntimeError("Missing Google CSE credentials")
+
+    try:
+        resp = requests.get(
+            CSE_URL, params={"key": key, "cx": cx, "q": query, "num": num}, timeout=10
+        )
+        resp.raise_for_status()
+        payload = resp.json()
+    except Exception as exc:  # pragma: no cover - network errors
+        log.error("CSE request failed: %s", exc)
+        raise
+
+    domains: List[str] = []
+    for item in payload.get("items", []):
+        url = item.get("link")
+        if not url:
+            continue
+        ext = tldextract.extract(url)
+        domain = f"{ext.domain}.{ext.suffix}" if ext.suffix else ext.domain
+        if domain and domain not in domains:
+            domains.append(domain)
+    return domains
+
+
+def run(queries: List[str], num: int = 10) -> List[str]:
+    all_domains: List[str] = []
+    for q in queries:
+        try:
+            all_domains.extend(search_sites(q, num))
+        except Exception as exc:  # pragma: no cover - logging
+            log.warning("search failed for %s: %s", q, exc)
+    # dedupe while preserving order
+    return list(dict.fromkeys(all_domains))

--- a/tests/test_rss.py
+++ b/tests/test_rss.py
@@ -1,0 +1,7 @@
+from src.scrape import rss
+
+
+def test_discover_feeds(monkeypatch):
+    monkeypatch.setattr("feedfinder2.find_feeds", lambda url: [f"{url}/feed"])
+    feeds = rss.discover_feeds(["example.com"])
+    assert feeds == {"example.com": ["https://example.com/feed"]}

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -1,0 +1,33 @@
+import os
+from typing import List
+
+
+from src.scrape.search import search_sites
+
+
+class DummyResponse:
+    def __init__(self, items: List[str]):
+        self._items = items
+
+    def raise_for_status(self):
+        pass
+
+    def json(self):
+        return {"items": [{"link": url} for url in self._items]}
+
+
+def test_search_sites(monkeypatch):
+    def fake_get(url, params, timeout):
+        return DummyResponse(
+            [
+                "https://example.com/post1",
+                "https://blog.example.com/post2",
+                "https://other.com/abc",
+            ]
+        )
+
+    monkeypatch.setattr("requests.get", fake_get)
+    os.environ["GOOGLE_CSE_API_KEY"] = "1"
+    os.environ["GOOGLE_CSE_CX"] = "2"
+    domains = search_sites("test")
+    assert domains == ["example.com", "other.com"]


### PR DESCRIPTION
## Summary
- implement dynamic source discovery via Google CSE
- discover RSS feeds for found domains
- orchestrate search and feed discovery in `src.cli`
- add config keys for search parameters
- document new step
- ensure CI runs tests and validates CSE credentials

## Testing
- `pip install -r requirements.txt`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68876e8a92448325b0ba77a0db76b9e0