### PR TITLE
Fix exports fallback & robust feed discovery

### DIFF
--- a/src/persist/exports.py
+++ b/src/persist/exports.py
@@ -1,18 +1,37 @@
 import logging
+import json
 from pathlib import Path
 
 import duckdb
+import pandas as pd
 
 log = logging.getLogger(__name__)
 
 
 def run(db_path: Path = Path("yachts.duckdb")) -> Path:
-    """Export yacht data from DuckDB to CSV."""
-    con = duckdb.connect(str(db_path))
-    try:
-        df = con.execute("SELECT name, length_m FROM yachts").fetch_df()
-    finally:
-        con.close()
+    """Export yacht data from DuckDB to CSV.
+
+    If the database is missing or empty, fall back to ``exports/new_data.json``
+    if it exists.
+    """
+
+    df = pd.DataFrame()
+    if db_path.exists():
+        con = duckdb.connect(str(db_path))
+        try:
+            df = con.execute("SELECT name, length_m FROM yachts").fetch_df()
+        finally:
+            con.close()
+
+    if df.empty:
+        json_path = Path("exports") / "new_data.json"
+        if json_path.exists():
+            try:
+                records = json.loads(json_path.read_text())
+                df = pd.DataFrame(records)
+                df = df[["name", "length_m"]]
+            except Exception as exc:  # pragma: no cover - data errors
+                log.warning("failed to load %s: %s", json_path, exc)
 
     if df.empty:
         raise RuntimeError("yachts table is empty")

--- a/src/scrape/parse.py
+++ b/src/scrape/parse.py
@@ -1,8 +1,81 @@
+from __future__ import annotations
+
 import logging
+from typing import List
+from urllib.parse import urljoin, urlparse
+
+import feedfinder2
+import requests
+from bs4 import BeautifulSoup
 
 log = logging.getLogger(__name__)
 
+_ANCHOR_TOKENS = [".rss", ".xml", "/feed", "format=rss"]
+_DEFAULT_ENDPOINTS = ["/feed", "/rss", "/atom", "/feeds/posts/default"]
 
-def run() -> None:
-    """Placeholder implementation with logging."""
+
+def discover_feeds(url: str) -> List[str]:
+    """Return a list of feed URLs discovered on ``url``."""
+
+    def _fetch(u: str) -> tuple[str, str]:
+        try:
+            resp = requests.get(u, timeout=10)
+            resp.raise_for_status()
+            return resp.text, resp.url
+        except Exception as exc:  # pragma: no cover - network failures
+            log.warning("request failed for %s: %s", u, exc)
+            return "", u
+
+    html, final_url = _fetch(url)
+    feeds: List[str] = []
+
+    if html:
+        soup = BeautifulSoup(html, "lxml")
+        # <link rel="alternate" type="application/rss+xml" href="...">
+        for link in soup.find_all("link", rel="alternate"):
+            type_ = (link.get("type") or "").lower()
+            if type_ in {"application/rss+xml", "application/atom+xml"}:
+                href = link.get("href")
+                if href:
+                    feeds.append(urljoin(final_url, href))
+        # <a href="...rss"> or similar heuristics
+        for a in soup.find_all("a", href=True):
+            href = a["href"]
+            if any(token in href.lower() for token in _ANCHOR_TOKENS):
+                feeds.append(urljoin(final_url, href))
+
+    # feedfinder2 fallback
+    if not feeds:
+        try:
+            found = feedfinder2.find_feeds(html or final_url)
+            feeds.extend(found)
+        except Exception as exc:  # pragma: no cover - library failures
+            log.debug("feedfinder2 failed for %s: %s", url, exc)
+
+    # default endpoints like /feed or /rss
+    if not feeds:
+        parsed = urlparse(final_url)
+        root = f"{parsed.scheme}://{parsed.netloc}"
+        for ep in _DEFAULT_ENDPOINTS:
+            candidate = urljoin(root, ep)
+            try:
+                r = requests.head(candidate, allow_redirects=True, timeout=5)
+                content_type = r.headers.get("content-type", "").lower()
+                if r.status_code >= 400 or "xml" not in content_type:
+                    r = requests.get(candidate, allow_redirects=True, timeout=5)
+                    content_type = r.headers.get("content-type", "").lower()
+                if r.status_code < 400 and "xml" in content_type:
+                    feeds.append(candidate)
+                    break
+            except Exception:  # pragma: no cover - network failures
+                continue
+
+    if not feeds and html:
+        log.debug("HTML snippet for %s: %s", url, html[:500])
+
+    # deduplicate while preserving order
+    return list(dict.fromkeys(feeds))
+
+
+def run() -> None:  # pragma: no cover - manual invocation only
     log.info("stub")

--- a/tests/test_exports.py
+++ b/tests/test_exports.py
@@ -12,3 +12,14 @@ def test_run_exports(tmp_path, monkeypatch):
     df = pd.read_csv(out)
     assert list(df.columns) == ["name", "length_m"]
     assert len(df) == 1
+
+
+def test_run_exports_json(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "exports").mkdir()
+    (tmp_path / "exports" / "new_data.json").write_text(
+        '[{"name": "B", "length_m": 2}]'
+    )
+    out = exports.run(tmp_path / "missing.duckdb")
+    df = pd.read_csv(out)
+    assert df.iloc[0]["name"] == "B"

--- a/tests/test_feed_discovery.py
+++ b/tests/test_feed_discovery.py
@@ -1,0 +1,47 @@
+import requests
+from src.scrape import parse
+
+
+class DummyResp:
+    def __init__(self, text="", status=200, headers=None, url="https://example.com/"):
+        self.text = text
+        self.status_code = status
+        self.headers = headers or {"content-type": "text/html"}
+        self.url = url
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise requests.HTTPError(self.status_code)
+
+
+def test_link_and_anchor(monkeypatch):
+    html = """<html><head><link rel='alternate' type='application/rss+xml' href='/feed.xml'></head><body><a href='feed.xml'>feed</a></body></html>"""
+    monkeypatch.setattr(requests, "get", lambda *a, **k: DummyResp(html))
+    feeds = parse.discover_feeds("https://example.com")
+    assert feeds == ["https://example.com/feed.xml"]
+
+
+def test_feedfinder_fallback(monkeypatch):
+    monkeypatch.setattr(requests, "get", lambda *a, **k: DummyResp(""))
+    monkeypatch.setattr(
+        parse.feedfinder2, "find_feeds", lambda html: ["https://example.com/rss"]
+    )
+    feeds = parse.discover_feeds("https://example.com")
+    assert feeds == ["https://example.com/rss"]
+
+
+def test_default_endpoint(monkeypatch):
+    monkeypatch.setattr(requests, "get", lambda *a, **k: DummyResp("<html></html>"))
+    head_resp = DummyResp("", headers={"content-type": "application/rss+xml"})
+    monkeypatch.setattr(requests, "head", lambda *a, **k: head_resp)
+    monkeypatch.setattr(parse.feedfinder2, "find_feeds", lambda html: [])
+    feeds = parse.discover_feeds("https://example.com/blog")
+    assert feeds == ["https://example.com/feed"]
+
+
+def test_no_feeds(monkeypatch):
+    monkeypatch.setattr(requests, "get", lambda *a, **k: DummyResp("<html></html>"))
+    monkeypatch.setattr(requests, "head", lambda *a, **k: DummyResp(status=404))
+    monkeypatch.setattr(parse.feedfinder2, "find_feeds", lambda html: [])
+    feeds = parse.discover_feeds("https://example.com")
+    assert feeds == []


### PR DESCRIPTION
## Summary
- implement multi-strategy feed discovery in `src.scrape.parse`
- fall back to `new_data.json` if DuckDB data missing
- expand export tests for JSON fallback
- add comprehensive feed discovery tests

## Testing
- `pip install -r requirements.txt`
- `ruff check --fix .`
- `black --check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6888867840708325a1382701ae6132d7