### PR TITLE
Fix feed discovery and export

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,3 +67,43 @@ If **`main`** pipeline fails twice consecutively:
 3. Open Issue tagging `@tenderworks-prodigy/maintainers`
 
 ---
+## Large-Output & Context-Handling Guidelines
+
+**Prevent stdout overflows** (no single line > 1600 bytes) by fetching and slicing before printing:
+
+1. **Fetch programmatically**  
+   Default to a Python pattern (requests + BeautifulSoup + textwrap) to download and wrap pages.  
+   ```python
+   import requests, textwrap
+   from bs4 import BeautifulSoup
+
+   URL  = "https://example.com/large-page"
+   html = requests.get(URL, timeout=15).text                 # ① pull page
+   text = BeautifulSoup(html, "html.parser").get_text()      # ② strip tags
+   safe = "\n".join(textwrap.wrap(text, width=1600))         # ③ hard-wrap
+   print(safe[:4000])                                        # ④ print only the needed snippet
+
+2. **Avoid giant single-line prints**
+   Wrap or slice parsed text (textwrap.wrap(text, 1600) or text[:4000]) so no line exceeds the limit.
+
+3. **Targeted keyword/regex search**
+Filter for relevance first (e.g. only lines containing a keyword or matching a regex) to avoid dumping entire pages.
+
+4. **Chunk large outputs**
+If you need more context, emit in segments:
+
+print(safe[0:4000])
+print(safe[4000:8000])
+…and so on
+
+5. **Leverage cached/local docs**
+Store frequently-used references under knowledge/ in pre-wrapped form to avoid repeated external fetches.
+
+6. **Complete context over speed**
+When in doubt, fetch and slice multiple segments rather than answering prematurely with missing info.
+
+7. **Maintain reproducibility**
+Install any extra parsing libs in your venv (e.g. pip install bs4) so environments stay predictable
+Feel free to drop or adjust any bullet to match your style—this covers all the bases for safe, complete context retrieval.
+
+

--- a/src/persist/exports.py
+++ b/src/persist/exports.py
@@ -1,6 +1,5 @@
 import logging
 import json
-import os
 from pathlib import Path
 
 import duckdb
@@ -34,12 +33,11 @@ def run(db_path: Path = Path("yachts.duckdb")) -> Path:
             except Exception as exc:  # pragma: no cover - data errors
                 log.warning("failed to load %s: %s", json_path, exc)
 
-    exports = Path("exports")
-    exports.mkdir(parents=True, exist_ok=True)
-    out = exports / "yachts.csv"
+    export_dir = Path("exports")
+    export_dir.mkdir(parents=True, exist_ok=True)
+    out = export_dir / "yachts.csv"
     if df.empty:
         df = pd.DataFrame(columns=["name", "length_m"])
     df.to_csv(out, index=False)
     log.info("saved %d rows -> %s", len(df), out)
-    print("EXPORTS DIR:", os.listdir("exports"))
     return out

--- a/tests/cassettes/atom.yaml
+++ b/tests/cassettes/atom.yaml
@@ -11,5382 +11,2510 @@ interactions:
       User-Agent:
       - python-requests/2.31.0
     method: GET
-    uri: https://proxy:8080/
+    uri: https://proxy:8080/feeds/posts/default?alt=atom
   response:
     body:
-      string: "<!DOCTYPE html>\n<html class='v2' dir='ltr' xmlns='http://www.w3.org/1999/xhtml'
-        xmlns:b='http://www.google.com/2005/gml/b' xmlns:data='http://www.google.com/2005/gml/data'
-        xmlns:expr='http://www.google.com/2005/gml/expr'>\n<head>\n<link href='https://www.blogger.com/static/v1/widgets/573632073-css_bundle_v2.css'
-        rel='stylesheet' type='text/css'/>\n<script data-domain='pythoninsider.blogspot.com'
-        defer='defer' src='https://analytics.python.org/js/script.outbound-links.js'></script>\n<link
-        href='https://blog.python.org/favicon.ico' rel='icon' type='image/x-icon'/>\n<meta
-        content='blogger' name='generator'/>\n<link href='https://blog.python.org/feeds/posts/default'
-        rel='alternate' title='Python Insider - Atom' type='application/atom+xml'/>\n<link
-        href='https://blog.python.org/feeds/posts/default?alt=rss' rel='alternate'
-        title='Python Insider - RSS' type='application/rss+xml'/>\n<link href='https://www.blogger.com/feeds/3941553907430899163/posts/default'
-        rel='service.post' title='Python Insider - Atom' type='application/atom+xml'/>\n<!--[if
-        IE]><script type=\"text/javascript\" src=\"https://www.blogger.com/static/v1/jsbin/2591933621-ieretrofit.js\"></script>
-        <![endif]-->\n<meta content='https://blog.python.org/' name='og:url:domain'/>\n<!--[if
-        IE]> <script> (function() { var html5 = (\"abbr,article,aside,audio,canvas,datalist,details,\"
-        + \"figure,footer,header,hgroup,mark,menu,meter,nav,output,\" + \"progress,section,time,video\").split(',');
-        for (var i = 0; i < html5.length; i++) { document.createElement(html5[i]);
-        } try { document.execCommand('BackgroundImageCache', false, true); } catch(e)
-        {} })(); </script> <![endif]-->\n<title>Python Insider</title>\n<meta name='author'
-        value='The Python Community'/>\n<style id='page-skin-1' type='text/css'><!--\n\n--></style>\n<style
-        id='template-skin-1' type='text/css'><!--\n\n--></style>\n<!--[if lt IE 9]>
-        <script src=\"http://html5shiv.googlecode.com/svn/trunk/html5.js\"></script>
-        <![endif]-->\n<style type='text/css'>\nbody {\n  font-family: Arial,Tahoma,Helvetica,FreeSans,sans-serif;\n
-        \ font-size: 12px;\n  color: #111;\n  background:#3272ac;\n\n  background-image:
-        -webkit-gradient(\n    linear,\n    left bottom,\n    left top,\n    color-stop(0.21,
-        rgb(50,114,172)),\n    color-stop(0.84, rgb(250,229,164))\n);\nbackground-image:
-        -moz-linear-gradient(\n    center bottom,\n    #3272ac 21%,\n    #fae5a4 84%\n);\n\nbackground-repeat:no-repeat;\n}\n\nh2
-        {font-size: 1em; }\nh3 { font-size: 1.2em}\n\n#wholeC {\n  background-color:#fff;\n
-        \ width: 90%;\n  margin: 0 auto 2em auto;\n}\n\n#cmain {\n  float:left;\n
-        \ width: 68%;\n  padding:0;\n  margin: 2em 0 2em 2%;\n}\n#cside {\n  float:right;\n
-        \ width: 23%;\n  margin-right: 2%;\n  margin-top: 2em;\n  margin-bottom: 3em;\n
-        \ padding-bottom: 3em;\n  font-size: 0.95em;\n}\n#cside a {\nfont-size: 0.95em\n}\n#cside
-        h2 {\ntext-transform:uppercase;\ncolor: #715707\n}\n\na { color: #142f46 }\na:hover
-        { color: #557 }\na:visited { color: #334 }\n\nh2.date-header { font-size:
-        13px; }\nh3.post-title { font-size: 16px; margin-bottom: 1em; }\n\ndiv.date-outer
-        {\n/* blog post container */\nmargin: 0 0 2em 0;\npadding: 0;\nfont-size:13px;\nline-height:133%;\n}\n\nheader#chead
-        {\ndisplay: block;\nmargin: 0 auto 1em auto;\npadding: 0;\nwidth: 70%;\nheight:145px;\noverflow:
-        hidden;\ncolor: #222;\nbackground: #fff;\nborder-bottom: 1px solid #ddd; \n\n}\n#Header1
-        {\nfont-size:16px;\n}\n#Header1 .description {\nposition:relative;\ntop: -35px;\nleft:
-        116px;\n}\n\n.wshad {\n    padding: 2em 8px;\n    border: 1px solid #99A;\n
-        \   -moz-box-shadow: 0 5px 10px #222;\n    -webkit-box-shadow: 0 5px 10px
-        #222;\n    box-shadow: 0 5px 10px #222;\n}\n\n.post-footer {\nborder-top:1px
-        outset #ddd;border-right:1px inset #ddd;\nbackground-color: #f5f5f5;\npadding:
-        10px 5px;\nposition:relative;\nleft:-1.2em;\nopacity: 0.75;\nfont-size:0.9em;\n}\n\n</style>\n<script
-        src='https://code.jquery.com/jquery-3.2.1.slim.min.js'></script>\n<script>\n$(document).ready(function()
-        {\n  $(\"a\").each(function() {\n    var i = $(this).attr(\"href\");\n    if
-        (!i) {\n      return;\n    }\n    var n = i.replace(\"https://pythoninsider.blogspot.com\",
-        \"https://blog.python.org\");\n    $(this).attr(\"href\", function() {\n      return
-        n\n    })\n  })\n});\n</script>\n<link href='https://www.blogger.com/dyn-css/authorization.css?targetBlogID=3941553907430899163&amp;zx=eb47a3b4-8679-40a3-a3c9-0305e654ac4c'
-        media='none' onload='if(media!=&#39;all&#39;)media=&#39;all&#39;' rel='stylesheet'/><noscript><link
-        href='https://www.blogger.com/dyn-css/authorization.css?targetBlogID=3941553907430899163&amp;zx=eb47a3b4-8679-40a3-a3c9-0305e654ac4c'
-        rel='stylesheet'/></noscript>\n<meta name='google-adsense-platform-account'
-        content='ca-host-pub-1556223355139109'/>\n<meta name='google-adsense-platform-domain'
-        content='blogspot.com'/>\n\n</head>\n<body>\n<div class='navbar section' id='navbar'><div
-        class='widget Navbar' data-version='1' id='Navbar1'><script type=\"text/javascript\">\n
-        \   function setAttributeOnload(object, attribute, val) {\n      if(window.addEventListener)
-        {\n        window.addEventListener('load',\n          function(){ object[attribute]
-        = val; }, false);\n      } else {\n        window.attachEvent('onload', function(){
-        object[attribute] = val; });\n      }\n    }\n  </script>\n<div id=\"navbar-iframe-container\"></div>\n<script
-        type=\"text/javascript\" src=\"https://apis.google.com/js/platform.js\"></script>\n<script
-        type=\"text/javascript\">\n      gapi.load(\"gapi.iframes:gapi.iframes.style.bubble\",
-        function() {\n        if (gapi.iframes && gapi.iframes.getContext) {\n          gapi.iframes.getContext().openChild({\n
-        \             url: 'https://www.blogger.com/navbar/3941553907430899163?origin\\x3dhttps://pythoninsider.blogspot.com',\n
-        \             where: document.getElementById(\"navbar-iframe-container\"),\n
-        \             id: \"navbar-iframe\"\n          });\n        }\n      });\n
-        \   </script><script type=\"text/javascript\">\n(function() {\nvar script
-        = document.createElement('script');\nscript.type = 'text/javascript';\nscript.src
-        = '//pagead2.googlesyndication.com/pagead/js/google_top_exp.js';\nvar head
-        = document.getElementsByTagName('head')[0];\nif (head) {\nhead.appendChild(script);\n}})();\n</script>\n</div></div>\n<div
-        id='wholeC'>\n<header id='chead'>\n<div class='header section' id='header'><div
-        class='widget Header' data-version='1' id='Header1'>\n<div id='header-inner'>\n<a
-        href='https://pythoninsider.blogspot.com/' style='display: block'>\n<img alt='Python
-        Insider' height='139px; ' id='Header1_headerimg' src='https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEiaYv-cjwDu6xU0AXLrBK0BEw19ERUxBEsbApijz0uyz_ouDUsdt-RS8Ims7R2PCwvlQAFhxxA15m7zgeB582M-Wsz9bSTpLk7WkzBdwwrMVRJPE-OstLYwR3TFITAh77gF2XEEnIzJAGRK/s1600/python-insider-header.png'
-        style='display: block' width='600px; '/>\n</a>\n<div class='descriptionwrapper'>\n<p
-        class='description'><span>Python core development news and information.</span></p>\n</div>\n</div>\n</div></div>\n</header>\n<div
-        id='cmain'>\n<section id='ccontent'>\n<div class='main section' id='main'><div
-        class='widget Blog' data-version='1' id='Blog1'>\n<div class='blog-posts hfeed'>\n\n
-        \         <div class=\"date-outer\">\n        \n<h2 class='date-header'><span>Tuesday,
-        July 22, 2025</span></h2>\n\n          <div class=\"date-posts\">\n        \n<div
-        class='post-outer'>\n<div class='post hentry'>\n<a name='8412948848050014787'></a>\n<h3
-        class='post-title entry-title'>\n<a href='https://pythoninsider.blogspot.com/2025/07/python-314-release-candidate-1-is-go.html'>Python
-        3.14 release candidate 1 is go!</a>\n</h3>\n<div class='post-header'>\n<div
-        class='post-header-line-1'></div>\n</div>\n<div class='post-body entry-content'>\n<p><a
-        href=\"https://www.youtube.com/watch?v=ydyXFUmv6S4\">It&#8217;s</a> the\nfirst
-        3.14 release candidate!</p>\n<p><a class=\"uri\" href=\"https://www.python.org/downloads/release/python-3140rc1/\">https://www.python.org/downloads/release/python-3140rc1/</a></p>\n<p><strong>This
-        is the first release candidate of Python\n3.14</strong></p>\n<p>This release,
-        <strong>3.14.0rc1</strong>, is the penultimate release\npreview. Entering
-        the release candidate phase, only reviewed code\nchanges which are clear bug
-        fixes are allowed between this release\ncandidate and the final release. The
-        second candidate (and the last\nplanned release preview) is scheduled for
-        Tuesday, 2025-08-26, while the\nofficial release of 3.14.0 is scheduled for
-        Tuesday, 2025-10-07.</p>\n<p>There will be <strong><em>no ABI changes</em></strong>
-        from this\npoint forward in the 3.14 series, and the goal is that there will
-        be as\nfew code changes as possible.</p>\n<h1 id=\"call-to-action\">Call to
-        action</h1>\n<p>We <strong><em>strongly encourage</em></strong> maintainers
-        of\nthird-party Python projects to prepare their projects for 3.14 during\nthis
-        phase, and where necessary publish Python 3.14 wheels on PyPI to be\nready
-        for the final release of 3.14.0, and to help other projects do\ntheir own
-        testing. Any binary wheels built against Python 3.14.0rc1\n<strong><em>will
-        work</em></strong> with future versions of Python 3.14.\nAs always, report
-        any issues to <a href=\"https://github.com/python/cpython/issues\">the Python
-        bug\ntracker</a>.</p>\n<p>Please keep in mind that this is a preview release
-        and while it&#8217;s as\nclose to the final release as we can get it, its
-        use is\n<strong><em>not</em></strong> recommended for production\nenvironments.</p>\n<h2
-        id=\"core-developers-time-to-work-on-documentation-now\">Core\ndevelopers:
-        time to work on documentation now</h2>\n<ul>\n<li>Are all your changes properly
-        documented?</li>\n<li>Are they mentioned in <a href=\"https://docs.python.org/3.14/whatsnew/3.14.html\">What&#8217;s\nNew</a>?</li>\n<li>Did
-        you notice other changes you know of to have insufficient\ndocumentation?</li>\n</ul>\n<h1
-        id=\"major-new-features-of-the-3.14-series-compared-to-3.13\">Major\nnew features
-        of the 3.14 series, compared to 3.13</h1>\n<p>Some of the major new features
-        and changes in Python 3.14 are:</p>\n<h2 id=\"new-features\">New features</h2>\n<ul>\n<li><a
-        href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pep779\">PEP\n779</a>:
-        Free-threaded Python is officially supported</li>\n<li><a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pep649\">PEP\n649</a>:
+      string: "<?xml version='1.0' encoding='UTF-8'?><?xml-stylesheet href=\"http://www.blogger.com/styles/atom.css\"
+        type=\"text/css\"?><feed xmlns='http://www.w3.org/2005/Atom' xmlns:openSearch='http://a9.com/-/spec/opensearchrss/1.0/'
+        xmlns:blogger='http://schemas.google.com/blogger/2008' xmlns:georss='http://www.georss.org/georss'
+        xmlns:gd=\"http://schemas.google.com/g/2005\" xmlns:thr='http://purl.org/syndication/thread/1.0'><id>tag:blogger.com,1999:blog-3941553907430899163</id><updated>2025-07-22T16:13:02.093-04:00</updated><category
+        term=\"releases\"/><category term=\"pypi\"/><category term=\"3\"/><category
+        term=\"pip\"/><category term=\"buildbot\"/><category term=\"contributors\"/><category
+        term=\"docs\"/><category term=\"ironpython\"/><category term=\"mercurial\"/><category
+        term=\"platforms\"/><title type='text'>Python Insider</title><subtitle type='html'>Python
+        core development news and information.</subtitle><link rel='http://schemas.google.com/g/2005#feed'
+        type='application/atom+xml' href='https://pythoninsider.blogspot.com/feeds/posts/default'/><link
+        rel='self' type='application/atom+xml' href='https://www.blogger.com/feeds/3941553907430899163/posts/default?alt=atom'/><link
+        rel='alternate' type='text/html' href='https://pythoninsider.blogspot.com/'/><link
+        rel='hub' href='http://pubsubhubbub.appspot.com/'/><link rel='next' type='application/atom+xml'
+        href='https://www.blogger.com/feeds/3941553907430899163/posts/default?alt=atom&amp;start-index=26&amp;max-results=25'/><author><name>Doug
+        Hellmann</name><uri>http://www.blogger.com/profile/01892352754222143463</uri><email>noreply@blogger.com</email><gd:image
+        rel='http://schemas.google.com/g/2005#thumbnail' width='32' height='32' src='//blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEhprDrJ7x4JLYZ0F-yZ25SDisFaC19kVukvFnUpbX2BB_YUybQYi4OW9ERIONydJKc-cAIzeLlauRp2sEweO4Fzs37ogvBgNAJmZAZF5yRhwffCQBxcZxFl_-e72cMtTiQ/s220/book-smaller.jpg'/></author><generator
+        version='7.00' uri='http://www.blogger.com'>Blogger</generator><openSearch:totalResults>287</openSearch:totalResults><openSearch:startIndex>1</openSearch:startIndex><openSearch:itemsPerPage>25</openSearch:itemsPerPage><entry><id>tag:blogger.com,1999:blog-3941553907430899163.post-8412948848050014787</id><published>2025-07-22T15:47:00.003-04:00</published><updated>2025-07-22T16:13:01.820-04:00</updated><category
+        scheme=\"http://www.blogger.com/atom/ns#\" term=\"releases\"/><title type='text'>Python
+        3.14 release candidate 1 is go!</title><content type='html'>&lt;p&gt;&lt;a
+        href=&quot;https://www.youtube.com/watch?v=ydyXFUmv6S4&quot;&gt;It\u2019s&lt;/a&gt;
+        the\nfirst 3.14 release candidate!&lt;/p&gt;\n&lt;p&gt;&lt;a href=&quot;https://www.python.org/downloads/release/python-3140rc1/&quot;\nclass=&quot;uri&quot;&gt;https://www.python.org/downloads/release/python-3140rc1/&lt;/a&gt;&lt;/p&gt;\n&lt;p&gt;&lt;strong&gt;This
+        is the first release candidate of Python\n3.14&lt;/strong&gt;&lt;/p&gt;\n&lt;p&gt;This
+        release, &lt;strong&gt;3.14.0rc1&lt;/strong&gt;, is the penultimate release\npreview.
+        Entering the release candidate phase, only reviewed code\nchanges which are
+        clear bug fixes are allowed between this release\ncandidate and the final
+        release. The second candidate (and the last\nplanned release preview) is scheduled
+        for Tuesday, 2025-08-26, while the\nofficial release of 3.14.0 is scheduled
+        for Tuesday, 2025-10-07.&lt;/p&gt;\n&lt;p&gt;There will be &lt;strong&gt;&lt;em&gt;no
+        ABI changes&lt;/em&gt;&lt;/strong&gt; from this\npoint forward in the 3.14
+        series, and the goal is that there will be as\nfew code changes as possible.&lt;/p&gt;\n&lt;h1
+        id=&quot;call-to-action&quot;&gt;Call to action&lt;/h1&gt;\n&lt;p&gt;We &lt;strong&gt;&lt;em&gt;strongly
+        encourage&lt;/em&gt;&lt;/strong&gt; maintainers of\nthird-party Python projects
+        to prepare their projects for 3.14 during\nthis phase, and where necessary
+        publish Python 3.14 wheels on PyPI to be\nready for the final release of 3.14.0,
+        and to help other projects do\ntheir own testing. Any binary wheels built
+        against Python 3.14.0rc1\n&lt;strong&gt;&lt;em&gt;will work&lt;/em&gt;&lt;/strong&gt;
+        with future versions of Python 3.14.\nAs always, report any issues to &lt;a\nhref=&quot;https://github.com/python/cpython/issues&quot;&gt;the
+        Python bug\ntracker&lt;/a&gt;.&lt;/p&gt;\n&lt;p&gt;Please keep in mind that
+        this is a preview release and while it\u2019s as\nclose to the final release
+        as we can get it, its use is\n&lt;strong&gt;&lt;em&gt;not&lt;/em&gt;&lt;/strong&gt;
+        recommended for production\nenvironments.&lt;/p&gt;\n&lt;h2 id=&quot;core-developers-time-to-work-on-documentation-now&quot;&gt;Core\ndevelopers:
+        time to work on documentation now&lt;/h2&gt;\n&lt;ul&gt;\n&lt;li&gt;Are all
+        your changes properly documented?&lt;/li&gt;\n&lt;li&gt;Are they mentioned
+        in &lt;a\nhref=&quot;https://docs.python.org/3.14/whatsnew/3.14.html&quot;&gt;What\u2019s\nNew&lt;/a&gt;?&lt;/li&gt;\n&lt;li&gt;Did
+        you notice other changes you know of to have insufficient\ndocumentation?&lt;/li&gt;\n&lt;/ul&gt;\n&lt;h1
+        id=&quot;major-new-features-of-the-3.14-series-compared-to-3.13&quot;&gt;Major\nnew
+        features of the 3.14 series, compared to 3.13&lt;/h1&gt;\n&lt;p&gt;Some of
+        the major new features and changes in Python 3.14 are:&lt;/p&gt;\n&lt;h2 id=&quot;new-features&quot;&gt;New
+        features&lt;/h2&gt;\n&lt;ul&gt;\n&lt;li&gt;&lt;a\nhref=&quot;https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pep779&quot;&gt;PEP\n779&lt;/a&gt;:
+        Free-threaded Python is officially supported&lt;/li&gt;\n&lt;li&gt;&lt;a\nhref=&quot;https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pep649&quot;&gt;PEP\n649&lt;/a&gt;:
         The evaluation of type annotations is now deferred, improving\nthe semantics
-        of using annotations.</li>\n<li><a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pep750\">PEP\n750</a>:
+        of using annotations.&lt;/li&gt;\n&lt;li&gt;&lt;a\nhref=&quot;https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pep750&quot;&gt;PEP\n750&lt;/a&gt;:
         Template string literals (t-strings) for custom string\nprocessing, using
-        the familiar syntax of f-strings.</li>\n<li><a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pep734\">PEP\n734</a>:
-        Multiple interpreters in the stdlib.</li>\n<li><a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pep784\">PEP\n784</a>:
-        A new module <code>compression.zstd</code> providing support\nfor the Zstandard
-        compression algorithm.</li>\n<li><a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pep758\">PEP\n758</a>:
-        <code>except</code> and <code>except*</code> expressions may\nnow omit the
-        brackets.</li>\n<li><a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pyrepl-highlighting\">Syntax\nhighlighting
-        in PyREPL</a>, and support for color in <a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-color-unittest\">unittest</a>,\n<a
-        href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-color-argparse\">argparse</a>,\n<a
-        href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-color-json\">json</a>\nand
-        <a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-color-calendar\">calendar</a>\nCLIs.</li>\n<li><a
-        href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pep768\">PEP\n768</a>:
-        A zero-overhead external debugger interface for CPython.</li>\n<li><a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#uuid\">UUID\nversions
-        6-8</a> are now supported by the <code>uuid</code> module, and\ngeneration
-        of versions 3-5 are up to 40% faster.</li>\n<li><a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pep765\">PEP\n765</a>:
-        Disallow\n<code>return</code>/<code>break</code>/<code>continue</code> that
-        exit a\n<code>finally</code> block.</li>\n<li><a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pep741\">PEP\n741</a>:
-        An improved C API for configuring Python.</li>\n<li>A <a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-tail-call\">new\ntype
-        of interpreter</a>. For certain newer compilers, this interpreter\nprovides
+        the familiar syntax of f-strings.&lt;/li&gt;\n&lt;li&gt;&lt;a\nhref=&quot;https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pep734&quot;&gt;PEP\n734&lt;/a&gt;:
+        Multiple interpreters in the stdlib.&lt;/li&gt;\n&lt;li&gt;&lt;a\nhref=&quot;https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pep784&quot;&gt;PEP\n784&lt;/a&gt;:
+        A new module &lt;code&gt;compression.zstd&lt;/code&gt; providing support\nfor
+        the Zstandard compression algorithm.&lt;/li&gt;\n&lt;li&gt;&lt;a\nhref=&quot;https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pep758&quot;&gt;PEP\n758&lt;/a&gt;:
+        &lt;code&gt;except&lt;/code&gt; and &lt;code&gt;except*&lt;/code&gt; expressions
+        may\nnow omit the brackets.&lt;/li&gt;\n&lt;li&gt;&lt;a\nhref=&quot;https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pyrepl-highlighting&quot;&gt;Syntax\nhighlighting
+        in PyREPL&lt;/a&gt;, and support for color in &lt;a\nhref=&quot;https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-color-unittest&quot;&gt;unittest&lt;/a&gt;,\n&lt;a\nhref=&quot;https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-color-argparse&quot;&gt;argparse&lt;/a&gt;,\n&lt;a\nhref=&quot;https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-color-json&quot;&gt;json&lt;/a&gt;\nand
+        &lt;a\nhref=&quot;https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-color-calendar&quot;&gt;calendar&lt;/a&gt;\nCLIs.&lt;/li&gt;\n&lt;li&gt;&lt;a\nhref=&quot;https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pep768&quot;&gt;PEP\n768&lt;/a&gt;:
+        A zero-overhead external debugger interface for CPython.&lt;/li&gt;\n&lt;li&gt;&lt;a
+        href=&quot;https://docs.python.org/3.14/whatsnew/3.14.html#uuid&quot;&gt;UUID\nversions
+        6-8&lt;/a&gt; are now supported by the &lt;code&gt;uuid&lt;/code&gt; module,
+        and\ngeneration of versions 3-5 are up to 40% faster.&lt;/li&gt;\n&lt;li&gt;&lt;a\nhref=&quot;https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pep765&quot;&gt;PEP\n765&lt;/a&gt;:
+        Disallow\n&lt;code&gt;return&lt;/code&gt;/&lt;code&gt;break&lt;/code&gt;/&lt;code&gt;continue&lt;/code&gt;
+        that exit a\n&lt;code&gt;finally&lt;/code&gt; block.&lt;/li&gt;\n&lt;li&gt;&lt;a\nhref=&quot;https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pep741&quot;&gt;PEP\n741&lt;/a&gt;:
+        An improved C API for configuring Python.&lt;/li&gt;\n&lt;li&gt;A &lt;a\nhref=&quot;https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-tail-call&quot;&gt;new\ntype
+        of interpreter&lt;/a&gt;. For certain newer compilers, this interpreter\nprovides
         significantly better performance. Opt-in for now, requires\nbuilding from
-        source.</li>\n<li><a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#improved-error-messages\">Improved\nerror
-        messages.</a></li>\n<li><a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#hmac\">Builtin\nimplementation
-        of HMAC</a> with formally verified code from the HACL*\nproject.</li>\n<li>A
-        <a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#asyncio-introspection-capabilities\">new\ncommand-line
-        interface</a> to inspect running Python processes using\nasynchronous tasks.</li>\n<li>The
-        pdb module now supports <a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#remote-attaching-to-a-running-python-process-with-pdb\">remote\nattaching
-        to a running Python process</a>.</li>\n</ul>\n<p><small>(Hey, <strong>fellow
-        core developer,</strong> if a feature you\nfind important is missing from
-        this list, let Hugo know.)</small></p>\n<p>For more details on the changes
-        to Python 3.14, see <a href=\"https://docs.python.org/3.14/whatsnew/3.14.html\">What&#8217;s
-        new in\nPython 3.14</a>. The next pre-release of Python 3.14 will be the final\nrelease
-        candidate, 3.14.0rc2, scheduled for 2025-08-26.</p>\n<h2 id=\"build-changes\">Build
-        changes</h2>\n<ul>\n<li><a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pep761\">PEP\n761</a>:
+        source.&lt;/li&gt;\n&lt;li&gt;&lt;a\nhref=&quot;https://docs.python.org/3.14/whatsnew/3.14.html#improved-error-messages&quot;&gt;Improved\nerror
+        messages.&lt;/a&gt;&lt;/li&gt;\n&lt;li&gt;&lt;a\nhref=&quot;https://docs.python.org/3.14/whatsnew/3.14.html#hmac&quot;&gt;Builtin\nimplementation
+        of HMAC&lt;/a&gt; with formally verified code from the HACL*\nproject.&lt;/li&gt;\n&lt;li&gt;A
+        &lt;a\nhref=&quot;https://docs.python.org/3.14/whatsnew/3.14.html#asyncio-introspection-capabilities&quot;&gt;new\ncommand-line
+        interface&lt;/a&gt; to inspect running Python processes using\nasynchronous
+        tasks.&lt;/li&gt;\n&lt;li&gt;The pdb module now supports &lt;a\nhref=&quot;https://docs.python.org/3.14/whatsnew/3.14.html#remote-attaching-to-a-running-python-process-with-pdb&quot;&gt;remote\nattaching
+        to a running Python process&lt;/a&gt;.&lt;/li&gt;\n&lt;/ul&gt;\n&lt;p&gt;&lt;small&gt;(Hey,
+        &lt;strong&gt;fellow core developer,&lt;/strong&gt; if a feature you\nfind
+        important is missing from this list, let Hugo know.)&lt;/small&gt;&lt;/p&gt;\n&lt;p&gt;For
+        more details on the changes to Python 3.14, see &lt;a\nhref=&quot;https://docs.python.org/3.14/whatsnew/3.14.html&quot;&gt;What\u2019s
+        new in\nPython 3.14&lt;/a&gt;. The next pre-release of Python 3.14 will be
+        the final\nrelease candidate, 3.14.0rc2, scheduled for 2025-08-26.&lt;/p&gt;\n&lt;h2
+        id=&quot;build-changes&quot;&gt;Build changes&lt;/h2&gt;\n&lt;ul&gt;\n&lt;li&gt;&lt;a\nhref=&quot;https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pep761&quot;&gt;PEP\n761&lt;/a&gt;:
         Python 3.14 and onwards no longer provides PGP signatures for\nrelease artifacts.
-        Instead, Sigstore is recommended for verifiers.</li>\n<li>Official macOS and
-        Windows release binaries include an <a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-jit-compiler\"><em>experimental</em>\nJIT
-        compiler</a>.</li>\n</ul>\n<h2 id=\"incompatible-changes-removals-and-new-deprecations\">Incompatible\nchanges,
-        removals and new deprecations</h2>\n<ul>\n<li><a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#incompatible-changes\">Incompatible\nchanges</a></li>\n<li>Python
-        <a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#removed\">removals</a>\nand
-        <a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#deprecated\">deprecations</a></li>\n<li>C
-        API <a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#c-api-removed\">removals</a>\nand
-        <a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#c-api-deprecated\">deprecations</a></li>\n<li>Overview
-        of all <a href=\"https://docs.python.org/3.14/deprecations/index.html\">pending\ndeprecations</a></li>\n</ul>\n<h1
-        id=\"python-install-manager\">Python install manager</h1>\n<p>The installer
-        we offer for Windows is being replaced by our new\ninstall manager, which
-        can be installed from <a href=\"https://apps.microsoft.com/detail/9NQ7512CXL7T\">the
-        Windows\nStore</a> or from its <a href=\"https://www.python.org/downloads/latest/pymanager/\">download\npage</a>.
-        See <a href=\"https://docs.python.org/3.14/using/windows.html\">our\ndocumentation</a>
+        Instead, Sigstore is recommended for verifiers.&lt;/li&gt;\n&lt;li&gt;Official
+        macOS and Windows release binaries include an &lt;a\nhref=&quot;https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-jit-compiler&quot;&gt;&lt;em&gt;experimental&lt;/em&gt;\nJIT
+        compiler&lt;/a&gt;.&lt;/li&gt;\n&lt;/ul&gt;\n&lt;h2 id=&quot;incompatible-changes-removals-and-new-deprecations&quot;&gt;Incompatible\nchanges,
+        removals and new deprecations&lt;/h2&gt;\n&lt;ul&gt;\n&lt;li&gt;&lt;a\nhref=&quot;https://docs.python.org/3.14/whatsnew/3.14.html#incompatible-changes&quot;&gt;Incompatible\nchanges&lt;/a&gt;&lt;/li&gt;\n&lt;li&gt;Python
+        &lt;a\nhref=&quot;https://docs.python.org/3.14/whatsnew/3.14.html#removed&quot;&gt;removals&lt;/a&gt;\nand
+        &lt;a\nhref=&quot;https://docs.python.org/3.14/whatsnew/3.14.html#deprecated&quot;&gt;deprecations&lt;/a&gt;&lt;/li&gt;\n&lt;li&gt;C
+        API &lt;a\nhref=&quot;https://docs.python.org/3.14/whatsnew/3.14.html#c-api-removed&quot;&gt;removals&lt;/a&gt;\nand
+        &lt;a\nhref=&quot;https://docs.python.org/3.14/whatsnew/3.14.html#c-api-deprecated&quot;&gt;deprecations&lt;/a&gt;&lt;/li&gt;\n&lt;li&gt;Overview
+        of all &lt;a\nhref=&quot;https://docs.python.org/3.14/deprecations/index.html&quot;&gt;pending\ndeprecations&lt;/a&gt;&lt;/li&gt;\n&lt;/ul&gt;\n&lt;h1
+        id=&quot;python-install-manager&quot;&gt;Python install manager&lt;/h1&gt;\n&lt;p&gt;The
+        installer we offer for Windows is being replaced by our new\ninstall manager,
+        which can be installed from &lt;a\nhref=&quot;https://apps.microsoft.com/detail/9NQ7512CXL7T&quot;&gt;the
+        Windows\nStore&lt;/a&gt; or from its &lt;a\nhref=&quot;https://www.python.org/downloads/latest/pymanager/&quot;&gt;download\npage&lt;/a&gt;.
+        See &lt;a\nhref=&quot;https://docs.python.org/3.14/using/windows.html&quot;&gt;our\ndocumentation&lt;/a&gt;
         for more information. The JSON file available for\ndownload below contains
         the list of all the installable packages\navailable as part of this release,
         including file URLs and hashes, but\nis not required to install the latest
         release. The traditional installer\nwill remain available throughout the 3.14
-        and 3.15 releases.</p>\n<h1 id=\"more-resources\">More resources</h1>\n<ul>\n<li><a
-        href=\"https://docs.python.org/3.14/\">Online\ndocumentation</a></li>\n<li><a
-        href=\"https://peps.python.org/pep-0745/\">PEP 745</a>, 3.14\nRelease Schedule</li>\n<li>Report
-        bugs at <a href=\"https://github.com/python/cpython/issues\">github.com/python/cpython/issues</a></li>\n<li><a
-        href=\"https://www.python.org/psf/donations/\">Help fund Python and\nits community</a></li>\n</ul>\n<h1
-        id=\"and-now-for-something-completely-different\">And now for\nsomething completely
-        different</h1>\n<p>Today, 22nd July, is Pi Approximation Day, because 22/7
-        is a common\napproximation of <em>\u03C0</em> and closer to <em>\u03C0</em>
-        than 3.14.</p>\n<p>22/7 is a Diophantine approximation, named after Diophantus
-        of\nAlexandria (3rd century CE), which is a way of estimating a real number\nas
-        a ratio of two integers. 22/7 has been known since antiquity;\nArchimedes
-        (3rd century BCE) wrote the first known proof that 22/7\noverestimates <em>\u03C0</em>
-        by comparing 96-sided polygons to the circle it\ncircumscribes.</p>\n<p>Another
+        and 3.15 releases.&lt;/p&gt;\n&lt;h1 id=&quot;more-resources&quot;&gt;More
+        resources&lt;/h1&gt;\n&lt;ul&gt;\n&lt;li&gt;&lt;a href=&quot;https://docs.python.org/3.14/&quot;&gt;Online\ndocumentation&lt;/a&gt;&lt;/li&gt;\n&lt;li&gt;&lt;a
+        href=&quot;https://peps.python.org/pep-0745/&quot;&gt;PEP 745&lt;/a&gt;, 3.14\nRelease
+        Schedule&lt;/li&gt;\n&lt;li&gt;Report bugs at &lt;a\nhref=&quot;https://github.com/python/cpython/issues&quot;&gt;github.com/python/cpython/issues&lt;/a&gt;&lt;/li&gt;\n&lt;li&gt;&lt;a
+        href=&quot;https://www.python.org/psf/donations/&quot;&gt;Help fund Python
+        and\nits community&lt;/a&gt;&lt;/li&gt;\n&lt;/ul&gt;\n&lt;h1 id=&quot;and-now-for-something-completely-different&quot;&gt;And
+        now for\nsomething completely different&lt;/h1&gt;\n&lt;p&gt;Today, 22nd July,
+        is Pi Approximation Day, because 22/7 is a common\napproximation of &lt;em&gt;\u03C0&lt;/em&gt;
+        and closer to &lt;em&gt;\u03C0&lt;/em&gt; than 3.14.&lt;/p&gt;\n&lt;p&gt;22/7
+        is a Diophantine approximation, named after Diophantus of\nAlexandria (3rd
+        century CE), which is a way of estimating a real number\nas a ratio of two
+        integers. 22/7 has been known since antiquity;\nArchimedes (3rd century BCE)
+        wrote the first known proof that 22/7\noverestimates &lt;em&gt;\u03C0&lt;/em&gt;
+        by comparing 96-sided polygons to the circle it\ncircumscribes.&lt;/p&gt;\n&lt;p&gt;Another
         approximation is 355/113. In Chinese mathematics, 22/7 and\n355/113 are respectively
-        known as Yuel\xFC (\u7EA6\u7387; yu\u0113l\u01DC; &#8220;approximate\nratio&#8221;)
-        and Mil\xFC (\u5BC6\u7387; m\xECl\u01DC; &#8220;close ratio&#8221;).</p>\n<p>Happy
-        <a href=\"https://piapproximationday.com/\">Pi Approximation\nDay</a>!</p>\n<h1
-        id=\"enjoy-the-new-release\">Enjoy the new release</h1>\n<p>Thanks to all
-        of the many volunteers who help make Python Development\nand these releases
-        possible! Please consider supporting our efforts by\nvolunteering yourself
-        or through organisation contributions to the <a href=\"https://www.python.org/psf-landing/\">Python
-        Software\nFoundation</a>.</p>\n<p>Regards from a Helsinki heatwave after an
-        excellent <a href=\"https://ep2025.europython.eu/\">EuroPython</a>,</p>\n<p>Your
-        release team, <br>Hugo van Kemenade \n  <br>Ned Deily\n  <br>Steve Dower\n
-        \ <br>\u0141ukasz Langa\n</p>\n<div style='clear: both;'></div>\n</div>\n<div
-        class='post-footer'>\n<div class='post-footer-line post-footer-line-1'><span
-        class='post-author vcard'>\nPosted by\n<span class='fn'>Hugo</span>\n</span>\n<span
-        class='post-timestamp'>\nat\n<a class='timestamp-link' href='https://pythoninsider.blogspot.com/2025/07/python-314-release-candidate-1-is-go.html'
-        rel='bookmark' title='permanent link'><abbr class='published' title='2025-07-22T15:47:00-04:00'>3:47&#8239;PM</abbr></a>\n</span>\n<span
-        class='post-comment-link'>\n</span>\n<span class='post-icons'>\n</span>\n<div
-        class='post-share-buttons'>\n<a class='goog-inline-block share-button sb-email'
-        href='https://www.blogger.com/share-post.g?blogID=3941553907430899163&postID=8412948848050014787&target=email'
-        target='_blank' title='Email This'><span class='share-button-link-text'>Email
-        This</span></a><a class='goog-inline-block share-button sb-blog' href='https://www.blogger.com/share-post.g?blogID=3941553907430899163&postID=8412948848050014787&target=blog'
-        onclick='window.open(this.href, \"_blank\", \"height=270,width=475\"); return
-        false;' target='_blank' title='BlogThis!'><span class='share-button-link-text'>BlogThis!</span></a><a
-        class='goog-inline-block share-button sb-twitter' href='https://www.blogger.com/share-post.g?blogID=3941553907430899163&postID=8412948848050014787&target=twitter'
-        target='_blank' title='Share to X'><span class='share-button-link-text'>Share
-        to X</span></a><a class='goog-inline-block share-button sb-facebook' href='https://www.blogger.com/share-post.g?blogID=3941553907430899163&postID=8412948848050014787&target=facebook'
-        onclick='window.open(this.href, \"_blank\", \"height=430,width=640\"); return
-        false;' target='_blank' title='Share to Facebook'><span class='share-button-link-text'>Share
-        to Facebook</span></a><a class='goog-inline-block share-button sb-pinterest'
-        href='https://www.blogger.com/share-post.g?blogID=3941553907430899163&postID=8412948848050014787&target=pinterest'
-        target='_blank' title='Share to Pinterest'><span class='share-button-link-text'>Share
-        to Pinterest</span></a>\n</div>\n</div>\n<div class='post-footer-line post-footer-line-2'><span
-        class='post-labels'>\nLabels:\n<a href='https://pythoninsider.blogspot.com/search/label/releases'
-        rel='tag'>releases</a>\n</span>\n</div>\n<div class='post-footer-line post-footer-line-3'><span
-        class='post-location'>\n</span>\n</div>\n</div>\n</div>\n</div>\n\n          </div></div>\n
-        \       \n\n          <div class=\"date-outer\">\n        \n<h2 class='date-header'><span>Tuesday,
-        July 8, 2025</span></h2>\n\n          <div class=\"date-posts\">\n        \n<div
-        class='post-outer'>\n<div class='post hentry'>\n<a name='2902244612701978117'></a>\n<h3
-        class='post-title entry-title'>\n<a href='https://pythoninsider.blogspot.com/2025/07/python-3140-beta-4-is-here.html'>Python
-        3.14.0 beta 4 is here!</a>\n</h3>\n<div class='post-header'>\n<div class='post-header-line-1'></div>\n</div>\n<div
-        class='post-body entry-content'>\n<p><a href=\"https://www.youtube.com/watch?v=cCim90WO1-4\">It&#8217;s</a>
-        the\nfinal 3.14 beta!</p>\n<p><a class=\"uri\" href=\"https://www.python.org/downloads/release/python-3140b4/\">https://www.python.org/downloads/release/python-3140b4/</a></p>\n<p><strong>This
-        is a beta preview of Python 3.14</strong></p>\n<p>Python 3.14 is still in
-        development. This release, 3.14.0b4, is the\nlast of four planned beta releases.</p>\n<p>Beta
-        release previews are intended to give the wider community the\nopportunity
-        to test new features and bug fixes and to prepare their\nprojects to support
-        the new feature release.</p>\n<p>We <strong><em>strongly encourage</em></strong>
-        maintainers of\nthird-party Python projects to <strong><em>test with 3.14</em></strong>\nduring
-        the beta phase and report issues found to <a href=\"https://github.com/python/cpython/issues\">the
-        Python bug\ntracker</a> as soon as possible. While the release is planned
-        to be\nfeature-complete entering the beta phase, it is possible that features\nmay
-        be modified or, in rare cases, deleted up until the start of the\nrelease
-        candidate phase (Tuesday 2025-07-22). Our goal is to have\n<strong><em>no
-        ABI changes</em></strong> after beta 4 and as few code\nchanges as possible
-        after the first release candidate. To achieve that,\nit will be <strong><em>extremely
-        important</em></strong> to get as much\nexposure for 3.14 as possible during
-        the beta phase.</p>\n<p>This includes creating pre-release wheels for 3.14,
-        as it helps other\nprojects to do their own testing. However, we recommend
-        that your\nregular production releases wait until 3.14.0rc1, to avoid the
-        risk of\nABI breaks.</p>\n<p>Please keep in mind that this is a preview release
-        and its use is\n<strong><em>not</em></strong> recommended for production\nenvironments.</p>\n<h1
-        id=\"major-new-features-of-the-3.14-series-compared-to-3.13\">Major\nnew features
-        of the 3.14 series, compared to 3.13</h1>\n<p>Some of the major new features
-        and changes in Python 3.14 are:</p>\n<h2 id=\"new-features\">New features</h2>\n<p><em>Note
-        that PEPs <a href=\"https://discuss.python.org/t/pep-734-multiple-interpreters-in-the-stdlib/41147/36\">734</a>\nand
-        <a href=\"https://discuss.python.org/t/pep-779-criteria-for-supported-status-for-free-threaded-python/84319/123\">779</a>\nare
-        exceptionally new in beta 3!</em></p>\n<ul>\n<li><a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pep779\">PEP\n779</a>:
-        Free-threaded Python is officially supported</li>\n<li><a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pep649\">PEP\n649</a>:
-        The evaluation of type annotations is now deferred, improving\nthe semantics
-        of using annotations.</li>\n<li><a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pep750\">PEP\n750</a>:
-        Template string literals (t-strings) for custom string\nprocessing, using
-        the familiar syntax of f-strings.</li>\n<li><a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pep734\">PEP\n734</a>:
-        Multiple interpreters in the stdlib.</li>\n<li><a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pep784\">PEP\n784</a>:
-        A new module <code>compression.zstd</code> providing support\nfor the Zstandard
-        compression algorithm.</li>\n<li><a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pep758\">PEP\n758</a>:
-        <code>except</code> and <code>except*</code> expressions may\nnow omit the
-        brackets.</li>\n<li><a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pyrepl-highlighting\">Syntax\nhighlighting
-        in PyREPL</a>, and support for color in <a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-color-unittest\">unittest</a>,\n<a
-        href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-color-argparse\">argparse</a>,\n<a
-        href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-color-json\">json</a>\nand
-        <a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-color-calendar\">calendar</a>\nCLIs.</li>\n<li><a
-        href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pep768\">PEP\n768</a>:
-        A zero-overhead external debugger interface for CPython.</li>\n<li><a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#uuid\">UUID\nversions
-        6-8</a> are now supported by the <code>uuid</code> module, and\ngeneration
-        of versions 3-5 and 8 are up to 40% faster.</li>\n<li><a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pep765\">PEP\n765</a>:
-        Disallow\n<code>return</code>/<code>break</code>/<code>continue</code> that
-        exit a\n<code>finally</code> block.</li>\n<li><a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pep741\">PEP\n741</a>:
-        An improved C API for configuring Python.</li>\n<li>A <a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-tail-call\">new\ntype
-        of interpreter</a>. For certain newer compilers, this interpreter\nprovides
-        significantly better performance. Opt-in for now, requires\nbuilding from
-        source.</li>\n<li><a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#improved-error-messages\">Improved\nerror
-        messages.</a></li>\n<li><a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#hmac\">Builtin\nimplementation
-        of HMAC</a> with formally verified code from the HACL*\nproject.</li>\n<li>A
-        <a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#asyncio-introspection-capabilities\">new\ncommand-line
-        interface</a> to inspect running Python processes using\nasynchronous tasks.</li>\n<li>The
-        pdb module now supports <a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#remote-attaching-to-a-running-python-process-with-pdb\">remote\nattaching
-        to a running Python process</a>.</li>\n</ul>\n<p><small>(Hey, <strong>fellow
-        core developer,</strong> if a feature you\nfind important is missing from
-        this list, let Hugo know.)</small></p>\n<p>For more details on the changes
-        to Python 3.14, see <a href=\"https://docs.python.org/3.14/whatsnew/3.14.html\">What&#8217;s
-        new in\nPython 3.14</a>. The next pre-release of Python 3.14 will be the first\nrelease
-        candidate, 3.14.0rc1, scheduled for 2025-07-22.</p>\n<h2 id=\"build-changes\">Build
-        changes</h2>\n<ul>\n<li><a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pep761\">PEP\n761</a>:
-        Python 3.14 and onwards no longer provides PGP signatures for\nrelease artifacts.
-        Instead, Sigstore is recommended for verifiers.</li>\n<li>Official macOS and
-        Windows release binaries include an <a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-jit-compiler\"><em>experimental</em>\nJIT
-        compiler</a>.</li>\n</ul>\n<h2 id=\"incompatible-changes-removals-and-new-deprecations\">Incompatible\nchanges,
-        removals and new deprecations</h2>\n<ul>\n<li><a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#incompatible-changes\">Incompatible\nchanges</a></li>\n<li>Python
-        <a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#removed\">removals</a>\nand
-        <a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#deprecated\">deprecations</a></li>\n<li>C
-        API <a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#c-api-removed\">removals</a>\nand
-        <a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#c-api-deprecated\">deprecations</a></li>\n<li>Overview
-        of all <a href=\"https://docs.python.org/3.14/deprecations/index.html\">pending\ndeprecations</a></li>\n</ul>\n<h1
-        id=\"python-install-manager\">Python install manager</h1>\n<p>The installer
-        we offer for Windows is being replaced by our new\ninstall manager, which
-        can be installed from <a href=\"https://apps.microsoft.com/detail/9NQ7512CXL7T\">the
-        Windows\nStore</a> or from its <a href=\"https://www.python.org/downloads/latest/pymanager/\">download\npage</a>.
-        See <a href=\"https://docs.python.org/3.14/using/windows.html\">our\ndocumentation</a>
-        for more information. The JSON file available for\ndownload below contains
-        the list of all the installable packages\navailable as part of this release,
-        including file URLs and hashes, but\nis not required to install the latest
-        release. The traditional installer\nwill remain available throughout the 3.14
-        and 3.15 releases.</p>\n<h1 id=\"more-resources\">More resources</h1>\n<ul>\n<li><a
-        href=\"https://docs.python.org/3.14/\">Online\ndocumentation</a></li>\n<li><a
-        href=\"https://peps.python.org/pep-0745/\">PEP 745</a>, 3.14\nRelease Schedule</li>\n<li>Report
-        bugs at <a href=\"https://github.com/python/cpython/issues\">github.com/python/cpython/issues</a></li>\n<li><a
-        href=\"https://www.python.org/psf/donations/\">Help fund Python and\nits community</a></li>\n</ul>\n<h1
-        id=\"and-now-for-something-completely-different\">And now for\nsomething completely
-        different</h1>\n<p>All this talk of <em>\u03C0</em> and yet some say <em>\u03C0</em>
-        is wrong. <a href=\"https://www.tauday.com/\">Tau Day</a> (June 28th, 6/28
-        in the US)\ncelebrates <em>\u03C4</em> as the &#8220;true circle constant&#8221;,
-        as the ratio of a\ncircle&#8217;s circumference to its radius, <em>C/r</em>
-        = 6.283185&#8230; The <a href=\"https://www.tauday.com/tau-manifesto\">Tau
-        Manifesto</a> declares\n<em>\u03C0</em> &#8220;a confusing and unnatural choice
-        for the circle constant&#8221;,\nin part because &#8220;<em>2\u03C0</em> occurs
-        with astonishing frequency\nthroughout mathematics&#8221;.</p>\n<p>If you
-        wish to embrace <em>\u03C4</em> the good news is <a href=\"https://peps.python.org/pep-0628/\">PEP
-        628</a> added <a href=\"https://docs.python.org/3/library/math.html#math.tau\"><code>math.tau</code></a>\nto
-        Python 3.6 in 2016:</p>\n<blockquote>\n<p>When working with radians, it is
-        trivial to convert any given\nfraction of a circle to a value in radians in
-        terms of <code>tau</code>.\nA quarter circle is <code>tau/4</code>, a half
-        circle is\n<code>tau/2</code>, seven 25ths is <code>7*tau/25</code>, etc.
-        In\ncontrast with the equivalent expressions in terms of <code>pi</code>\n(<code>pi/2</code>,
-        <code>pi</code>, <code>14*pi/25</code>), the\nunnecessary and needlessly confusing
-        multiplication by two is gone.</p>\n</blockquote>\n<h1 id=\"enjoy-the-new-release\">Enjoy
-        the new release</h1>\n<p>Thanks to all of the many volunteers who help make
-        Python Development\nand these releases possible! Please consider supporting
-        our efforts by\nvolunteering yourself or through organisation contributions
-        to the <a href=\"https://www.python.org/psf-landing/\">Python Software\nFoundation</a>.</p>\n<p>Regards
-        from a cloudy Helsinki, looking forward to Prague and <a href=\"https://ep2025.europython.eu/\">EuroPython</a>
-        next week,</p>\n<p>Your release team, <br>Hugo van Kemenade <br>Ned Deily
-        <br>Steve\nDower <br>\u0141ukasz Langa</p>\n<div style='clear: both;'></div>\n</div>\n<div
-        class='post-footer'>\n<div class='post-footer-line post-footer-line-1'><span
-        class='post-author vcard'>\nPosted by\n<span class='fn'>Hugo</span>\n</span>\n<span
-        class='post-timestamp'>\nat\n<a class='timestamp-link' href='https://pythoninsider.blogspot.com/2025/07/python-3140-beta-4-is-here.html'
-        rel='bookmark' title='permanent link'><abbr class='published' title='2025-07-08T11:04:00-04:00'>11:04&#8239;AM</abbr></a>\n</span>\n<span
-        class='post-comment-link'>\n</span>\n<span class='post-icons'>\n</span>\n<div
-        class='post-share-buttons'>\n<a class='goog-inline-block share-button sb-email'
-        href='https://www.blogger.com/share-post.g?blogID=3941553907430899163&postID=2902244612701978117&target=email'
-        target='_blank' title='Email This'><span class='share-button-link-text'>Email
-        This</span></a><a class='goog-inline-block share-button sb-blog' href='https://www.blogger.com/share-post.g?blogID=3941553907430899163&postID=2902244612701978117&target=blog'
-        onclick='window.open(this.href, \"_blank\", \"height=270,width=475\"); return
-        false;' target='_blank' title='BlogThis!'><span class='share-button-link-text'>BlogThis!</span></a><a
-        class='goog-inline-block share-button sb-twitter' href='https://www.blogger.com/share-post.g?blogID=3941553907430899163&postID=2902244612701978117&target=twitter'
-        target='_blank' title='Share to X'><span class='share-button-link-text'>Share
-        to X</span></a><a class='goog-inline-block share-button sb-facebook' href='https://www.blogger.com/share-post.g?blogID=3941553907430899163&postID=2902244612701978117&target=facebook'
-        onclick='window.open(this.href, \"_blank\", \"height=430,width=640\"); return
-        false;' target='_blank' title='Share to Facebook'><span class='share-button-link-text'>Share
-        to Facebook</span></a><a class='goog-inline-block share-button sb-pinterest'
-        href='https://www.blogger.com/share-post.g?blogID=3941553907430899163&postID=2902244612701978117&target=pinterest'
-        target='_blank' title='Share to Pinterest'><span class='share-button-link-text'>Share
-        to Pinterest</span></a>\n</div>\n</div>\n<div class='post-footer-line post-footer-line-2'><span
-        class='post-labels'>\nLabels:\n<a href='https://pythoninsider.blogspot.com/search/label/releases'
-        rel='tag'>releases</a>\n</span>\n</div>\n<div class='post-footer-line post-footer-line-3'><span
-        class='post-location'>\n</span>\n</div>\n</div>\n</div>\n</div>\n\n          </div></div>\n
-        \       \n\n          <div class=\"date-outer\">\n        \n<h2 class='date-header'><span>Tuesday,
-        June 17, 2025</span></h2>\n\n          <div class=\"date-posts\">\n        \n<div
-        class='post-outer'>\n<div class='post hentry'>\n<a name='6430176619474922622'></a>\n<h3
-        class='post-title entry-title'>\n<a href='https://pythoninsider.blogspot.com/2025/06/python-3140-beta-3-is-here.html'>Python
-        3.14.0 beta 3 is here!</a>\n</h3>\n<div class='post-header'>\n<div class='post-header-line-1'></div>\n</div>\n<div
-        class='post-body entry-content'>\n<p>It&#8217;s 3.14 beta 3!</p>\n<p><a class=\"uri\"
-        href=\"https://www.python.org/downloads/release/python-3140b3/\">https://www.python.org/downloads/release/python-3140b3/</a></p>\n<p><strong>This
-        is a beta preview of Python 3.14</strong></p>\n<p>Python 3.14 is still in
-        development. This release, 3.14.0b3, is the\nthird of four planned beta releases.</p>\n<p>Beta
-        release previews are intended to give the wider community the\nopportunity
-        to test new features and bug fixes and to prepare their\nprojects to support
-        the new feature release.</p>\n<p>We <strong><em>strongly encourage</em></strong>
-        maintainers of\nthird-party Python projects to <strong><em>test with 3.14</em></strong>\nduring
-        the beta phase and report issues found to <a href=\"https://github.com/python/cpython/issues\">the
-        Python bug\ntracker</a> as soon as possible. While the release is planned
-        to be\nfeature-complete entering the beta phase, it is possible that features\nmay
-        be modified or, in rare cases, deleted up until the start of the\nrelease
-        candidate phase (Tuesday 2025-07-22). Our goal is to have\n<strong><em>no
-        ABI changes</em></strong> after beta 4 and as few code\nchanges as possible
-        after the first release candidate. To achieve that,\nit will be <strong><em>extremely
-        important</em></strong> to get as much\nexposure for 3.14 as possible during
-        the beta phase.</p>\n<p>This includes creating pre-release wheels for 3.14,
-        as it helps other\nprojects to do their own testing. However, we recommend
-        that your\nregular production releases wait until 3.14.0rc1, to avoid the
-        risk of\nABI breaks.</p>\n<p>Please keep in mind that this is a preview release
-        and its use is\n<strong><em>not</em></strong> recommended for production\nenvironments.</p>\n<h1
-        id=\"major-new-features-of-the-3.14-series-compared-to-3.13\">Major\nnew features
-        of the 3.14 series, compared to 3.13</h1>\n<p>Some of the major new features
-        and changes in Python 3.14 are:</p>\n<h2 id=\"new-features\">New features</h2>\n<p><em>Note
-        that PEPs <a href=\"https://discuss.python.org/t/pep-734-multiple-interpreters-in-the-stdlib/41147/36\">734</a>\nand
-        <a href=\"https://discuss.python.org/t/pep-779-criteria-for-supported-status-for-free-threaded-python/84319/123\">779</a>\nare
-        exceptionally new in beta 3!</em></p>\n<ul>\n<li><a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pep779\">PEP\n779</a>:
-        Free-threaded Python is officially supported</li>\n<li><a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pep649\">PEP\n649</a>:
-        The evaluation of type annotations is now deferred, improving\nthe semantics
-        of using annotations.</li>\n<li><a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pep750\">PEP\n750</a>:
-        Template string literals (t-strings) for custom string\nprocessing, using
-        the familiar syntax of f-strings.</li>\n<li><a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pep734\">PEP\n734</a>:
-        Multiple interpreters in the stdlib.</li>\n<li><a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pep784\">PEP\n784</a>:
-        A new module <code>compression.zstd</code> providing support\nfor the Zstandard
-        compression algorithm.</li>\n<li><a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pep758\">PEP\n758</a>:
-        <code>except</code> and <code>except*</code> expressions may\nnow omit the
-        brackets.</li>\n<li><a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pyrepl-highlighting\">Syntax\nhighlighting
-        in PyREPL</a>, and support for color in <a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-color-unittest\">unittest</a>,\n<a
-        href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-color-argparse\">argparse</a>,\n<a
-        href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-color-json\">json</a>\nand
-        <a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-color-calendar\">calendar</a>\nCLIs.</li>\n<li><a
-        href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pep768\">PEP\n768</a>:
-        A zero-overhead external debugger interface for CPython.</li>\n<li><a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#uuid\">UUID\nversions
-        6-8</a> are now supported by the <code>uuid</code> module, and\ngeneration
-        of versions 3-5 and 8 are up to 40% faster.</li>\n<li><a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pep765\">PEP\n765</a>:
-        Disallow\n<code>return</code>/<code>break</code>/<code>continue</code> that
-        exit a\n<code>finally</code> block.</li>\n<li><a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pep741\">PEP\n741</a>:
-        An improved C API for configuring Python.</li>\n<li>A <a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-tail-call\">new\ntype
-        of interpreter</a>. For certain newer compilers, this interpreter\nprovides
-        significantly better performance. Opt-in for now, requires\nbuilding from
-        source.</li>\n<li><a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#improved-error-messages\">Improved\nerror
-        messages.</a></li>\n<li><a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#hmac\">Builtin\nimplementation
-        of HMAC</a> with formally verified code from the HACL*\nproject.</li>\n<li>A
-        <a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#asyncio-introspection-capabilities\">new\ncommand-line
-        interface</a> to inspect running Python processes using\nasynchronous tasks.</li>\n<li>The
-        pdb module now supports <a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#remote-attaching-to-a-running-python-process-with-pdb\">remote\nattaching
-        to a running Python process</a>.</li>\n</ul>\n<p><small>(Hey, <strong>fellow
-        core developer,</strong> if a feature you\nfind important is missing from
-        this list, let Hugo know.)</small></p>\n<p>For more details on the changes
-        to Python 3.14, see <a href=\"https://docs.python.org/3.14/whatsnew/3.14.html\">What&#8217;s
-        new in\nPython 3.14</a>. The next pre-release of Python 3.14 will be the final\nbeta,
-        3.14.0b4, scheduled for 2025-07-08.</p>\n<h2 id=\"build-changes\">Build changes</h2>\n<ul>\n<li><a
-        href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pep761\">PEP\n761</a>:
-        Python 3.14 and onwards no longer provides PGP signatures for\nrelease artifacts.
-        Instead, Sigstore is recommended for verifiers.</li>\n<li>Official macOS and
-        Windows release binaries include an <a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-jit-compiler\"><em>experimental</em>\nJIT
-        compiler</a>.</li>\n</ul>\n<h2 id=\"incompatible-changes-removals-and-new-deprecations\">Incompatible\nchanges,
-        removals and new deprecations</h2>\n<ul>\n<li><a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#incompatible-changes\">Incompatible\nchanges</a></li>\n<li>Python
-        <a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#removed\">removals</a>\nand
-        <a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#deprecated\">deprecations</a></li>\n<li>C
-        API <a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#c-api-removed\">removals</a>\nand
-        <a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#c-api-deprecated\">deprecations</a></li>\n<li>Overview
-        of all <a href=\"https://docs.python.org/3.14/deprecations/index.html\">pending\ndeprecations</a></li>\n</ul>\n<h1
-        id=\"python-install-manager\">Python install manager</h1>\n<p>The installer
-        we offer for Windows is being replaced by our new\ninstall manager, which
-        can be installed from <a href=\"https://apps.microsoft.com/detail/9NQ7512CXL7T\">the
-        Windows\nStore</a> or <a href=\"https://www.python.org/ftp/python/pymanager/\">our\nFTP
-        page</a>. See <a href=\"https://docs.python.org/3.14/using/windows.html\">our\ndocumentation</a>
-        for more information. The JSON file available for\ndownload below contains
-        the list of all the installable packages\navailable as part of this release,
-        including file URLs and hashes, but\nis not required to install the latest
-        release. The traditional installer\nwill remain available throughout the 3.14
-        and 3.15 releases.</p>\n<h1 id=\"more-resources\">More resources</h1>\n<ul>\n<li><a
-        href=\"https://docs.python.org/3.14/\">Online\ndocumentation</a></li>\n<li><a
-        href=\"https://peps.python.org/pep-0745/\">PEP 745</a>, 3.14\nRelease Schedule</li>\n<li>Report
-        bugs at <a href=\"https://github.com/python/cpython/issues\">github.com/python/cpython/issues</a></li>\n<li><a
-        href=\"https://www.python.org/psf/donations/\">Help fund Python and\nits community</a></li>\n</ul>\n<h1
-        id=\"and-now-for-something-completely-different\">And now for\nsomething completely
-        different</h1>\n<p>If you&#8217;re heading out to sea, remember the <a href=\"https://xkcd.com/3023/\">Maritime
-        Approximation</a>:</p>\n<blockquote>\n<p><em>\u03C0</em> mph = <em>e</em>
-        knots</p>\n</blockquote>\n<h1 id=\"enjoy-the-new-release\">Enjoy the new release</h1>\n<p>Thanks
+        known as Yuel\xFC (\u7EA6\u7387; yu\u0113l\u01DC; \u201Capproximate\nratio\u201D)
+        and Mil\xFC (\u5BC6\u7387; m\xECl\u01DC; \u201Cclose ratio\u201D).&lt;/p&gt;\n&lt;p&gt;Happy
+        &lt;a href=&quot;https://piapproximationday.com/&quot;&gt;Pi Approximation\nDay&lt;/a&gt;!&lt;/p&gt;\n&lt;h1
+        id=&quot;enjoy-the-new-release&quot;&gt;Enjoy the new release&lt;/h1&gt;\n&lt;p&gt;Thanks
         to all of the many volunteers who help make Python Development\nand these
         releases possible! Please consider supporting our efforts by\nvolunteering
-        yourself or through organisation contributions to the <a href=\"https://www.python.org/psf-landing/\">Python
-        Software\nFoundation</a>.</p>\n<p>Regards from sunny Helsinki with 19 hours
-        of daylight,</p>\n<p>Your release team, \n  <br>Hugo van Kemenade\n  <br>Ned
-        Deily\n  <br>Steve Dower\n  <br>\u0141ukasz Langa\n</p>\n<div style='clear:
-        both;'></div>\n</div>\n<div class='post-footer'>\n<div class='post-footer-line
-        post-footer-line-1'><span class='post-author vcard'>\nPosted by\n<span class='fn'>Hugo</span>\n</span>\n<span
-        class='post-timestamp'>\nat\n<a class='timestamp-link' href='https://pythoninsider.blogspot.com/2025/06/python-3140-beta-3-is-here.html'
-        rel='bookmark' title='permanent link'><abbr class='published' title='2025-06-17T14:43:00-04:00'>2:43&#8239;PM</abbr></a>\n</span>\n<span
-        class='post-comment-link'>\n</span>\n<span class='post-icons'>\n</span>\n<div
-        class='post-share-buttons'>\n<a class='goog-inline-block share-button sb-email'
-        href='https://www.blogger.com/share-post.g?blogID=3941553907430899163&postID=6430176619474922622&target=email'
-        target='_blank' title='Email This'><span class='share-button-link-text'>Email
-        This</span></a><a class='goog-inline-block share-button sb-blog' href='https://www.blogger.com/share-post.g?blogID=3941553907430899163&postID=6430176619474922622&target=blog'
-        onclick='window.open(this.href, \"_blank\", \"height=270,width=475\"); return
-        false;' target='_blank' title='BlogThis!'><span class='share-button-link-text'>BlogThis!</span></a><a
-        class='goog-inline-block share-button sb-twitter' href='https://www.blogger.com/share-post.g?blogID=3941553907430899163&postID=6430176619474922622&target=twitter'
-        target='_blank' title='Share to X'><span class='share-button-link-text'>Share
-        to X</span></a><a class='goog-inline-block share-button sb-facebook' href='https://www.blogger.com/share-post.g?blogID=3941553907430899163&postID=6430176619474922622&target=facebook'
-        onclick='window.open(this.href, \"_blank\", \"height=430,width=640\"); return
-        false;' target='_blank' title='Share to Facebook'><span class='share-button-link-text'>Share
-        to Facebook</span></a><a class='goog-inline-block share-button sb-pinterest'
-        href='https://www.blogger.com/share-post.g?blogID=3941553907430899163&postID=6430176619474922622&target=pinterest'
-        target='_blank' title='Share to Pinterest'><span class='share-button-link-text'>Share
-        to Pinterest</span></a>\n</div>\n</div>\n<div class='post-footer-line post-footer-line-2'><span
-        class='post-labels'>\nLabels:\n<a href='https://pythoninsider.blogspot.com/search/label/releases'
-        rel='tag'>releases</a>\n</span>\n</div>\n<div class='post-footer-line post-footer-line-3'><span
-        class='post-location'>\n</span>\n</div>\n</div>\n</div>\n</div>\n\n          </div></div>\n
-        \       \n\n          <div class=\"date-outer\">\n        \n<h2 class='date-header'><span>Wednesday,
-        June 11, 2025</span></h2>\n\n          <div class=\"date-posts\">\n        \n<div
-        class='post-outer'>\n<div class='post hentry'>\n<a name='6912588868872774611'></a>\n<h3
-        class='post-title entry-title'>\n<a href='https://pythoninsider.blogspot.com/2025/06/python-3135-is-now-available.html'>Python
-        3.13.5 is now available!</a>\n</h3>\n<div class='post-header'>\n<div class='post-header-line-1'></div>\n</div>\n<div
-        class='post-body entry-content'>\n<p>When I was younger we would call this
-        a brown paper bag release, but \nactually, we shouldn&#8217;t hide from our
-        mistakes. We&#8217;re only human. So, \nplease enjoy:</p>\n<h1 style=\"text-align:
-        left;\"><a class=\"anchor\" href=\"https://discuss.python.org/t/python-3-13-5-is-now-available-yes-really/95211#p-254481-python-3135-1\"
-        name=\"p-254481-python-3135-1\"></a>Python 3.13.5</h1><div style=\"text-align:
-        left;\">&nbsp;</div><div style=\"text-align: left;\"><a href=\"https://www.python.org/downloads/release/python-3135/\">&nbsp;https://www.python.org/downloads/release/python-3135/</a></div><h3
-        style=\"text-align: left;\"><a class=\"anchor\" href=\"https://discuss.python.org/t/python-3-13-5-is-now-available-yes-really/95211#p-254481-this-is-the-fifth-maintenance-release-of-python-313-2\"
-        name=\"p-254481-this-is-the-fifth-maintenance-release-of-python-313-2\"></a>&nbsp;</h3><h3
-        style=\"text-align: left;\">This is the fifth maintenance release of Python
-        3.13</h3>\n<p>Python 3.13 is the newest major release of the Python programming
-        \nlanguage, and it contains many new features and optimizations compared \nto
-        Python 3.12. 3.13.5 is the fifth maintenance release of 3.13.</p>\n<p>3.13.5
-        is an expedited release to fix a couple of significant issues with the 3.13.4
-        release:</p>\n<ul><li><a href=\"https://github.com/python/cpython/issues/135151\">gh-135151</a>:
-        Building extension modules on Windows for the regular (non-free-threaded)
-        build failed.</li><li><a aria-label=\"gh-135171 link clicked 1 time\" data-clicks=\"1\"
-        href=\"https://github.com/python/cpython/issues/135171\">gh-135171</a>: Generator
-        expressions stopped raising <code>TypeError</code> (when iterating over non-iterable
-        objects) at creation time, delaying it to first use.</li><li><a href=\"https://github.com/python/cpython/issues/135326\">gh-135326</a>:
-        Passing int-like objects (like <code>numpy.int64</code>) to <code>random.getrandbits()</code>
-        failed, when it worked before.</li></ul>\n<p>Several other bug fixes (which
-        would otherwise have waited until the \nnext release) are also included. Special
-        thanks to everyone who worked \nhard the last couple of days to fix these
-        issues as quickly as possible.</p>\n<p><a href=\"https://docs.python.org/release/3.13.5/whatsnew/changelog.html#python-3-13-5\">Full
-        Changelog</a></p>\n<h3 style=\"text-align: left;\"><a class=\"anchor\" href=\"https://discuss.python.org/t/python-3-13-5-is-now-available-yes-really/95211#p-254481-more-resources-3\"
-        name=\"p-254481-more-resources-3\"></a>More resources</h3>\n<ul><li><a href=\"https://docs.python.org/3.13/\">Online
-        Documentation</a></li><li><a aria-label=\"PEP 719 link clicked 1 time\" data-clicks=\"1\"
-        href=\"https://peps.python.org/pep-0719/\">PEP 719</a>, 3.13 Release Schedule
-        (not that you&#8217;ll find this release on there yet.)</li><li>Report bugs
-        via <a href=\"https://github.com/python/cpython/issues\">GitHub</a>.</li><li><a
-        href=\"https://www.python.org/psf/donations/python-dev/\">Help fund Python
-        directly</a> (or <a href=\"https://github.com/sponsors/python\">via GitHub
-        Sponsors</a>), and support <a href=\"https://www.python.org/psf/donations/\">the
-        Python community</a>.</li></ul>\n<h3 style=\"text-align: left;\"><a class=\"anchor\"
-        href=\"https://discuss.python.org/t/python-3-13-5-is-now-available-yes-really/95211#p-254481-stay-safe-and-upgrade-4\"
-        name=\"p-254481-stay-safe-and-upgrade-4\"></a>&nbsp;</h3><h3 style=\"text-align:
-        left;\">Stay safe and upgrade!</h3>\n<p>As always, upgrading is highly recommended
-        to all users of 3.13.</p>\n<h3 style=\"text-align: left;\"><a class=\"anchor\"
-        href=\"https://discuss.python.org/t/python-3-13-5-is-now-available-yes-really/95211#p-254481-enjoy-the-new-releases-5\"
-        name=\"p-254481-enjoy-the-new-releases-5\"></a>&nbsp;</h3><h3 style=\"text-align:
-        left;\">Enjoy the new releases</h3>\n<p>Thanks to all of the many volunteers
-        who help make Python Development\n and these releases possible! Please consider
-        supporting our efforts by \nvolunteering yourself or through organization
-        contributions to the \nPython Software Foundation.</p>\n<p>Regards from hey,
-        it&#8217;s us again, your release team,<br />\nThomas Wouters <br />\nNed
-        Deily <br />\nSteve Dower <br />\n\u0141ukasz Langa <br /></p>\n<div style='clear:
-        both;'></div>\n</div>\n<div class='post-footer'>\n<div class='post-footer-line
-        post-footer-line-1'><span class='post-author vcard'>\nPosted by\n<span class='fn'>Thomas
-        Wouters</span>\n</span>\n<span class='post-timestamp'>\nat\n<a class='timestamp-link'
-        href='https://pythoninsider.blogspot.com/2025/06/python-3135-is-now-available.html'
-        rel='bookmark' title='permanent link'><abbr class='published' title='2025-06-11T18:03:00-04:00'>6:03&#8239;PM</abbr></a>\n</span>\n<span
-        class='post-comment-link'>\n</span>\n<span class='post-icons'>\n</span>\n<div
-        class='post-share-buttons'>\n<a class='goog-inline-block share-button sb-email'
-        href='https://www.blogger.com/share-post.g?blogID=3941553907430899163&postID=6912588868872774611&target=email'
-        target='_blank' title='Email This'><span class='share-button-link-text'>Email
-        This</span></a><a class='goog-inline-block share-button sb-blog' href='https://www.blogger.com/share-post.g?blogID=3941553907430899163&postID=6912588868872774611&target=blog'
-        onclick='window.open(this.href, \"_blank\", \"height=270,width=475\"); return
-        false;' target='_blank' title='BlogThis!'><span class='share-button-link-text'>BlogThis!</span></a><a
-        class='goog-inline-block share-button sb-twitter' href='https://www.blogger.com/share-post.g?blogID=3941553907430899163&postID=6912588868872774611&target=twitter'
-        target='_blank' title='Share to X'><span class='share-button-link-text'>Share
-        to X</span></a><a class='goog-inline-block share-button sb-facebook' href='https://www.blogger.com/share-post.g?blogID=3941553907430899163&postID=6912588868872774611&target=facebook'
-        onclick='window.open(this.href, \"_blank\", \"height=430,width=640\"); return
-        false;' target='_blank' title='Share to Facebook'><span class='share-button-link-text'>Share
-        to Facebook</span></a><a class='goog-inline-block share-button sb-pinterest'
-        href='https://www.blogger.com/share-post.g?blogID=3941553907430899163&postID=6912588868872774611&target=pinterest'
-        target='_blank' title='Share to Pinterest'><span class='share-button-link-text'>Share
-        to Pinterest</span></a>\n</div>\n</div>\n<div class='post-footer-line post-footer-line-2'><span
-        class='post-labels'>\n</span>\n</div>\n<div class='post-footer-line post-footer-line-3'><span
-        class='post-location'>\n</span>\n</div>\n</div>\n</div>\n</div>\n\n          </div></div>\n
-        \       \n\n          <div class=\"date-outer\">\n        \n<h2 class='date-header'><span>Tuesday,
-        June 3, 2025</span></h2>\n\n          <div class=\"date-posts\">\n        \n<div
-        class='post-outer'>\n<div class='post hentry'>\n<a name='8911393060938687340'></a>\n<h3
-        class='post-title entry-title'>\n<a href='https://pythoninsider.blogspot.com/2025/06/python-3134-31211-31113-31018-and-3923.html'>Python
-        3.13.4, 3.12.11, 3.11.13, 3.10.18 and 3.9.23 are now available</a>\n</h3>\n<div
-        class='post-header'>\n<div class='post-header-line-1'></div>\n</div>\n<div
-        class='post-body entry-content'>\n<p>&nbsp;</p><h1 style=\"text-align: left;\">Python
-        Release Party</h1>\n<p>It was only meant to be release day for 3.13.4 today,
-        but poor number\n 13 looked so lonely&#8230; And hey, we had a couple of tarfile
-        CVEs that we \nhad to fix. So most of the Release Managers and all the \nDevelopers-in-Residence
-        (including Security Developer-in-Residence Seth Michael Larson) came together
-        to make it a full release party.</p>\n<h1 style=\"text-align: left;\">Security
-        content in these releases</h1>\n<ul><li><a href=\"https://github.com/python/cpython/issues/135034\">gh-135034</a>:
-        Fixes multiple issues that allowed <code>tarfile</code> extraction filters
-        (<code>filter=\"data\"</code> and <code>filter=\"tar\"</code>) to be bypassed
-        using crafted symlinks and hard links.Addresses <a href=\"https://www.cve.org/CVERecord?id=CVE-2024-12718\"><b>CVE
-        2024-12718</b></a>, <a href=\"https://www.cve.org/CVERecord?id=CVE-2025-4138\"><b>CVE
-        2025-4138</b></a>, <a href=\"https://www.cve.org/CVERecord?id=CVE-2025-4330\"><b>CVE
-        2025-4330</b></a>, and <a href=\"https://www.cve.org/CVERecord?id=CVE-2025-4517\"><b>CVE
-        2025-4517</b></a>.</li><li><a href=\"https://github.com/python/cpython/issues/133767\">gh-133767</a>:
-        Fix use-after-free in the &#8220;unicode-escape&#8221; decoder with a non-&#8220;strict&#8221;
-        error handler.</li><li><a href=\"https://github.com/python/cpython/issues/128840\">gh-128840</a>:
-        Short-circuit the processing of long IPv6 addresses early in <a href=\"https://docs.python.org/release/3.13.4/library/ipaddress.html#module-ipaddress\"><code>ipaddress</code></a>
-        to prevent excessive memory consumption and a minor denial-of-service.</li></ul>\n<p>In
-        addition to the security fixed mentioned above, a few additional changes to
-        the <code>ipaddress</code> were backported to make the security fixes feasible.
-        (See the full changelogs for each release for more details.)</p>\n<h1 style=\"text-align:
-        left;\">Python 3.13.4</h1>\n<p>In addition to the security fixes, the fourth
-        maintenance release of \nPython 3.13 contains more than 300 bugfixes, build
-        improvements and \ndocumentation changes.</p><p><a href=\"https://www.python.org/downloads/release/python-3134/\">https://www.python.org/downloads/release/python-3134/</a></p>\n\n<h1
-        style=\"text-align: left;\">Python 3.12.11</h1><p><a href=\"https://www.python.org/downloads/release/python-31211/\">https://www.python.org/downloads/release/python-31211/</a></p><h1
-        style=\"text-align: left;\">Python 3.11.13</h1><p>&nbsp;<a href=\"https://www.python.org/downloads/release/python-31113/\">https://www.python.org/downloads/release/python-31113/</a></p><h1
-        style=\"text-align: left;\">Python 3.10.18</h1>\n<aside class=\"onebox allowlistedgeneric\"
-        data-onebox-src=\"https://www.python.org/downloads/release/python-31018/\"><br
-        /></aside><aside class=\"onebox allowlistedgeneric\" data-onebox-src=\"https://www.python.org/downloads/release/python-31018/\"><a
-        href=\"https://www.python.org/downloads/release/python-31018/\">https://www.python.org/downloads/release/python-31018/</a></aside><aside
-        class=\"onebox allowlistedgeneric\" data-onebox-src=\"https://www.python.org/downloads/release/python-31018/\">&nbsp;</aside>\n\n<h1
-        style=\"text-align: left;\">Python 3.9.23</h1>\n<p>Additional security content
-        in this release (already fixed in older releases for the other versions):</p>\n<ul><li><a
-        href=\"https://github.com/python/cpython/issues/80222\">gh-80222</a>:\n Fix
-        bug in the folding of quoted strings when flattening an email \nmessage using
-        a modern email policy. Previously when a quoted string was\n folded so that
-        it spanned more than one line, the surrounding quotes \nand internal escapes
-        would be omitted. This could theoretically be used \nto spoof header lines
-        using a carefully constructed quoted string if the\n resulting rendered email
-        was transmitted or re-parsed.</li></ul>\n<aside class=\"onebox allowlistedgeneric\"
-        data-onebox-src=\"https://www.python.org/downloads/release/python-3923/\"><a
-        href=\"https://www.python.org/downloads/release/python-3923\">https://www.python.org/downloads/release/python-3923</a><div
-        class=\"onebox-metadata\">\n    \n    \n  </div>\n\n  \n<br /></aside>\n\n<h1
-        style=\"text-align: left;\">Stay safe and upgrade!</h1>\n<p>As always, upgrading
-        is highly recommended to all users of affected versions.</p>\n<h1 style=\"text-align:
-        left;\">Enjoy the new releases</h1>\n<p>Thanks to all of the many volunteers
-        who help make Python Development\n and these releases possible! Please consider
-        supporting our efforts by \nvolunteering yourself or through organization
-        contributions to the \nPython Software Foundation.</p>\n<p>Regards from your
-        very <s>tired</s> tireless release team,<br />\nThomas Wouters <br />\nPablo
-        Galindo Salgado <br />\n\u0141ukasz Langa <br />\nNed Deily <br />\nSteve
-        Dower <br /></p>\n<div style='clear: both;'></div>\n</div>\n<div class='post-footer'>\n<div
-        class='post-footer-line post-footer-line-1'><span class='post-author vcard'>\nPosted
-        by\n<span class='fn'>Thomas Wouters</span>\n</span>\n<span class='post-timestamp'>\nat\n<a
-        class='timestamp-link' href='https://pythoninsider.blogspot.com/2025/06/python-3134-31211-31113-31018-and-3923.html'
-        rel='bookmark' title='permanent link'><abbr class='published' title='2025-06-03T17:04:00-04:00'>5:04&#8239;PM</abbr></a>\n</span>\n<span
-        class='post-comment-link'>\n</span>\n<span class='post-icons'>\n</span>\n<div
-        class='post-share-buttons'>\n<a class='goog-inline-block share-button sb-email'
-        href='https://www.blogger.com/share-post.g?blogID=3941553907430899163&postID=8911393060938687340&target=email'
-        target='_blank' title='Email This'><span class='share-button-link-text'>Email
-        This</span></a><a class='goog-inline-block share-button sb-blog' href='https://www.blogger.com/share-post.g?blogID=3941553907430899163&postID=8911393060938687340&target=blog'
-        onclick='window.open(this.href, \"_blank\", \"height=270,width=475\"); return
-        false;' target='_blank' title='BlogThis!'><span class='share-button-link-text'>BlogThis!</span></a><a
-        class='goog-inline-block share-button sb-twitter' href='https://www.blogger.com/share-post.g?blogID=3941553907430899163&postID=8911393060938687340&target=twitter'
-        target='_blank' title='Share to X'><span class='share-button-link-text'>Share
-        to X</span></a><a class='goog-inline-block share-button sb-facebook' href='https://www.blogger.com/share-post.g?blogID=3941553907430899163&postID=8911393060938687340&target=facebook'
-        onclick='window.open(this.href, \"_blank\", \"height=430,width=640\"); return
-        false;' target='_blank' title='Share to Facebook'><span class='share-button-link-text'>Share
-        to Facebook</span></a><a class='goog-inline-block share-button sb-pinterest'
-        href='https://www.blogger.com/share-post.g?blogID=3941553907430899163&postID=8911393060938687340&target=pinterest'
-        target='_blank' title='Share to Pinterest'><span class='share-button-link-text'>Share
-        to Pinterest</span></a>\n</div>\n</div>\n<div class='post-footer-line post-footer-line-2'><span
-        class='post-labels'>\n</span>\n</div>\n<div class='post-footer-line post-footer-line-3'><span
-        class='post-location'>\n</span>\n</div>\n</div>\n</div>\n</div>\n\n          </div></div>\n
-        \       \n\n          <div class=\"date-outer\">\n        \n<h2 class='date-header'><span>Monday,
-        May 26, 2025</span></h2>\n\n          <div class=\"date-posts\">\n        \n<div
-        class='post-outer'>\n<div class='post hentry'>\n<a name='8971055125507701901'></a>\n<h3
-        class='post-title entry-title'>\n<a href='https://pythoninsider.blogspot.com/2025/05/python-3140-beta-2-is-here.html'>Python
-        3.14.0 beta 2 is here!</a>\n</h3>\n<div class='post-header'>\n<div class='post-header-line-1'></div>\n</div>\n<div
-        class='post-body entry-content'>\n<p>Here&#8217;s the second 3.14 beta.</p>\n<p><a
-        class=\"uri\" href=\"https://www.python.org/downloads/release/python-3140b2/\">https://www.python.org/downloads/release/python-3140b2/</a></p>\n<p><strong>This
-        is a beta preview of Python 3.14</strong></p>\n<p>Python 3.14 is still in
-        development. This release, 3.14.0b2, is the\nsecond of four planned beta releases.</p>\n<p>Beta
-        release previews are intended to give the wider community the\nopportunity
-        to test new features and bug fixes and to prepare their\nprojects to support
-        the new feature release.</p>\n<p>We <strong><em>strongly encourage</em></strong>
-        maintainers of\nthird-party Python projects to <strong><em>test with 3.14</em></strong>\nduring
-        the beta phase and report issues found to <a href=\"https://github.com/python/cpython/issues\">the
-        Python bug\ntracker</a> as soon as possible. While the release is planned
+        yourself or through organisation contributions to the &lt;a\nhref=&quot;https://www.python.org/psf-landing/&quot;&gt;Python
+        Software\nFoundation&lt;/a&gt;.&lt;/p&gt;\n&lt;p&gt;Regards from a Helsinki
+        heatwave after an excellent &lt;a\nhref=&quot;https://ep2025.europython.eu/&quot;&gt;EuroPython&lt;/a&gt;,&lt;/p&gt;\n&lt;p&gt;Your
+        release team, &lt;br&gt;Hugo van Kemenade \n  &lt;br&gt;Ned Deily\n  &lt;br&gt;Steve
+        Dower\n  &lt;br&gt;\u0141ukasz Langa\n&lt;/p&gt;\n</content><link rel='edit'
+        type='application/atom+xml' href='https://www.blogger.com/feeds/3941553907430899163/posts/default/8412948848050014787'/><link
+        rel='self' type='application/atom+xml' href='https://www.blogger.com/feeds/3941553907430899163/posts/default/8412948848050014787'/><link
+        rel='alternate' type='text/html' href='https://pythoninsider.blogspot.com/2025/07/python-314-release-candidate-1-is-go.html'
+        title='Python 3.14 release candidate 1 is go!'/><author><name>Hugo</name><uri>http://www.blogger.com/profile/02811718172961252565</uri><email>noreply@blogger.com</email><gd:image
+        rel='http://schemas.google.com/g/2005#thumbnail' width='16' height='16' src='https://img1.blogblog.com/img/b16-rounded.gif'/></author></entry><entry><id>tag:blogger.com,1999:blog-3941553907430899163.post-2902244612701978117</id><published>2025-07-08T11:04:00.001-04:00</published><updated>2025-07-08T11:54:01.251-04:00</updated><category
+        scheme=\"http://www.blogger.com/atom/ns#\" term=\"releases\"/><title type='text'>Python
+        3.14.0 beta 4 is here!</title><content type='html'>&lt;p&gt;&lt;a href=&quot;https://www.youtube.com/watch?v=cCim90WO1-4&quot;&gt;It\u2019s&lt;/a&gt;
+        the\nfinal 3.14 beta!&lt;/p&gt;\n&lt;p&gt;&lt;a href=&quot;https://www.python.org/downloads/release/python-3140b4/&quot;\nclass=&quot;uri&quot;&gt;https://www.python.org/downloads/release/python-3140b4/&lt;/a&gt;&lt;/p&gt;\n&lt;p&gt;&lt;strong&gt;This
+        is a beta preview of Python 3.14&lt;/strong&gt;&lt;/p&gt;\n&lt;p&gt;Python
+        3.14 is still in development. This release, 3.14.0b4, is the\nlast of four
+        planned beta releases.&lt;/p&gt;\n&lt;p&gt;Beta release previews are intended
+        to give the wider community the\nopportunity to test new features and bug
+        fixes and to prepare their\nprojects to support the new feature release.&lt;/p&gt;\n&lt;p&gt;We
+        &lt;strong&gt;&lt;em&gt;strongly encourage&lt;/em&gt;&lt;/strong&gt; maintainers
+        of\nthird-party Python projects to &lt;strong&gt;&lt;em&gt;test with 3.14&lt;/em&gt;&lt;/strong&gt;\nduring
+        the beta phase and report issues found to &lt;a\nhref=&quot;https://github.com/python/cpython/issues&quot;&gt;the
+        Python bug\ntracker&lt;/a&gt; as soon as possible. While the release is planned
         to be\nfeature-complete entering the beta phase, it is possible that features\nmay
         be modified or, in rare cases, deleted up until the start of the\nrelease
-        candidate phase (Tuesday 2025-07-22). Our goal is to have\n<strong><em>no
-        ABI changes</em></strong> after beta 4 and as few code\nchanges as possible
-        after the first release candidate. To achieve that,\nit will be <strong><em>extremely
-        important</em></strong> to get as much\nexposure for 3.14 as possible during
-        the beta phase.</p>\n<p>This includes creating pre-release wheels for 3.14,
-        as it helps other\nprojects to do their own testing. However, we recommend
-        that your\nregular production releases wait until 3.14.0rc1, to avoid the
-        risk of\nABI breaks.</p>\n<p>Please keep in mind that this is a preview release
-        and its use is\n<strong><em>not</em></strong> recommended for production\nenvironments.</p>\n<h1
-        id=\"major-new-features-of-the-3.14-series-compared-to-3.13\">Major\nnew features
-        of the 3.14 series, compared to 3.13</h1>\n<p>Some of the major new features
-        and changes in Python 3.14 are:</p>\n<h2 id=\"new-features\">New features</h2>\n<ul>\n<li><a
-        href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pep649\">PEP\n649</a>:
+        candidate phase (Tuesday 2025-07-22). Our goal is to have\n&lt;strong&gt;&lt;em&gt;no
+        ABI changes&lt;/em&gt;&lt;/strong&gt; after beta 4 and as few code\nchanges
+        as possible after the first release candidate. To achieve that,\nit will be
+        &lt;strong&gt;&lt;em&gt;extremely important&lt;/em&gt;&lt;/strong&gt; to get
+        as much\nexposure for 3.14 as possible during the beta phase.&lt;/p&gt;\n&lt;p&gt;This
+        includes creating pre-release wheels for 3.14, as it helps other\nprojects
+        to do their own testing. However, we recommend that your\nregular production
+        releases wait until 3.14.0rc1, to avoid the risk of\nABI breaks.&lt;/p&gt;\n&lt;p&gt;Please
+        keep in mind that this is a preview release and its use is\n&lt;strong&gt;&lt;em&gt;not&lt;/em&gt;&lt;/strong&gt;
+        recommended for production\nenvironments.&lt;/p&gt;\n&lt;h1 id=&quot;major-new-features-of-the-3.14-series-compared-to-3.13&quot;&gt;Major\nnew
+        features of the 3.14 series, compared to 3.13&lt;/h1&gt;\n&lt;p&gt;Some of
+        the major new features and changes in Python 3.14 are:&lt;/p&gt;\n&lt;h2 id=&quot;new-features&quot;&gt;New
+        features&lt;/h2&gt;\n&lt;p&gt;&lt;em&gt;Note that PEPs &lt;a\nhref=&quot;https://discuss.python.org/t/pep-734-multiple-interpreters-in-the-stdlib/41147/36&quot;&gt;734&lt;/a&gt;\nand
+        &lt;a\nhref=&quot;https://discuss.python.org/t/pep-779-criteria-for-supported-status-for-free-threaded-python/84319/123&quot;&gt;779&lt;/a&gt;\nare
+        exceptionally new in beta 3!&lt;/em&gt;&lt;/p&gt;\n&lt;ul&gt;\n&lt;li&gt;&lt;a\nhref=&quot;https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pep779&quot;&gt;PEP\n779&lt;/a&gt;:
+        Free-threaded Python is officially supported&lt;/li&gt;\n&lt;li&gt;&lt;a\nhref=&quot;https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pep649&quot;&gt;PEP\n649&lt;/a&gt;:
         The evaluation of type annotations is now deferred, improving\nthe semantics
-        of using annotations.</li>\n<li><a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pep750\">PEP\n750</a>:
+        of using annotations.&lt;/li&gt;\n&lt;li&gt;&lt;a\nhref=&quot;https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pep750&quot;&gt;PEP\n750&lt;/a&gt;:
         Template string literals (t-strings) for custom string\nprocessing, using
-        the familiar syntax of f-strings.</li>\n<li><a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pep784\">PEP\n784</a>:
-        A new module <code>compression.zstd</code> providing support\nfor the Zstandard
-        compression algorithm.</li>\n<li><a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pep758\">PEP\n758</a>:
-        <code>except</code> and <code>except*</code> expressions may\nnow omit the
-        brackets.</li>\n<li><a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pyrepl-highlighting\">Syntax\nhighlighting
-        in PyREPL</a>, and support for color in <a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-color-unittest\">unittest</a>,\n<a
-        href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-color-argparse\">argparse</a>,\n<a
-        href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-color-json\">json</a>\nand
-        <a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-color-calendar\">calendar</a>\nCLIs.</li>\n<li><a
-        href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pep768\">PEP\n768</a>:
-        A zero-overhead external debugger interface for CPython.</li>\n<li><a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#uuid\">UUID\nversions
-        6-8</a> are now supported by the <code>uuid</code> module, and\ngeneration
-        of versions 3-5 and 8 are up to 40% faster.</li>\n<li><a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pep765\">PEP\n765</a>:
-        Disallow\n<code>return</code>/<code>break</code>/<code>continue</code> that
-        exit a\n<code>finally</code> block.</li>\n<li><a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pep741\">PEP\n741</a>:
-        An improved C API for configuring Python.</li>\n<li>A <a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-tail-call\">new\ntype
-        of interpreter</a>. For certain newer compilers, this interpreter\nprovides
+        the familiar syntax of f-strings.&lt;/li&gt;\n&lt;li&gt;&lt;a\nhref=&quot;https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pep734&quot;&gt;PEP\n734&lt;/a&gt;:
+        Multiple interpreters in the stdlib.&lt;/li&gt;\n&lt;li&gt;&lt;a\nhref=&quot;https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pep784&quot;&gt;PEP\n784&lt;/a&gt;:
+        A new module &lt;code&gt;compression.zstd&lt;/code&gt; providing support\nfor
+        the Zstandard compression algorithm.&lt;/li&gt;\n&lt;li&gt;&lt;a\nhref=&quot;https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pep758&quot;&gt;PEP\n758&lt;/a&gt;:
+        &lt;code&gt;except&lt;/code&gt; and &lt;code&gt;except*&lt;/code&gt; expressions
+        may\nnow omit the brackets.&lt;/li&gt;\n&lt;li&gt;&lt;a\nhref=&quot;https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pyrepl-highlighting&quot;&gt;Syntax\nhighlighting
+        in PyREPL&lt;/a&gt;, and support for color in &lt;a\nhref=&quot;https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-color-unittest&quot;&gt;unittest&lt;/a&gt;,\n&lt;a\nhref=&quot;https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-color-argparse&quot;&gt;argparse&lt;/a&gt;,\n&lt;a\nhref=&quot;https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-color-json&quot;&gt;json&lt;/a&gt;\nand
+        &lt;a\nhref=&quot;https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-color-calendar&quot;&gt;calendar&lt;/a&gt;\nCLIs.&lt;/li&gt;\n&lt;li&gt;&lt;a\nhref=&quot;https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pep768&quot;&gt;PEP\n768&lt;/a&gt;:
+        A zero-overhead external debugger interface for CPython.&lt;/li&gt;\n&lt;li&gt;&lt;a
+        href=&quot;https://docs.python.org/3.14/whatsnew/3.14.html#uuid&quot;&gt;UUID\nversions
+        6-8&lt;/a&gt; are now supported by the &lt;code&gt;uuid&lt;/code&gt; module,
+        and\ngeneration of versions 3-5 and 8 are up to 40% faster.&lt;/li&gt;\n&lt;li&gt;&lt;a\nhref=&quot;https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pep765&quot;&gt;PEP\n765&lt;/a&gt;:
+        Disallow\n&lt;code&gt;return&lt;/code&gt;/&lt;code&gt;break&lt;/code&gt;/&lt;code&gt;continue&lt;/code&gt;
+        that exit a\n&lt;code&gt;finally&lt;/code&gt; block.&lt;/li&gt;\n&lt;li&gt;&lt;a\nhref=&quot;https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pep741&quot;&gt;PEP\n741&lt;/a&gt;:
+        An improved C API for configuring Python.&lt;/li&gt;\n&lt;li&gt;A &lt;a\nhref=&quot;https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-tail-call&quot;&gt;new\ntype
+        of interpreter&lt;/a&gt;. For certain newer compilers, this interpreter\nprovides
         significantly better performance. Opt-in for now, requires\nbuilding from
-        source.</li>\n<li><a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#improved-error-messages\">Improved\nerror
-        messages.</a></li>\n<li><a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#hmac\">Builtin\nimplementation
-        of HMAC</a> with formally verified code from the HACL*\nproject.</li>\n<li>A
-        <a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#asyncio-introspection-capabilities\">new\ncommand-line
-        interface</a> to inspect running Python processes using\nasynchronous tasks.</li>\n<li>The
-        pdb module now supports <a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#remote-attaching-to-a-running-python-process-with-pdb\">remote\nattaching
-        to a running Python process</a>.</li>\n</ul>\n<p><small>(Hey, <strong>fellow
-        core developer,</strong> if a feature you\nfind important is missing from
-        this list, let Hugo know.)</small></p>\n<p>For more details on the changes
-        to Python 3.14, see <a href=\"https://docs.python.org/3.14/whatsnew/3.14.html\">What&#8217;s
-        new in\nPython 3.14</a>. The next pre-release of Python 3.14 will be 3.14.0b3,\nscheduled
-        for 2025-06-17.</p>\n<h2 id=\"build-changes\">Build changes</h2>\n<ul>\n<li><a
-        href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pep761\">PEP\n761</a>:
+        source.&lt;/li&gt;\n&lt;li&gt;&lt;a\nhref=&quot;https://docs.python.org/3.14/whatsnew/3.14.html#improved-error-messages&quot;&gt;Improved\nerror
+        messages.&lt;/a&gt;&lt;/li&gt;\n&lt;li&gt;&lt;a\nhref=&quot;https://docs.python.org/3.14/whatsnew/3.14.html#hmac&quot;&gt;Builtin\nimplementation
+        of HMAC&lt;/a&gt; with formally verified code from the HACL*\nproject.&lt;/li&gt;\n&lt;li&gt;A
+        &lt;a\nhref=&quot;https://docs.python.org/3.14/whatsnew/3.14.html#asyncio-introspection-capabilities&quot;&gt;new\ncommand-line
+        interface&lt;/a&gt; to inspect running Python processes using\nasynchronous
+        tasks.&lt;/li&gt;\n&lt;li&gt;The pdb module now supports &lt;a\nhref=&quot;https://docs.python.org/3.14/whatsnew/3.14.html#remote-attaching-to-a-running-python-process-with-pdb&quot;&gt;remote\nattaching
+        to a running Python process&lt;/a&gt;.&lt;/li&gt;\n&lt;/ul&gt;\n&lt;p&gt;&lt;small&gt;(Hey,
+        &lt;strong&gt;fellow core developer,&lt;/strong&gt; if a feature you\nfind
+        important is missing from this list, let Hugo know.)&lt;/small&gt;&lt;/p&gt;\n&lt;p&gt;For
+        more details on the changes to Python 3.14, see &lt;a\nhref=&quot;https://docs.python.org/3.14/whatsnew/3.14.html&quot;&gt;What\u2019s
+        new in\nPython 3.14&lt;/a&gt;. The next pre-release of Python 3.14 will be
+        the first\nrelease candidate, 3.14.0rc1, scheduled for 2025-07-22.&lt;/p&gt;\n&lt;h2
+        id=&quot;build-changes&quot;&gt;Build changes&lt;/h2&gt;\n&lt;ul&gt;\n&lt;li&gt;&lt;a\nhref=&quot;https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pep761&quot;&gt;PEP\n761&lt;/a&gt;:
         Python 3.14 and onwards no longer provides PGP signatures for\nrelease artifacts.
-        Instead, Sigstore is recommended for verifiers.</li>\n<li>Official macOS and
-        Windows release binaries include an <a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-jit-compiler\"><em>experimental</em>\nJIT
-        compiler</a>.</li>\n</ul>\n<h2 id=\"incompatible-changes-removals-and-new-deprecations\">Incompatible\nchanges,
-        removals and new deprecations</h2>\n<ul>\n<li><a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#incompatible-changes\">Incompatible\nchanges</a></li>\n<li>Python
-        <a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#removed\">removals</a>\nand
-        <a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#deprecated\">deprecations</a></li>\n<li>C
-        API <a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#c-api-removed\">removals</a>\nand
-        <a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#c-api-deprecated\">deprecations</a></li>\n<li>Overview
-        of all <a href=\"https://docs.python.org/3.14/deprecations/index.html\">pending\ndeprecations</a></li>\n</ul>\n<h1
-        id=\"python-install-manager\">Python install manager</h1>\n<p>The installer
-        we offer for Windows is being replaced by our new\ninstall manager, which
-        can be installed from <a href=\"https://apps.microsoft.com/detail/9NQ7512CXL7T\">the
-        Windows\nStore</a> or <a href=\"https://www.python.org/ftp/python/pymanager/\">our\nFTP
-        page</a>. See <a href=\"https://docs.python.org/3.14/using/windows.html\">our\ndocumentation</a>
+        Instead, Sigstore is recommended for verifiers.&lt;/li&gt;\n&lt;li&gt;Official
+        macOS and Windows release binaries include an &lt;a\nhref=&quot;https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-jit-compiler&quot;&gt;&lt;em&gt;experimental&lt;/em&gt;\nJIT
+        compiler&lt;/a&gt;.&lt;/li&gt;\n&lt;/ul&gt;\n&lt;h2 id=&quot;incompatible-changes-removals-and-new-deprecations&quot;&gt;Incompatible\nchanges,
+        removals and new deprecations&lt;/h2&gt;\n&lt;ul&gt;\n&lt;li&gt;&lt;a\nhref=&quot;https://docs.python.org/3.14/whatsnew/3.14.html#incompatible-changes&quot;&gt;Incompatible\nchanges&lt;/a&gt;&lt;/li&gt;\n&lt;li&gt;Python
+        &lt;a\nhref=&quot;https://docs.python.org/3.14/whatsnew/3.14.html#removed&quot;&gt;removals&lt;/a&gt;\nand
+        &lt;a\nhref=&quot;https://docs.python.org/3.14/whatsnew/3.14.html#deprecated&quot;&gt;deprecations&lt;/a&gt;&lt;/li&gt;\n&lt;li&gt;C
+        API &lt;a\nhref=&quot;https://docs.python.org/3.14/whatsnew/3.14.html#c-api-removed&quot;&gt;removals&lt;/a&gt;\nand
+        &lt;a\nhref=&quot;https://docs.python.org/3.14/whatsnew/3.14.html#c-api-deprecated&quot;&gt;deprecations&lt;/a&gt;&lt;/li&gt;\n&lt;li&gt;Overview
+        of all &lt;a\nhref=&quot;https://docs.python.org/3.14/deprecations/index.html&quot;&gt;pending\ndeprecations&lt;/a&gt;&lt;/li&gt;\n&lt;/ul&gt;\n&lt;h1
+        id=&quot;python-install-manager&quot;&gt;Python install manager&lt;/h1&gt;\n&lt;p&gt;The
+        installer we offer for Windows is being replaced by our new\ninstall manager,
+        which can be installed from &lt;a\nhref=&quot;https://apps.microsoft.com/detail/9NQ7512CXL7T&quot;&gt;the
+        Windows\nStore&lt;/a&gt; or from its &lt;a\nhref=&quot;https://www.python.org/downloads/latest/pymanager/&quot;&gt;download\npage&lt;/a&gt;.
+        See &lt;a\nhref=&quot;https://docs.python.org/3.14/using/windows.html&quot;&gt;our\ndocumentation&lt;/a&gt;
         for more information. The JSON file available for\ndownload below contains
         the list of all the installable packages\navailable as part of this release,
         including file URLs and hashes, but\nis not required to install the latest
         release. The traditional installer\nwill remain available throughout the 3.14
-        and 3.15 releases.</p>\n<h1 id=\"more-resources\">More resources</h1>\n<ul>\n<li><a
-        href=\"https://docs.python.org/3.14/\">Online\ndocumentation</a></li>\n<li><a
-        href=\"https://peps.python.org/pep-0745/\">PEP 745</a>, 3.14\nRelease Schedule</li>\n<li>Report
-        bugs at <a href=\"https://github.com/python/cpython/issues\">github.com/python/cpython/issues</a></li>\n<li><a
-        href=\"https://www.python.org/psf/donations/\">Help fund Python and\nits community</a></li>\n</ul>\n<h1
-        id=\"and-now-for-something-completely-different\">And now for\nsomething completely
-        different</h1>\n<p>In 1897, the State of Indiana almost passed a bill defining\n<em>\u03C0</em>
-        as 3.2.</p>\n<p>Of course, it&#8217;s not that simple.</p>\n<p>Edwin J. Goodwin,
-        M.D., claimed to have come up with a solution to an\nancient geometrical problem
-        called squaring the circle, first proposed\nin Greek mathematics. It involves
-        trying to draw a circle and a square\nwith the same area, using only a compass
-        and a straight edge. It turns\nout to be impossible because <em>\u03C0</em>
-        is transcendental (and this had\nbeen proved just 13 years earlier by Ferdinand
-        von Lindemann), but\nGoodwin fudged things so the value of <em>\u03C0</em>
-        was 3.2 (his writings\nhave included at least nine different values of <em>\u03C0</em>:
-        including 4,\n3.236, 3.232, 3.2325&#8230; and even 9.2376&#8230;).</p>\n<p>Goodwin
-        had copyrighted his proof and offered it to the State of\nIndiana to use in
-        their educational textbooks without paying royalties,\nprovided they endorsed
-        it. And so Indiana Bill No.&#160;246 was introduced to\nthe House on 18th
-        January 1897. It was not understood and initially\nreferred to the House Committee
+        and 3.15 releases.&lt;/p&gt;\n&lt;h1 id=&quot;more-resources&quot;&gt;More
+        resources&lt;/h1&gt;\n&lt;ul&gt;\n&lt;li&gt;&lt;a href=&quot;https://docs.python.org/3.14/&quot;&gt;Online\ndocumentation&lt;/a&gt;&lt;/li&gt;\n&lt;li&gt;&lt;a
+        href=&quot;https://peps.python.org/pep-0745/&quot;&gt;PEP 745&lt;/a&gt;, 3.14\nRelease
+        Schedule&lt;/li&gt;\n&lt;li&gt;Report bugs at &lt;a\nhref=&quot;https://github.com/python/cpython/issues&quot;&gt;github.com/python/cpython/issues&lt;/a&gt;&lt;/li&gt;\n&lt;li&gt;&lt;a
+        href=&quot;https://www.python.org/psf/donations/&quot;&gt;Help fund Python
+        and\nits community&lt;/a&gt;&lt;/li&gt;\n&lt;/ul&gt;\n&lt;h1 id=&quot;and-now-for-something-completely-different&quot;&gt;And
+        now for\nsomething completely different&lt;/h1&gt;\n&lt;p&gt;All this talk
+        of &lt;em&gt;\u03C0&lt;/em&gt; and yet some say &lt;em&gt;\u03C0&lt;/em&gt;
+        is wrong. &lt;a\nhref=&quot;https://www.tauday.com/&quot;&gt;Tau Day&lt;/a&gt;
+        (June 28th, 6/28 in the US)\ncelebrates &lt;em&gt;\u03C4&lt;/em&gt; as the
+        \u201Ctrue circle constant\u201D, as the ratio of a\ncircle\u2019s circumference
+        to its radius, &lt;em&gt;C/r&lt;/em&gt; = 6.283185\u2026 The &lt;a\nhref=&quot;https://www.tauday.com/tau-manifesto&quot;&gt;Tau
+        Manifesto&lt;/a&gt; declares\n&lt;em&gt;\u03C0&lt;/em&gt; \u201Ca confusing
+        and unnatural choice for the circle constant\u201D,\nin part because \u201C&lt;em&gt;2\u03C0&lt;/em&gt;
+        occurs with astonishing frequency\nthroughout mathematics\u201D.&lt;/p&gt;\n&lt;p&gt;If
+        you wish to embrace &lt;em&gt;\u03C4&lt;/em&gt; the good news is &lt;a\nhref=&quot;https://peps.python.org/pep-0628/&quot;&gt;PEP
+        628&lt;/a&gt; added &lt;a\nhref=&quot;https://docs.python.org/3/library/math.html#math.tau&quot;&gt;&lt;code&gt;math.tau&lt;/code&gt;&lt;/a&gt;\nto
+        Python 3.6 in 2016:&lt;/p&gt;\n&lt;blockquote&gt;\n&lt;p&gt;When working with
+        radians, it is trivial to convert any given\nfraction of a circle to a value
+        in radians in terms of &lt;code&gt;tau&lt;/code&gt;.\nA quarter circle is
+        &lt;code&gt;tau/4&lt;/code&gt;, a half circle is\n&lt;code&gt;tau/2&lt;/code&gt;,
+        seven 25ths is &lt;code&gt;7*tau/25&lt;/code&gt;, etc. In\ncontrast with the
+        equivalent expressions in terms of &lt;code&gt;pi&lt;/code&gt;\n(&lt;code&gt;pi/2&lt;/code&gt;,
+        &lt;code&gt;pi&lt;/code&gt;, &lt;code&gt;14*pi/25&lt;/code&gt;), the\nunnecessary
+        and needlessly confusing multiplication by two is gone.&lt;/p&gt;\n&lt;/blockquote&gt;\n&lt;h1
+        id=&quot;enjoy-the-new-release&quot;&gt;Enjoy the new release&lt;/h1&gt;\n&lt;p&gt;Thanks
+        to all of the many volunteers who help make Python Development\nand these
+        releases possible! Please consider supporting our efforts by\nvolunteering
+        yourself or through organisation contributions to the &lt;a\nhref=&quot;https://www.python.org/psf-landing/&quot;&gt;Python
+        Software\nFoundation&lt;/a&gt;.&lt;/p&gt;\n&lt;p&gt;Regards from a cloudy
+        Helsinki, looking forward to Prague and &lt;a\nhref=&quot;https://ep2025.europython.eu/&quot;&gt;EuroPython&lt;/a&gt;
+        next week,&lt;/p&gt;\n&lt;p&gt;Your release team, &lt;br&gt;Hugo van Kemenade
+        &lt;br&gt;Ned Deily &lt;br&gt;Steve\nDower &lt;br&gt;\u0141ukasz Langa&lt;/p&gt;\n</content><link
+        rel='edit' type='application/atom+xml' href='https://www.blogger.com/feeds/3941553907430899163/posts/default/2902244612701978117'/><link
+        rel='self' type='application/atom+xml' href='https://www.blogger.com/feeds/3941553907430899163/posts/default/2902244612701978117'/><link
+        rel='alternate' type='text/html' href='https://pythoninsider.blogspot.com/2025/07/python-3140-beta-4-is-here.html'
+        title='Python 3.14.0 beta 4 is here!'/><author><name>Hugo</name><uri>http://www.blogger.com/profile/02811718172961252565</uri><email>noreply@blogger.com</email><gd:image
+        rel='http://schemas.google.com/g/2005#thumbnail' width='16' height='16' src='https://img1.blogblog.com/img/b16-rounded.gif'/></author></entry><entry><id>tag:blogger.com,1999:blog-3941553907430899163.post-6430176619474922622</id><published>2025-06-17T14:43:00.005-04:00</published><updated>2025-06-17T14:43:44.401-04:00</updated><category
+        scheme=\"http://www.blogger.com/atom/ns#\" term=\"releases\"/><title type='text'>Python
+        3.14.0 beta 3 is here!</title><content type='html'>&lt;p&gt;It\u2019s 3.14
+        beta 3!&lt;/p&gt;\n&lt;p&gt;&lt;a href=&quot;https://www.python.org/downloads/release/python-3140b3/&quot;\nclass=&quot;uri&quot;&gt;https://www.python.org/downloads/release/python-3140b3/&lt;/a&gt;&lt;/p&gt;\n&lt;p&gt;&lt;strong&gt;This
+        is a beta preview of Python 3.14&lt;/strong&gt;&lt;/p&gt;\n&lt;p&gt;Python
+        3.14 is still in development. This release, 3.14.0b3, is the\nthird of four
+        planned beta releases.&lt;/p&gt;\n&lt;p&gt;Beta release previews are intended
+        to give the wider community the\nopportunity to test new features and bug
+        fixes and to prepare their\nprojects to support the new feature release.&lt;/p&gt;\n&lt;p&gt;We
+        &lt;strong&gt;&lt;em&gt;strongly encourage&lt;/em&gt;&lt;/strong&gt; maintainers
+        of\nthird-party Python projects to &lt;strong&gt;&lt;em&gt;test with 3.14&lt;/em&gt;&lt;/strong&gt;\nduring
+        the beta phase and report issues found to &lt;a\nhref=&quot;https://github.com/python/cpython/issues&quot;&gt;the
+        Python bug\ntracker&lt;/a&gt; as soon as possible. While the release is planned
+        to be\nfeature-complete entering the beta phase, it is possible that features\nmay
+        be modified or, in rare cases, deleted up until the start of the\nrelease
+        candidate phase (Tuesday 2025-07-22). Our goal is to have\n&lt;strong&gt;&lt;em&gt;no
+        ABI changes&lt;/em&gt;&lt;/strong&gt; after beta 4 and as few code\nchanges
+        as possible after the first release candidate. To achieve that,\nit will be
+        &lt;strong&gt;&lt;em&gt;extremely important&lt;/em&gt;&lt;/strong&gt; to get
+        as much\nexposure for 3.14 as possible during the beta phase.&lt;/p&gt;\n&lt;p&gt;This
+        includes creating pre-release wheels for 3.14, as it helps other\nprojects
+        to do their own testing. However, we recommend that your\nregular production
+        releases wait until 3.14.0rc1, to avoid the risk of\nABI breaks.&lt;/p&gt;\n&lt;p&gt;Please
+        keep in mind that this is a preview release and its use is\n&lt;strong&gt;&lt;em&gt;not&lt;/em&gt;&lt;/strong&gt;
+        recommended for production\nenvironments.&lt;/p&gt;\n&lt;h1 id=&quot;major-new-features-of-the-3.14-series-compared-to-3.13&quot;&gt;Major\nnew
+        features of the 3.14 series, compared to 3.13&lt;/h1&gt;\n&lt;p&gt;Some of
+        the major new features and changes in Python 3.14 are:&lt;/p&gt;\n&lt;h2 id=&quot;new-features&quot;&gt;New
+        features&lt;/h2&gt;\n&lt;p&gt;&lt;em&gt;Note that PEPs &lt;a\nhref=&quot;https://discuss.python.org/t/pep-734-multiple-interpreters-in-the-stdlib/41147/36&quot;&gt;734&lt;/a&gt;\nand
+        &lt;a\nhref=&quot;https://discuss.python.org/t/pep-779-criteria-for-supported-status-for-free-threaded-python/84319/123&quot;&gt;779&lt;/a&gt;\nare
+        exceptionally new in beta 3!&lt;/em&gt;&lt;/p&gt;\n&lt;ul&gt;\n&lt;li&gt;&lt;a\nhref=&quot;https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pep779&quot;&gt;PEP\n779&lt;/a&gt;:
+        Free-threaded Python is officially supported&lt;/li&gt;\n&lt;li&gt;&lt;a\nhref=&quot;https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pep649&quot;&gt;PEP\n649&lt;/a&gt;:
+        The evaluation of type annotations is now deferred, improving\nthe semantics
+        of using annotations.&lt;/li&gt;\n&lt;li&gt;&lt;a\nhref=&quot;https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pep750&quot;&gt;PEP\n750&lt;/a&gt;:
+        Template string literals (t-strings) for custom string\nprocessing, using
+        the familiar syntax of f-strings.&lt;/li&gt;\n&lt;li&gt;&lt;a\nhref=&quot;https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pep734&quot;&gt;PEP\n734&lt;/a&gt;:
+        Multiple interpreters in the stdlib.&lt;/li&gt;\n&lt;li&gt;&lt;a\nhref=&quot;https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pep784&quot;&gt;PEP\n784&lt;/a&gt;:
+        A new module &lt;code&gt;compression.zstd&lt;/code&gt; providing support\nfor
+        the Zstandard compression algorithm.&lt;/li&gt;\n&lt;li&gt;&lt;a\nhref=&quot;https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pep758&quot;&gt;PEP\n758&lt;/a&gt;:
+        &lt;code&gt;except&lt;/code&gt; and &lt;code&gt;except*&lt;/code&gt; expressions
+        may\nnow omit the brackets.&lt;/li&gt;\n&lt;li&gt;&lt;a\nhref=&quot;https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pyrepl-highlighting&quot;&gt;Syntax\nhighlighting
+        in PyREPL&lt;/a&gt;, and support for color in &lt;a\nhref=&quot;https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-color-unittest&quot;&gt;unittest&lt;/a&gt;,\n&lt;a\nhref=&quot;https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-color-argparse&quot;&gt;argparse&lt;/a&gt;,\n&lt;a\nhref=&quot;https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-color-json&quot;&gt;json&lt;/a&gt;\nand
+        &lt;a\nhref=&quot;https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-color-calendar&quot;&gt;calendar&lt;/a&gt;\nCLIs.&lt;/li&gt;\n&lt;li&gt;&lt;a\nhref=&quot;https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pep768&quot;&gt;PEP\n768&lt;/a&gt;:
+        A zero-overhead external debugger interface for CPython.&lt;/li&gt;\n&lt;li&gt;&lt;a
+        href=&quot;https://docs.python.org/3.14/whatsnew/3.14.html#uuid&quot;&gt;UUID\nversions
+        6-8&lt;/a&gt; are now supported by the &lt;code&gt;uuid&lt;/code&gt; module,
+        and\ngeneration of versions 3-5 and 8 are up to 40% faster.&lt;/li&gt;\n&lt;li&gt;&lt;a\nhref=&quot;https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pep765&quot;&gt;PEP\n765&lt;/a&gt;:
+        Disallow\n&lt;code&gt;return&lt;/code&gt;/&lt;code&gt;break&lt;/code&gt;/&lt;code&gt;continue&lt;/code&gt;
+        that exit a\n&lt;code&gt;finally&lt;/code&gt; block.&lt;/li&gt;\n&lt;li&gt;&lt;a\nhref=&quot;https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pep741&quot;&gt;PEP\n741&lt;/a&gt;:
+        An improved C API for configuring Python.&lt;/li&gt;\n&lt;li&gt;A &lt;a\nhref=&quot;https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-tail-call&quot;&gt;new\ntype
+        of interpreter&lt;/a&gt;. For certain newer compilers, this interpreter\nprovides
+        significantly better performance. Opt-in for now, requires\nbuilding from
+        source.&lt;/li&gt;\n&lt;li&gt;&lt;a\nhref=&quot;https://docs.python.org/3.14/whatsnew/3.14.html#improved-error-messages&quot;&gt;Improved\nerror
+        messages.&lt;/a&gt;&lt;/li&gt;\n&lt;li&gt;&lt;a\nhref=&quot;https://docs.python.org/3.14/whatsnew/3.14.html#hmac&quot;&gt;Builtin\nimplementation
+        of HMAC&lt;/a&gt; with formally verified code from the HACL*\nproject.&lt;/li&gt;\n&lt;li&gt;A
+        &lt;a\nhref=&quot;https://docs.python.org/3.14/whatsnew/3.14.html#asyncio-introspection-capabilities&quot;&gt;new\ncommand-line
+        interface&lt;/a&gt; to inspect running Python processes using\nasynchronous
+        tasks.&lt;/li&gt;\n&lt;li&gt;The pdb module now supports &lt;a\nhref=&quot;https://docs.python.org/3.14/whatsnew/3.14.html#remote-attaching-to-a-running-python-process-with-pdb&quot;&gt;remote\nattaching
+        to a running Python process&lt;/a&gt;.&lt;/li&gt;\n&lt;/ul&gt;\n&lt;p&gt;&lt;small&gt;(Hey,
+        &lt;strong&gt;fellow core developer,&lt;/strong&gt; if a feature you\nfind
+        important is missing from this list, let Hugo know.)&lt;/small&gt;&lt;/p&gt;\n&lt;p&gt;For
+        more details on the changes to Python 3.14, see &lt;a\nhref=&quot;https://docs.python.org/3.14/whatsnew/3.14.html&quot;&gt;What\u2019s
+        new in\nPython 3.14&lt;/a&gt;. The next pre-release of Python 3.14 will be
+        the final\nbeta, 3.14.0b4, scheduled for 2025-07-08.&lt;/p&gt;\n&lt;h2 id=&quot;build-changes&quot;&gt;Build
+        changes&lt;/h2&gt;\n&lt;ul&gt;\n&lt;li&gt;&lt;a\nhref=&quot;https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pep761&quot;&gt;PEP\n761&lt;/a&gt;:
+        Python 3.14 and onwards no longer provides PGP signatures for\nrelease artifacts.
+        Instead, Sigstore is recommended for verifiers.&lt;/li&gt;\n&lt;li&gt;Official
+        macOS and Windows release binaries include an &lt;a\nhref=&quot;https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-jit-compiler&quot;&gt;&lt;em&gt;experimental&lt;/em&gt;\nJIT
+        compiler&lt;/a&gt;.&lt;/li&gt;\n&lt;/ul&gt;\n&lt;h2 id=&quot;incompatible-changes-removals-and-new-deprecations&quot;&gt;Incompatible\nchanges,
+        removals and new deprecations&lt;/h2&gt;\n&lt;ul&gt;\n&lt;li&gt;&lt;a\nhref=&quot;https://docs.python.org/3.14/whatsnew/3.14.html#incompatible-changes&quot;&gt;Incompatible\nchanges&lt;/a&gt;&lt;/li&gt;\n&lt;li&gt;Python
+        &lt;a\nhref=&quot;https://docs.python.org/3.14/whatsnew/3.14.html#removed&quot;&gt;removals&lt;/a&gt;\nand
+        &lt;a\nhref=&quot;https://docs.python.org/3.14/whatsnew/3.14.html#deprecated&quot;&gt;deprecations&lt;/a&gt;&lt;/li&gt;\n&lt;li&gt;C
+        API &lt;a\nhref=&quot;https://docs.python.org/3.14/whatsnew/3.14.html#c-api-removed&quot;&gt;removals&lt;/a&gt;\nand
+        &lt;a\nhref=&quot;https://docs.python.org/3.14/whatsnew/3.14.html#c-api-deprecated&quot;&gt;deprecations&lt;/a&gt;&lt;/li&gt;\n&lt;li&gt;Overview
+        of all &lt;a\nhref=&quot;https://docs.python.org/3.14/deprecations/index.html&quot;&gt;pending\ndeprecations&lt;/a&gt;&lt;/li&gt;\n&lt;/ul&gt;\n&lt;h1
+        id=&quot;python-install-manager&quot;&gt;Python install manager&lt;/h1&gt;\n&lt;p&gt;The
+        installer we offer for Windows is being replaced by our new\ninstall manager,
+        which can be installed from &lt;a\nhref=&quot;https://apps.microsoft.com/detail/9NQ7512CXL7T&quot;&gt;the
+        Windows\nStore&lt;/a&gt; or &lt;a href=&quot;https://www.python.org/ftp/python/pymanager/&quot;&gt;our\nFTP
+        page&lt;/a&gt;. See &lt;a\nhref=&quot;https://docs.python.org/3.14/using/windows.html&quot;&gt;our\ndocumentation&lt;/a&gt;
+        for more information. The JSON file available for\ndownload below contains
+        the list of all the installable packages\navailable as part of this release,
+        including file URLs and hashes, but\nis not required to install the latest
+        release. The traditional installer\nwill remain available throughout the 3.14
+        and 3.15 releases.&lt;/p&gt;\n&lt;h1 id=&quot;more-resources&quot;&gt;More
+        resources&lt;/h1&gt;\n&lt;ul&gt;\n&lt;li&gt;&lt;a href=&quot;https://docs.python.org/3.14/&quot;&gt;Online\ndocumentation&lt;/a&gt;&lt;/li&gt;\n&lt;li&gt;&lt;a
+        href=&quot;https://peps.python.org/pep-0745/&quot;&gt;PEP 745&lt;/a&gt;, 3.14\nRelease
+        Schedule&lt;/li&gt;\n&lt;li&gt;Report bugs at &lt;a\nhref=&quot;https://github.com/python/cpython/issues&quot;&gt;github.com/python/cpython/issues&lt;/a&gt;&lt;/li&gt;\n&lt;li&gt;&lt;a
+        href=&quot;https://www.python.org/psf/donations/&quot;&gt;Help fund Python
+        and\nits community&lt;/a&gt;&lt;/li&gt;\n&lt;/ul&gt;\n&lt;h1 id=&quot;and-now-for-something-completely-different&quot;&gt;And
+        now for\nsomething completely different&lt;/h1&gt;\n&lt;p&gt;If you\u2019re
+        heading out to sea, remember the &lt;a\nhref=&quot;https://xkcd.com/3023/&quot;&gt;Maritime
+        Approximation&lt;/a&gt;:&lt;/p&gt;\n&lt;blockquote&gt;\n&lt;p&gt;&lt;em&gt;\u03C0&lt;/em&gt;
+        mph = &lt;em&gt;e&lt;/em&gt; knots&lt;/p&gt;\n&lt;/blockquote&gt;\n&lt;h1
+        id=&quot;enjoy-the-new-release&quot;&gt;Enjoy the new release&lt;/h1&gt;\n&lt;p&gt;Thanks
+        to all of the many volunteers who help make Python Development\nand these
+        releases possible! Please consider supporting our efforts by\nvolunteering
+        yourself or through organisation contributions to the &lt;a\nhref=&quot;https://www.python.org/psf-landing/&quot;&gt;Python
+        Software\nFoundation&lt;/a&gt;.&lt;/p&gt;\n&lt;p&gt;Regards from sunny Helsinki
+        with 19 hours of daylight,&lt;/p&gt;\n&lt;p&gt;Your release team, \n  &lt;br&gt;Hugo
+        van Kemenade\n  &lt;br&gt;Ned Deily\n  &lt;br&gt;Steve Dower\n  &lt;br&gt;\u0141ukasz
+        Langa\n&lt;/p&gt;\n</content><link rel='edit' type='application/atom+xml'
+        href='https://www.blogger.com/feeds/3941553907430899163/posts/default/6430176619474922622'/><link
+        rel='self' type='application/atom+xml' href='https://www.blogger.com/feeds/3941553907430899163/posts/default/6430176619474922622'/><link
+        rel='alternate' type='text/html' href='https://pythoninsider.blogspot.com/2025/06/python-3140-beta-3-is-here.html'
+        title='Python 3.14.0 beta 3 is here!'/><author><name>Hugo</name><uri>http://www.blogger.com/profile/02811718172961252565</uri><email>noreply@blogger.com</email><gd:image
+        rel='http://schemas.google.com/g/2005#thumbnail' width='16' height='16' src='https://img1.blogblog.com/img/b16-rounded.gif'/></author></entry><entry><id>tag:blogger.com,1999:blog-3941553907430899163.post-6912588868872774611</id><published>2025-06-11T18:03:00.001-04:00</published><updated>2025-06-11T18:03:28.206-04:00</updated><title
+        type='text'>Python 3.13.5 is now available!</title><content type='html'>&lt;p&gt;When
+        I was younger we would call this a brown paper bag release, but \nactually,
+        we shouldn\u2019t hide from our mistakes. We\u2019re only human. So, \nplease
+        enjoy:&lt;/p&gt;\n&lt;h1 style=&quot;text-align: left;&quot;&gt;&lt;a class=&quot;anchor&quot;
+        href=&quot;https://discuss.python.org/t/python-3-13-5-is-now-available-yes-really/95211#p-254481-python-3135-1&quot;
+        name=&quot;p-254481-python-3135-1&quot;&gt;&lt;/a&gt;Python 3.13.5&lt;/h1&gt;&lt;div
+        style=&quot;text-align: left;&quot;&gt;&amp;nbsp;&lt;/div&gt;&lt;div style=&quot;text-align:
+        left;&quot;&gt;&lt;a href=&quot;https://www.python.org/downloads/release/python-3135/&quot;&gt;&amp;nbsp;https://www.python.org/downloads/release/python-3135/&lt;/a&gt;&lt;/div&gt;&lt;h3
+        style=&quot;text-align: left;&quot;&gt;&lt;a class=&quot;anchor&quot; href=&quot;https://discuss.python.org/t/python-3-13-5-is-now-available-yes-really/95211#p-254481-this-is-the-fifth-maintenance-release-of-python-313-2&quot;
+        name=&quot;p-254481-this-is-the-fifth-maintenance-release-of-python-313-2&quot;&gt;&lt;/a&gt;&amp;nbsp;&lt;/h3&gt;&lt;h3
+        style=&quot;text-align: left;&quot;&gt;This is the fifth maintenance release
+        of Python 3.13&lt;/h3&gt;\n&lt;p&gt;Python 3.13 is the newest major release
+        of the Python programming \nlanguage, and it contains many new features and
+        optimizations compared \nto Python 3.12. 3.13.5 is the fifth maintenance release
+        of 3.13.&lt;/p&gt;\n&lt;p&gt;3.13.5 is an expedited release to fix a couple
+        of significant issues with the 3.13.4 release:&lt;/p&gt;\n&lt;ul&gt;&lt;li&gt;&lt;a
+        href=&quot;https://github.com/python/cpython/issues/135151&quot;&gt;gh-135151&lt;/a&gt;:
+        Building extension modules on Windows for the regular (non-free-threaded)
+        build failed.&lt;/li&gt;&lt;li&gt;&lt;a aria-label=&quot;gh-135171 link clicked
+        1 time&quot; data-clicks=&quot;1&quot; href=&quot;https://github.com/python/cpython/issues/135171&quot;&gt;gh-135171&lt;/a&gt;:
+        Generator expressions stopped raising &lt;code&gt;TypeError&lt;/code&gt; (when
+        iterating over non-iterable objects) at creation time, delaying it to first
+        use.&lt;/li&gt;&lt;li&gt;&lt;a href=&quot;https://github.com/python/cpython/issues/135326&quot;&gt;gh-135326&lt;/a&gt;:
+        Passing int-like objects (like &lt;code&gt;numpy.int64&lt;/code&gt;) to &lt;code&gt;random.getrandbits()&lt;/code&gt;
+        failed, when it worked before.&lt;/li&gt;&lt;/ul&gt;\n&lt;p&gt;Several other
+        bug fixes (which would otherwise have waited until the \nnext release) are
+        also included. Special thanks to everyone who worked \nhard the last couple
+        of days to fix these issues as quickly as possible.&lt;/p&gt;\n&lt;p&gt;&lt;a
+        href=&quot;https://docs.python.org/release/3.13.5/whatsnew/changelog.html#python-3-13-5&quot;&gt;Full
+        Changelog&lt;/a&gt;&lt;/p&gt;\n&lt;h3 style=&quot;text-align: left;&quot;&gt;&lt;a
+        class=&quot;anchor&quot; href=&quot;https://discuss.python.org/t/python-3-13-5-is-now-available-yes-really/95211#p-254481-more-resources-3&quot;
+        name=&quot;p-254481-more-resources-3&quot;&gt;&lt;/a&gt;More resources&lt;/h3&gt;\n&lt;ul&gt;&lt;li&gt;&lt;a
+        href=&quot;https://docs.python.org/3.13/&quot;&gt;Online Documentation&lt;/a&gt;&lt;/li&gt;&lt;li&gt;&lt;a
+        aria-label=&quot;PEP 719 link clicked 1 time&quot; data-clicks=&quot;1&quot;
+        href=&quot;https://peps.python.org/pep-0719/&quot;&gt;PEP 719&lt;/a&gt;, 3.13
+        Release Schedule (not that you\u2019ll find this release on there yet.)&lt;/li&gt;&lt;li&gt;Report
+        bugs via &lt;a href=&quot;https://github.com/python/cpython/issues&quot;&gt;GitHub&lt;/a&gt;.&lt;/li&gt;&lt;li&gt;&lt;a
+        href=&quot;https://www.python.org/psf/donations/python-dev/&quot;&gt;Help
+        fund Python directly&lt;/a&gt; (or &lt;a href=&quot;https://github.com/sponsors/python&quot;&gt;via
+        GitHub Sponsors&lt;/a&gt;), and support &lt;a href=&quot;https://www.python.org/psf/donations/&quot;&gt;the
+        Python community&lt;/a&gt;.&lt;/li&gt;&lt;/ul&gt;\n&lt;h3 style=&quot;text-align:
+        left;&quot;&gt;&lt;a class=&quot;anchor&quot; href=&quot;https://discuss.python.org/t/python-3-13-5-is-now-available-yes-really/95211#p-254481-stay-safe-and-upgrade-4&quot;
+        name=&quot;p-254481-stay-safe-and-upgrade-4&quot;&gt;&lt;/a&gt;&amp;nbsp;&lt;/h3&gt;&lt;h3
+        style=&quot;text-align: left;&quot;&gt;Stay safe and upgrade!&lt;/h3&gt;\n&lt;p&gt;As
+        always, upgrading is highly recommended to all users of 3.13.&lt;/p&gt;\n&lt;h3
+        style=&quot;text-align: left;&quot;&gt;&lt;a class=&quot;anchor&quot; href=&quot;https://discuss.python.org/t/python-3-13-5-is-now-available-yes-really/95211#p-254481-enjoy-the-new-releases-5&quot;
+        name=&quot;p-254481-enjoy-the-new-releases-5&quot;&gt;&lt;/a&gt;&amp;nbsp;&lt;/h3&gt;&lt;h3
+        style=&quot;text-align: left;&quot;&gt;Enjoy the new releases&lt;/h3&gt;\n&lt;p&gt;Thanks
+        to all of the many volunteers who help make Python Development\n and these
+        releases possible! Please consider supporting our efforts by \nvolunteering
+        yourself or through organization contributions to the \nPython Software Foundation.&lt;/p&gt;\n&lt;p&gt;Regards
+        from hey, it\u2019s us again, your release team,&lt;br /&gt;\nThomas Wouters
+        &lt;br /&gt;\nNed Deily &lt;br /&gt;\nSteve Dower &lt;br /&gt;\n\u0141ukasz
+        Langa &lt;br /&gt;&lt;/p&gt;</content><link rel='edit' type='application/atom+xml'
+        href='https://www.blogger.com/feeds/3941553907430899163/posts/default/6912588868872774611'/><link
+        rel='self' type='application/atom+xml' href='https://www.blogger.com/feeds/3941553907430899163/posts/default/6912588868872774611'/><link
+        rel='alternate' type='text/html' href='https://pythoninsider.blogspot.com/2025/06/python-3135-is-now-available.html'
+        title='Python 3.13.5 is now available!'/><author><name>Thomas Wouters</name><uri>http://www.blogger.com/profile/10346112333332923135</uri><email>noreply@blogger.com</email><gd:image
+        rel='http://schemas.google.com/g/2005#thumbnail' width='16' height='16' src='https://img1.blogblog.com/img/b16-rounded.gif'/></author></entry><entry><id>tag:blogger.com,1999:blog-3941553907430899163.post-8911393060938687340</id><published>2025-06-03T17:04:00.002-04:00</published><updated>2025-06-03T17:04:41.964-04:00</updated><title
+        type='text'>Python 3.13.4, 3.12.11, 3.11.13, 3.10.18 and 3.9.23 are now available</title><content
+        type='html'>&lt;p&gt;&amp;nbsp;&lt;/p&gt;&lt;h1 style=&quot;text-align: left;&quot;&gt;Python
+        Release Party&lt;/h1&gt;\n&lt;p&gt;It was only meant to be release day for
+        3.13.4 today, but poor number\n 13 looked so lonely\u2026 And hey, we had
+        a couple of tarfile CVEs that we \nhad to fix. So most of the Release Managers
+        and all the \nDevelopers-in-Residence (including Security Developer-in-Residence
+        Seth Michael Larson) came together to make it a full release party.&lt;/p&gt;\n&lt;h1
+        style=&quot;text-align: left;&quot;&gt;Security content in these releases&lt;/h1&gt;\n&lt;ul&gt;&lt;li&gt;&lt;a
+        href=&quot;https://github.com/python/cpython/issues/135034&quot;&gt;gh-135034&lt;/a&gt;:
+        Fixes multiple issues that allowed &lt;code&gt;tarfile&lt;/code&gt; extraction
+        filters (&lt;code&gt;filter=&quot;data&quot;&lt;/code&gt; and &lt;code&gt;filter=&quot;tar&quot;&lt;/code&gt;)
+        to be bypassed using crafted symlinks and hard links.Addresses &lt;a href=&quot;https://www.cve.org/CVERecord?id=CVE-2024-12718&quot;&gt;&lt;b&gt;CVE
+        2024-12718&lt;/b&gt;&lt;/a&gt;, &lt;a href=&quot;https://www.cve.org/CVERecord?id=CVE-2025-4138&quot;&gt;&lt;b&gt;CVE
+        2025-4138&lt;/b&gt;&lt;/a&gt;, &lt;a href=&quot;https://www.cve.org/CVERecord?id=CVE-2025-4330&quot;&gt;&lt;b&gt;CVE
+        2025-4330&lt;/b&gt;&lt;/a&gt;, and &lt;a href=&quot;https://www.cve.org/CVERecord?id=CVE-2025-4517&quot;&gt;&lt;b&gt;CVE
+        2025-4517&lt;/b&gt;&lt;/a&gt;.&lt;/li&gt;&lt;li&gt;&lt;a href=&quot;https://github.com/python/cpython/issues/133767&quot;&gt;gh-133767&lt;/a&gt;:
+        Fix use-after-free in the \u201Cunicode-escape\u201D decoder with a non-\u201Cstrict\u201D
+        error handler.&lt;/li&gt;&lt;li&gt;&lt;a href=&quot;https://github.com/python/cpython/issues/128840&quot;&gt;gh-128840&lt;/a&gt;:
+        Short-circuit the processing of long IPv6 addresses early in &lt;a href=&quot;https://docs.python.org/release/3.13.4/library/ipaddress.html#module-ipaddress&quot;&gt;&lt;code&gt;ipaddress&lt;/code&gt;&lt;/a&gt;
+        to prevent excessive memory consumption and a minor denial-of-service.&lt;/li&gt;&lt;/ul&gt;\n&lt;p&gt;In
+        addition to the security fixed mentioned above, a few additional changes to
+        the &lt;code&gt;ipaddress&lt;/code&gt; were backported to make the security
+        fixes feasible. (See the full changelogs for each release for more details.)&lt;/p&gt;\n&lt;h1
+        style=&quot;text-align: left;&quot;&gt;Python 3.13.4&lt;/h1&gt;\n&lt;p&gt;In
+        addition to the security fixes, the fourth maintenance release of \nPython
+        3.13 contains more than 300 bugfixes, build improvements and \ndocumentation
+        changes.&lt;/p&gt;&lt;p&gt;&lt;a href=&quot;https://www.python.org/downloads/release/python-3134/&quot;&gt;https://www.python.org/downloads/release/python-3134/&lt;/a&gt;&lt;/p&gt;\n\n&lt;h1
+        style=&quot;text-align: left;&quot;&gt;Python 3.12.11&lt;/h1&gt;&lt;p&gt;&lt;a
+        href=&quot;https://www.python.org/downloads/release/python-31211/&quot;&gt;https://www.python.org/downloads/release/python-31211/&lt;/a&gt;&lt;/p&gt;&lt;h1
+        style=&quot;text-align: left;&quot;&gt;Python 3.11.13&lt;/h1&gt;&lt;p&gt;&amp;nbsp;&lt;a
+        href=&quot;https://www.python.org/downloads/release/python-31113/&quot;&gt;https://www.python.org/downloads/release/python-31113/&lt;/a&gt;&lt;/p&gt;&lt;h1
+        style=&quot;text-align: left;&quot;&gt;Python 3.10.18&lt;/h1&gt;\n&lt;aside
+        class=&quot;onebox allowlistedgeneric&quot; data-onebox-src=&quot;https://www.python.org/downloads/release/python-31018/&quot;&gt;&lt;br
+        /&gt;&lt;/aside&gt;&lt;aside class=&quot;onebox allowlistedgeneric&quot; data-onebox-src=&quot;https://www.python.org/downloads/release/python-31018/&quot;&gt;&lt;a
+        href=&quot;https://www.python.org/downloads/release/python-31018/&quot;&gt;https://www.python.org/downloads/release/python-31018/&lt;/a&gt;&lt;/aside&gt;&lt;aside
+        class=&quot;onebox allowlistedgeneric&quot; data-onebox-src=&quot;https://www.python.org/downloads/release/python-31018/&quot;&gt;&amp;nbsp;&lt;/aside&gt;\n\n&lt;h1
+        style=&quot;text-align: left;&quot;&gt;Python 3.9.23&lt;/h1&gt;\n&lt;p&gt;Additional
+        security content in this release (already fixed in older releases for the
+        other versions):&lt;/p&gt;\n&lt;ul&gt;&lt;li&gt;&lt;a href=&quot;https://github.com/python/cpython/issues/80222&quot;&gt;gh-80222&lt;/a&gt;:\n
+        Fix bug in the folding of quoted strings when flattening an email \nmessage
+        using a modern email policy. Previously when a quoted string was\n folded
+        so that it spanned more than one line, the surrounding quotes \nand internal
+        escapes would be omitted. This could theoretically be used \nto spoof header
+        lines using a carefully constructed quoted string if the\n resulting rendered
+        email was transmitted or re-parsed.&lt;/li&gt;&lt;/ul&gt;\n&lt;aside class=&quot;onebox
+        allowlistedgeneric&quot; data-onebox-src=&quot;https://www.python.org/downloads/release/python-3923/&quot;&gt;&lt;a
+        href=&quot;https://www.python.org/downloads/release/python-3923&quot;&gt;https://www.python.org/downloads/release/python-3923&lt;/a&gt;&lt;div
+        class=&quot;onebox-metadata&quot;&gt;\n    \n    \n  &lt;/div&gt;\n\n  \n&lt;br
+        /&gt;&lt;/aside&gt;\n\n&lt;h1 style=&quot;text-align: left;&quot;&gt;Stay
+        safe and upgrade!&lt;/h1&gt;\n&lt;p&gt;As always, upgrading is highly recommended
+        to all users of affected versions.&lt;/p&gt;\n&lt;h1 style=&quot;text-align:
+        left;&quot;&gt;Enjoy the new releases&lt;/h1&gt;\n&lt;p&gt;Thanks to all of
+        the many volunteers who help make Python Development\n and these releases
+        possible! Please consider supporting our efforts by \nvolunteering yourself
+        or through organization contributions to the \nPython Software Foundation.&lt;/p&gt;\n&lt;p&gt;Regards
+        from your very &lt;s&gt;tired&lt;/s&gt; tireless release team,&lt;br /&gt;\nThomas
+        Wouters &lt;br /&gt;\nPablo Galindo Salgado &lt;br /&gt;\n\u0141ukasz Langa
+        &lt;br /&gt;\nNed Deily &lt;br /&gt;\nSteve Dower &lt;br /&gt;&lt;/p&gt;</content><link
+        rel='edit' type='application/atom+xml' href='https://www.blogger.com/feeds/3941553907430899163/posts/default/8911393060938687340'/><link
+        rel='self' type='application/atom+xml' href='https://www.blogger.com/feeds/3941553907430899163/posts/default/8911393060938687340'/><link
+        rel='alternate' type='text/html' href='https://pythoninsider.blogspot.com/2025/06/python-3134-31211-31113-31018-and-3923.html'
+        title='Python 3.13.4, 3.12.11, 3.11.13, 3.10.18 and 3.9.23 are now available'/><author><name>Thomas
+        Wouters</name><uri>http://www.blogger.com/profile/10346112333332923135</uri><email>noreply@blogger.com</email><gd:image
+        rel='http://schemas.google.com/g/2005#thumbnail' width='16' height='16' src='https://img1.blogblog.com/img/b16-rounded.gif'/></author></entry><entry><id>tag:blogger.com,1999:blog-3941553907430899163.post-8971055125507701901</id><published>2025-05-26T15:35:00.002-04:00</published><updated>2025-05-26T15:40:46.319-04:00</updated><category
+        scheme=\"http://www.blogger.com/atom/ns#\" term=\"releases\"/><title type='text'>Python
+        3.14.0 beta 2 is here!</title><content type='html'>&lt;p&gt;Here\u2019s the
+        second 3.14 beta.&lt;/p&gt;\n&lt;p&gt;&lt;a href=&quot;https://www.python.org/downloads/release/python-3140b2/&quot;\nclass=&quot;uri&quot;&gt;https://www.python.org/downloads/release/python-3140b2/&lt;/a&gt;&lt;/p&gt;\n&lt;p&gt;&lt;strong&gt;This
+        is a beta preview of Python 3.14&lt;/strong&gt;&lt;/p&gt;\n&lt;p&gt;Python
+        3.14 is still in development. This release, 3.14.0b2, is the\nsecond of four
+        planned beta releases.&lt;/p&gt;\n&lt;p&gt;Beta release previews are intended
+        to give the wider community the\nopportunity to test new features and bug
+        fixes and to prepare their\nprojects to support the new feature release.&lt;/p&gt;\n&lt;p&gt;We
+        &lt;strong&gt;&lt;em&gt;strongly encourage&lt;/em&gt;&lt;/strong&gt; maintainers
+        of\nthird-party Python projects to &lt;strong&gt;&lt;em&gt;test with 3.14&lt;/em&gt;&lt;/strong&gt;\nduring
+        the beta phase and report issues found to &lt;a\nhref=&quot;https://github.com/python/cpython/issues&quot;&gt;the
+        Python bug\ntracker&lt;/a&gt; as soon as possible. While the release is planned
+        to be\nfeature-complete entering the beta phase, it is possible that features\nmay
+        be modified or, in rare cases, deleted up until the start of the\nrelease
+        candidate phase (Tuesday 2025-07-22). Our goal is to have\n&lt;strong&gt;&lt;em&gt;no
+        ABI changes&lt;/em&gt;&lt;/strong&gt; after beta 4 and as few code\nchanges
+        as possible after the first release candidate. To achieve that,\nit will be
+        &lt;strong&gt;&lt;em&gt;extremely important&lt;/em&gt;&lt;/strong&gt; to get
+        as much\nexposure for 3.14 as possible during the beta phase.&lt;/p&gt;\n&lt;p&gt;This
+        includes creating pre-release wheels for 3.14, as it helps other\nprojects
+        to do their own testing. However, we recommend that your\nregular production
+        releases wait until 3.14.0rc1, to avoid the risk of\nABI breaks.&lt;/p&gt;\n&lt;p&gt;Please
+        keep in mind that this is a preview release and its use is\n&lt;strong&gt;&lt;em&gt;not&lt;/em&gt;&lt;/strong&gt;
+        recommended for production\nenvironments.&lt;/p&gt;\n&lt;h1 id=&quot;major-new-features-of-the-3.14-series-compared-to-3.13&quot;&gt;Major\nnew
+        features of the 3.14 series, compared to 3.13&lt;/h1&gt;\n&lt;p&gt;Some of
+        the major new features and changes in Python 3.14 are:&lt;/p&gt;\n&lt;h2 id=&quot;new-features&quot;&gt;New
+        features&lt;/h2&gt;\n&lt;ul&gt;\n&lt;li&gt;&lt;a\nhref=&quot;https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pep649&quot;&gt;PEP\n649&lt;/a&gt;:
+        The evaluation of type annotations is now deferred, improving\nthe semantics
+        of using annotations.&lt;/li&gt;\n&lt;li&gt;&lt;a\nhref=&quot;https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pep750&quot;&gt;PEP\n750&lt;/a&gt;:
+        Template string literals (t-strings) for custom string\nprocessing, using
+        the familiar syntax of f-strings.&lt;/li&gt;\n&lt;li&gt;&lt;a\nhref=&quot;https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pep784&quot;&gt;PEP\n784&lt;/a&gt;:
+        A new module &lt;code&gt;compression.zstd&lt;/code&gt; providing support\nfor
+        the Zstandard compression algorithm.&lt;/li&gt;\n&lt;li&gt;&lt;a\nhref=&quot;https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pep758&quot;&gt;PEP\n758&lt;/a&gt;:
+        &lt;code&gt;except&lt;/code&gt; and &lt;code&gt;except*&lt;/code&gt; expressions
+        may\nnow omit the brackets.&lt;/li&gt;\n&lt;li&gt;&lt;a\nhref=&quot;https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pyrepl-highlighting&quot;&gt;Syntax\nhighlighting
+        in PyREPL&lt;/a&gt;, and support for color in &lt;a\nhref=&quot;https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-color-unittest&quot;&gt;unittest&lt;/a&gt;,\n&lt;a\nhref=&quot;https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-color-argparse&quot;&gt;argparse&lt;/a&gt;,\n&lt;a\nhref=&quot;https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-color-json&quot;&gt;json&lt;/a&gt;\nand
+        &lt;a\nhref=&quot;https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-color-calendar&quot;&gt;calendar&lt;/a&gt;\nCLIs.&lt;/li&gt;\n&lt;li&gt;&lt;a\nhref=&quot;https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pep768&quot;&gt;PEP\n768&lt;/a&gt;:
+        A zero-overhead external debugger interface for CPython.&lt;/li&gt;\n&lt;li&gt;&lt;a
+        href=&quot;https://docs.python.org/3.14/whatsnew/3.14.html#uuid&quot;&gt;UUID\nversions
+        6-8&lt;/a&gt; are now supported by the &lt;code&gt;uuid&lt;/code&gt; module,
+        and\ngeneration of versions 3-5 and 8 are up to 40% faster.&lt;/li&gt;\n&lt;li&gt;&lt;a\nhref=&quot;https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pep765&quot;&gt;PEP\n765&lt;/a&gt;:
+        Disallow\n&lt;code&gt;return&lt;/code&gt;/&lt;code&gt;break&lt;/code&gt;/&lt;code&gt;continue&lt;/code&gt;
+        that exit a\n&lt;code&gt;finally&lt;/code&gt; block.&lt;/li&gt;\n&lt;li&gt;&lt;a\nhref=&quot;https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pep741&quot;&gt;PEP\n741&lt;/a&gt;:
+        An improved C API for configuring Python.&lt;/li&gt;\n&lt;li&gt;A &lt;a\nhref=&quot;https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-tail-call&quot;&gt;new\ntype
+        of interpreter&lt;/a&gt;. For certain newer compilers, this interpreter\nprovides
+        significantly better performance. Opt-in for now, requires\nbuilding from
+        source.&lt;/li&gt;\n&lt;li&gt;&lt;a\nhref=&quot;https://docs.python.org/3.14/whatsnew/3.14.html#improved-error-messages&quot;&gt;Improved\nerror
+        messages.&lt;/a&gt;&lt;/li&gt;\n&lt;li&gt;&lt;a\nhref=&quot;https://docs.python.org/3.14/whatsnew/3.14.html#hmac&quot;&gt;Builtin\nimplementation
+        of HMAC&lt;/a&gt; with formally verified code from the HACL*\nproject.&lt;/li&gt;\n&lt;li&gt;A
+        &lt;a\nhref=&quot;https://docs.python.org/3.14/whatsnew/3.14.html#asyncio-introspection-capabilities&quot;&gt;new\ncommand-line
+        interface&lt;/a&gt; to inspect running Python processes using\nasynchronous
+        tasks.&lt;/li&gt;\n&lt;li&gt;The pdb module now supports &lt;a\nhref=&quot;https://docs.python.org/3.14/whatsnew/3.14.html#remote-attaching-to-a-running-python-process-with-pdb&quot;&gt;remote\nattaching
+        to a running Python process&lt;/a&gt;.&lt;/li&gt;\n&lt;/ul&gt;\n&lt;p&gt;&lt;small&gt;(Hey,
+        &lt;strong&gt;fellow core developer,&lt;/strong&gt; if a feature you\nfind
+        important is missing from this list, let Hugo know.)&lt;/small&gt;&lt;/p&gt;\n&lt;p&gt;For
+        more details on the changes to Python 3.14, see &lt;a\nhref=&quot;https://docs.python.org/3.14/whatsnew/3.14.html&quot;&gt;What\u2019s
+        new in\nPython 3.14&lt;/a&gt;. The next pre-release of Python 3.14 will be
+        3.14.0b3,\nscheduled for 2025-06-17.&lt;/p&gt;\n&lt;h2 id=&quot;build-changes&quot;&gt;Build
+        changes&lt;/h2&gt;\n&lt;ul&gt;\n&lt;li&gt;&lt;a\nhref=&quot;https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pep761&quot;&gt;PEP\n761&lt;/a&gt;:
+        Python 3.14 and onwards no longer provides PGP signatures for\nrelease artifacts.
+        Instead, Sigstore is recommended for verifiers.&lt;/li&gt;\n&lt;li&gt;Official
+        macOS and Windows release binaries include an &lt;a\nhref=&quot;https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-jit-compiler&quot;&gt;&lt;em&gt;experimental&lt;/em&gt;\nJIT
+        compiler&lt;/a&gt;.&lt;/li&gt;\n&lt;/ul&gt;\n&lt;h2 id=&quot;incompatible-changes-removals-and-new-deprecations&quot;&gt;Incompatible\nchanges,
+        removals and new deprecations&lt;/h2&gt;\n&lt;ul&gt;\n&lt;li&gt;&lt;a\nhref=&quot;https://docs.python.org/3.14/whatsnew/3.14.html#incompatible-changes&quot;&gt;Incompatible\nchanges&lt;/a&gt;&lt;/li&gt;\n&lt;li&gt;Python
+        &lt;a\nhref=&quot;https://docs.python.org/3.14/whatsnew/3.14.html#removed&quot;&gt;removals&lt;/a&gt;\nand
+        &lt;a\nhref=&quot;https://docs.python.org/3.14/whatsnew/3.14.html#deprecated&quot;&gt;deprecations&lt;/a&gt;&lt;/li&gt;\n&lt;li&gt;C
+        API &lt;a\nhref=&quot;https://docs.python.org/3.14/whatsnew/3.14.html#c-api-removed&quot;&gt;removals&lt;/a&gt;\nand
+        &lt;a\nhref=&quot;https://docs.python.org/3.14/whatsnew/3.14.html#c-api-deprecated&quot;&gt;deprecations&lt;/a&gt;&lt;/li&gt;\n&lt;li&gt;Overview
+        of all &lt;a\nhref=&quot;https://docs.python.org/3.14/deprecations/index.html&quot;&gt;pending\ndeprecations&lt;/a&gt;&lt;/li&gt;\n&lt;/ul&gt;\n&lt;h1
+        id=&quot;python-install-manager&quot;&gt;Python install manager&lt;/h1&gt;\n&lt;p&gt;The
+        installer we offer for Windows is being replaced by our new\ninstall manager,
+        which can be installed from &lt;a\nhref=&quot;https://apps.microsoft.com/detail/9NQ7512CXL7T&quot;&gt;the
+        Windows\nStore&lt;/a&gt; or &lt;a href=&quot;https://www.python.org/ftp/python/pymanager/&quot;&gt;our\nFTP
+        page&lt;/a&gt;. See &lt;a\nhref=&quot;https://docs.python.org/3.14/using/windows.html&quot;&gt;our\ndocumentation&lt;/a&gt;
+        for more information. The JSON file available for\ndownload below contains
+        the list of all the installable packages\navailable as part of this release,
+        including file URLs and hashes, but\nis not required to install the latest
+        release. The traditional installer\nwill remain available throughout the 3.14
+        and 3.15 releases.&lt;/p&gt;\n&lt;h1 id=&quot;more-resources&quot;&gt;More
+        resources&lt;/h1&gt;\n&lt;ul&gt;\n&lt;li&gt;&lt;a href=&quot;https://docs.python.org/3.14/&quot;&gt;Online\ndocumentation&lt;/a&gt;&lt;/li&gt;\n&lt;li&gt;&lt;a
+        href=&quot;https://peps.python.org/pep-0745/&quot;&gt;PEP 745&lt;/a&gt;, 3.14\nRelease
+        Schedule&lt;/li&gt;\n&lt;li&gt;Report bugs at &lt;a\nhref=&quot;https://github.com/python/cpython/issues&quot;&gt;github.com/python/cpython/issues&lt;/a&gt;&lt;/li&gt;\n&lt;li&gt;&lt;a
+        href=&quot;https://www.python.org/psf/donations/&quot;&gt;Help fund Python
+        and\nits community&lt;/a&gt;&lt;/li&gt;\n&lt;/ul&gt;\n&lt;h1 id=&quot;and-now-for-something-completely-different&quot;&gt;And
+        now for\nsomething completely different&lt;/h1&gt;\n&lt;p&gt;In 1897, the
+        State of Indiana almost passed a bill defining\n&lt;em&gt;\u03C0&lt;/em&gt;
+        as 3.2.&lt;/p&gt;\n&lt;p&gt;Of course, it\u2019s not that simple.&lt;/p&gt;\n&lt;p&gt;Edwin
+        J. Goodwin, M.D., claimed to have come up with a solution to an\nancient geometrical
+        problem called squaring the circle, first proposed\nin Greek mathematics.
+        It involves trying to draw a circle and a square\nwith the same area, using
+        only a compass and a straight edge. It turns\nout to be impossible because
+        &lt;em&gt;\u03C0&lt;/em&gt; is transcendental (and this had\nbeen proved just
+        13 years earlier by Ferdinand von Lindemann), but\nGoodwin fudged things so
+        the value of &lt;em&gt;\u03C0&lt;/em&gt; was 3.2 (his writings\nhave included
+        at least nine different values of &lt;em&gt;\u03C0&lt;/em&gt;: including 4,\n3.236,
+        3.232, 3.2325\u2026 and even 9.2376\u2026).&lt;/p&gt;\n&lt;p&gt;Goodwin had
+        copyrighted his proof and offered it to the State of\nIndiana to use in their
+        educational textbooks without paying royalties,\nprovided they endorsed it.
+        And so Indiana Bill No.\_246 was introduced to\nthe House on 18th January
+        1897. It was not understood and initially\nreferred to the House Committee
         on Canals, also called the Committee on\nSwamp Lands. They then referred it
         to the Committee on Education, who\nduly recommended on 2nd February that
-        &#8220;said bill do pass&#8221;. It passed its\nsecond reading on the 5th
-        and the education chair moved that they\nsuspend the constitutional rule that
+        \u201Csaid bill do pass\u201D. It passed its\nsecond reading on the 5th and
+        the education chair moved that they\nsuspend the constitutional rule that
         required bills to be read on three\nseparate days. This passed 72-0, and the
-        bill itself passed 67-0.</p>\n<p>The bill was referred to the Senate on 10th
-        February, had its first\nreading on the 11th, and was referred to the Committee
-        on Temperance,\nwhose chair on the 12th recommended &#8220;that said bill
-        do pass&#8221;.</p>\n<p>A mathematics professor, <a href=\"https://www.biodiversitylibrary.org/page/14641808#page/455/mode/1up\">Clarence\nAbiathar
-        Waldo</a>, happened to be in the State Capitol on the day the\nHouse passed
-        the bill and walked in during the debate to hear an\nex-teacher argue:</p>\n<blockquote>\n<p>The
+        bill itself passed 67-0.&lt;/p&gt;\n&lt;p&gt;The bill was referred to the
+        Senate on 10th February, had its first\nreading on the 11th, and was referred
+        to the Committee on Temperance,\nwhose chair on the 12th recommended \u201Cthat
+        said bill do pass\u201D.&lt;/p&gt;\n&lt;p&gt;A mathematics professor, &lt;a\nhref=&quot;https://www.biodiversitylibrary.org/page/14641808#page/455/mode/1up&quot;&gt;Clarence\nAbiathar
+        Waldo&lt;/a&gt;, happened to be in the State Capitol on the day the\nHouse
+        passed the bill and walked in during the debate to hear an\nex-teacher argue:&lt;/p&gt;\n&lt;blockquote&gt;\n&lt;p&gt;The
         case is perfectly simple. If we pass this bill which establishes\na new and
         correct value for pi , the author offers to our state without\ncost the use
         of his discovery and its free publication in our school\ntext books, while
-        everyone else must pay him a royalty.</p>\n</blockquote>\n<p>Waldo ensured
-        the senators were &#8220;properly coached&#8221;; and on the 12th,\nduring
+        everyone else must pay him a royalty.&lt;/p&gt;\n&lt;/blockquote&gt;\n&lt;p&gt;Waldo
+        ensured the senators were \u201Cproperly coached\u201D; and on the 12th,\nduring
         the second reading, after an unsuccessful attempt to amend the\nbill it was
-        postponed indefinitely. But not before the senators had some\nfun.</p>\n<p>The
-        Indiana News reported on the 13th:</p>\n<blockquote>\n<p>&#8230;the bill was
-        brought up and made fun of. The Senators made bad puns\nabout it, ridiculed
-        it and laughed over it. The fun lasted half an hour.\nSenator Hubbell said
-        that it was not meet for the Senate, which was\ncosting the State $250 a day,
-        to waste its time in such frivolity. He\nsaid that in reading the leading
+        postponed indefinitely. But not before the senators had some\nfun.&lt;/p&gt;\n&lt;p&gt;The
+        Indiana News reported on the 13th:&lt;/p&gt;\n&lt;blockquote&gt;\n&lt;p&gt;\u2026the
+        bill was brought up and made fun of. The Senators made bad puns\nabout it,
+        ridiculed it and laughed over it. The fun lasted half an hour.\nSenator Hubbell
+        said that it was not meet for the Senate, which was\ncosting the State $250
+        a day, to waste its time in such frivolity. He\nsaid that in reading the leading
         newspapers of Chicago and the East, he\nfound that the Indiana State Legislature
         had laid itself open to\nridicule by the action already taken on the bill.
         He thought\nconsideration of such a proposition was not dignified or worthy
         of the\nSenate. He moved the indefinite postponement of the bill, and the
-        motion\ncarried.</p>\n</blockquote>\n<h1 id=\"enjoy-the-new-release\">Enjoy
-        the new release</h1>\n<p>Thanks to all of the many volunteers who help make
-        Python Development\nand these releases possible! Please consider supporting
-        our efforts by\nvolunteering yourself or through organisation contributions
-        to the <a href=\"https://www.python.org/psf-landing/\">Python Software\nFoundation</a>.</p>\n<p>Regards
-        from Helsinki, still light at 10pm,</p>\n<p>Your release team, <br>Hugo van
-        Kemenade<br>Ned Deily<br>Steve Dower<br>\u0141ukasz Langa</p>\n<div style='clear:
-        both;'></div>\n</div>\n<div class='post-footer'>\n<div class='post-footer-line
-        post-footer-line-1'><span class='post-author vcard'>\nPosted by\n<span class='fn'>Hugo</span>\n</span>\n<span
-        class='post-timestamp'>\nat\n<a class='timestamp-link' href='https://pythoninsider.blogspot.com/2025/05/python-3140-beta-2-is-here.html'
-        rel='bookmark' title='permanent link'><abbr class='published' title='2025-05-26T15:35:00-04:00'>3:35&#8239;PM</abbr></a>\n</span>\n<span
-        class='post-comment-link'>\n</span>\n<span class='post-icons'>\n</span>\n<div
-        class='post-share-buttons'>\n<a class='goog-inline-block share-button sb-email'
-        href='https://www.blogger.com/share-post.g?blogID=3941553907430899163&postID=8971055125507701901&target=email'
-        target='_blank' title='Email This'><span class='share-button-link-text'>Email
-        This</span></a><a class='goog-inline-block share-button sb-blog' href='https://www.blogger.com/share-post.g?blogID=3941553907430899163&postID=8971055125507701901&target=blog'
-        onclick='window.open(this.href, \"_blank\", \"height=270,width=475\"); return
-        false;' target='_blank' title='BlogThis!'><span class='share-button-link-text'>BlogThis!</span></a><a
-        class='goog-inline-block share-button sb-twitter' href='https://www.blogger.com/share-post.g?blogID=3941553907430899163&postID=8971055125507701901&target=twitter'
-        target='_blank' title='Share to X'><span class='share-button-link-text'>Share
-        to X</span></a><a class='goog-inline-block share-button sb-facebook' href='https://www.blogger.com/share-post.g?blogID=3941553907430899163&postID=8971055125507701901&target=facebook'
-        onclick='window.open(this.href, \"_blank\", \"height=430,width=640\"); return
-        false;' target='_blank' title='Share to Facebook'><span class='share-button-link-text'>Share
-        to Facebook</span></a><a class='goog-inline-block share-button sb-pinterest'
-        href='https://www.blogger.com/share-post.g?blogID=3941553907430899163&postID=8971055125507701901&target=pinterest'
-        target='_blank' title='Share to Pinterest'><span class='share-button-link-text'>Share
-        to Pinterest</span></a>\n</div>\n</div>\n<div class='post-footer-line post-footer-line-2'><span
-        class='post-labels'>\nLabels:\n<a href='https://pythoninsider.blogspot.com/search/label/releases'
-        rel='tag'>releases</a>\n</span>\n</div>\n<div class='post-footer-line post-footer-line-3'><span
-        class='post-location'>\n</span>\n</div>\n</div>\n</div>\n</div>\n\n          </div></div>\n
-        \       \n\n          <div class=\"date-outer\">\n        \n<h2 class='date-header'><span>Wednesday,
-        May 7, 2025</span></h2>\n\n          <div class=\"date-posts\">\n        \n<div
-        class='post-outer'>\n<div class='post hentry'>\n<a name='7865809690778671094'></a>\n<h3
-        class='post-title entry-title'>\n<a href='https://pythoninsider.blogspot.com/2025/05/python-3140-beta-1-is-here.html'>Python
-        3.14.0 beta 1 is here!</a>\n</h3>\n<div class='post-header'>\n<div class='post-header-line-1'></div>\n</div>\n<div
-        class='post-body entry-content'>\n<p>Only one day late, welcome to the first
-        beta!</p>\n<p><a class=\"uri\" href=\"https://www.python.org/downloads/release/python-3140b1/\">https://www.python.org/downloads/release/python-3140b1/</a></p>\n<p><strong>This
-        is a beta preview of Python 3.14</strong></p>\n<p>Python 3.14 is still in
-        development. This release, 3.14.0b1, is the\nfirst of four planned beta releases.</p>\n<p>Beta
-        release previews are intended to give the wider community the\nopportunity
-        to test new features and bug fixes and to prepare their\nprojects to support
-        the new feature release.</p>\n<p>We <strong><em>strongly encourage</em></strong>
-        maintainers of\nthird-party Python projects to <strong><em>test with 3.14</em></strong>\nduring
-        the beta phase and report issues found to <a href=\"https://github.com/python/cpython/issues\">the
-        Python bug\ntracker</a> as soon as possible. While the release is planned
+        motion\ncarried.&lt;/p&gt;\n&lt;/blockquote&gt;\n&lt;h1 id=&quot;enjoy-the-new-release&quot;&gt;Enjoy
+        the new release&lt;/h1&gt;\n&lt;p&gt;Thanks to all of the many volunteers
+        who help make Python Development\nand these releases possible! Please consider
+        supporting our efforts by\nvolunteering yourself or through organisation contributions
+        to the &lt;a\nhref=&quot;https://www.python.org/psf-landing/&quot;&gt;Python
+        Software\nFoundation&lt;/a&gt;.&lt;/p&gt;\n&lt;p&gt;Regards from Helsinki,
+        still light at 10pm,&lt;/p&gt;\n&lt;p&gt;Your release team, &lt;br&gt;Hugo
+        van Kemenade&lt;br&gt;Ned Deily&lt;br&gt;Steve Dower&lt;br&gt;\u0141ukasz
+        Langa&lt;/p&gt;\n</content><link rel='edit' type='application/atom+xml' href='https://www.blogger.com/feeds/3941553907430899163/posts/default/8971055125507701901'/><link
+        rel='self' type='application/atom+xml' href='https://www.blogger.com/feeds/3941553907430899163/posts/default/8971055125507701901'/><link
+        rel='alternate' type='text/html' href='https://pythoninsider.blogspot.com/2025/05/python-3140-beta-2-is-here.html'
+        title='Python 3.14.0 beta 2 is here!'/><author><name>Hugo</name><uri>http://www.blogger.com/profile/02811718172961252565</uri><email>noreply@blogger.com</email><gd:image
+        rel='http://schemas.google.com/g/2005#thumbnail' width='16' height='16' src='https://img1.blogblog.com/img/b16-rounded.gif'/></author></entry><entry><id>tag:blogger.com,1999:blog-3941553907430899163.post-7865809690778671094</id><published>2025-05-07T13:34:00.003-04:00</published><updated>2025-05-09T05:08:04.844-04:00</updated><category
+        scheme=\"http://www.blogger.com/atom/ns#\" term=\"releases\"/><title type='text'>Python
+        3.14.0 beta 1 is here!</title><content type='html'>&lt;p&gt;Only one day late,
+        welcome to the first beta!&lt;/p&gt;\n&lt;p&gt;&lt;a href=&quot;https://www.python.org/downloads/release/python-3140b1/&quot;\nclass=&quot;uri&quot;&gt;https://www.python.org/downloads/release/python-3140b1/&lt;/a&gt;&lt;/p&gt;\n&lt;p&gt;&lt;strong&gt;This
+        is a beta preview of Python 3.14&lt;/strong&gt;&lt;/p&gt;\n&lt;p&gt;Python
+        3.14 is still in development. This release, 3.14.0b1, is the\nfirst of four
+        planned beta releases.&lt;/p&gt;\n&lt;p&gt;Beta release previews are intended
+        to give the wider community the\nopportunity to test new features and bug
+        fixes and to prepare their\nprojects to support the new feature release.&lt;/p&gt;\n&lt;p&gt;We
+        &lt;strong&gt;&lt;em&gt;strongly encourage&lt;/em&gt;&lt;/strong&gt; maintainers
+        of\nthird-party Python projects to &lt;strong&gt;&lt;em&gt;test with 3.14&lt;/em&gt;&lt;/strong&gt;\nduring
+        the beta phase and report issues found to &lt;a\nhref=&quot;https://github.com/python/cpython/issues&quot;&gt;the
+        Python bug\ntracker&lt;/a&gt; as soon as possible. While the release is planned
         to be\nfeature-complete entering the beta phase, it is possible that features\nmay
         be modified or, in rare cases, deleted up until the start of the\nrelease
-        candidate phase (Tuesday 2025-07-22). Our goal is to have\n<strong><em>no
-        ABI changes</em></strong> after beta 4 and as few code\nchanges as possible
-        after the first release candidate. To achieve that,\nit will be <strong><em>extremely
-        important</em></strong> to get as much\nexposure for 3.14 as possible during
-        the beta phase.</p>\n<p>Please keep in mind that this is a preview release
-        and its use is\n<strong><em>not</em></strong> recommended for production\nenvironments.</p>\n<h1
-        id=\"major-new-features-of-the-3.14-series-compared-to-3.13\">Major\nnew features
-        of the 3.14 series, compared to 3.13</h1>\n<p>Some of the major new features
-        and changes in Python 3.14 are:</p>\n<h2 id=\"new-features\">New features</h2>\n<ul>\n<li><a
-        href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pep649\">PEP\n649</a>:
+        candidate phase (Tuesday 2025-07-22). Our goal is to have\n&lt;strong&gt;&lt;em&gt;no
+        ABI changes&lt;/em&gt;&lt;/strong&gt; after beta 4 and as few code\nchanges
+        as possible after the first release candidate. To achieve that,\nit will be
+        &lt;strong&gt;&lt;em&gt;extremely important&lt;/em&gt;&lt;/strong&gt; to get
+        as much\nexposure for 3.14 as possible during the beta phase.&lt;/p&gt;\n&lt;p&gt;Please
+        keep in mind that this is a preview release and its use is\n&lt;strong&gt;&lt;em&gt;not&lt;/em&gt;&lt;/strong&gt;
+        recommended for production\nenvironments.&lt;/p&gt;\n&lt;h1 id=&quot;major-new-features-of-the-3.14-series-compared-to-3.13&quot;&gt;Major\nnew
+        features of the 3.14 series, compared to 3.13&lt;/h1&gt;\n&lt;p&gt;Some of
+        the major new features and changes in Python 3.14 are:&lt;/p&gt;\n&lt;h2 id=&quot;new-features&quot;&gt;New
+        features&lt;/h2&gt;\n&lt;ul&gt;\n&lt;li&gt;&lt;a\nhref=&quot;https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pep649&quot;&gt;PEP\n649&lt;/a&gt;:
         The evaluation of type annotations is now deferred, improving\nthe semantics
-        of using annotations.</li>\n<li><a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pep750\">PEP\n750</a>:
+        of using annotations.&lt;/li&gt;\n&lt;li&gt;&lt;a\nhref=&quot;https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pep750&quot;&gt;PEP\n750&lt;/a&gt;:
         Template string literals (t-strings) for custom string\nprocessing, using
-        the familiar syntax of f-strings.</li>\n<li><a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pep784\">PEP\n784</a>:
-        A new module <code>compression.zstd</code> providing support\nfor the Zstandard
-        compression algorithm.</li>\n<li><a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pep758\">PEP\n758</a>:
-        <code>except</code> and <code>except*</code> expressions may\nnow omit the
-        brackets.</li>\n<li><a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pyrepl-highlighting\">Syntax\nhighlighting
-        in PyREPL</a>, and support for color in <a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-color-unittest\">unittest</a>,\n<a
-        href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-color-argparse\">argparse</a>,\n<a
-        href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-color-json\">json</a>\nand
-        <a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-color-calendar\">calendar</a>\nCLIs.</li>\n<li><a
-        href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pep768\">PEP\n768</a>:
-        A zero-overhead external debugger interface for CPython.</li>\n<li><a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#uuid\">UUID\nversions
-        6-8</a> are now supported by the <code>uuid</code> module, and\ngeneration
-        of versions 3-5 and 8 are up to 40% faster.</li>\n<li><a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pep765\">PEP\n765</a>:
-        Disallow\n<code>return</code>/<code>break</code>/<code>continue</code> that
-        exit a\n<code>finally</code> block.</li>\n<li><a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pep741\">PEP\n741</a>:
-        An improved C API for configuring Python.</li>\n<li>A <a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-tail-call\">new\ntype
-        of interpreter</a>. For certain newer compilers, this interpreter\nprovides
+        the familiar syntax of f-strings.&lt;/li&gt;\n&lt;li&gt;&lt;a\nhref=&quot;https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pep784&quot;&gt;PEP\n784&lt;/a&gt;:
+        A new module &lt;code&gt;compression.zstd&lt;/code&gt; providing support\nfor
+        the Zstandard compression algorithm.&lt;/li&gt;\n&lt;li&gt;&lt;a\nhref=&quot;https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pep758&quot;&gt;PEP\n758&lt;/a&gt;:
+        &lt;code&gt;except&lt;/code&gt; and &lt;code&gt;except*&lt;/code&gt; expressions
+        may\nnow omit the brackets.&lt;/li&gt;\n&lt;li&gt;&lt;a\nhref=&quot;https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pyrepl-highlighting&quot;&gt;Syntax\nhighlighting
+        in PyREPL&lt;/a&gt;, and support for color in &lt;a\nhref=&quot;https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-color-unittest&quot;&gt;unittest&lt;/a&gt;,\n&lt;a\nhref=&quot;https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-color-argparse&quot;&gt;argparse&lt;/a&gt;,\n&lt;a\nhref=&quot;https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-color-json&quot;&gt;json&lt;/a&gt;\nand
+        &lt;a\nhref=&quot;https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-color-calendar&quot;&gt;calendar&lt;/a&gt;\nCLIs.&lt;/li&gt;\n&lt;li&gt;&lt;a\nhref=&quot;https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pep768&quot;&gt;PEP\n768&lt;/a&gt;:
+        A zero-overhead external debugger interface for CPython.&lt;/li&gt;\n&lt;li&gt;&lt;a
+        href=&quot;https://docs.python.org/3.14/whatsnew/3.14.html#uuid&quot;&gt;UUID\nversions
+        6-8&lt;/a&gt; are now supported by the &lt;code&gt;uuid&lt;/code&gt; module,
+        and\ngeneration of versions 3-5 and 8 are up to 40% faster.&lt;/li&gt;\n&lt;li&gt;&lt;a\nhref=&quot;https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pep765&quot;&gt;PEP\n765&lt;/a&gt;:
+        Disallow\n&lt;code&gt;return&lt;/code&gt;/&lt;code&gt;break&lt;/code&gt;/&lt;code&gt;continue&lt;/code&gt;
+        that exit a\n&lt;code&gt;finally&lt;/code&gt; block.&lt;/li&gt;\n&lt;li&gt;&lt;a\nhref=&quot;https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pep741&quot;&gt;PEP\n741&lt;/a&gt;:
+        An improved C API for configuring Python.&lt;/li&gt;\n&lt;li&gt;A &lt;a\nhref=&quot;https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-tail-call&quot;&gt;new\ntype
+        of interpreter&lt;/a&gt;. For certain newer compilers, this interpreter\nprovides
         significantly better performance. Opt-in for now, requires\nbuilding from
-        source.</li>\n<li><a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#improved-error-messages\">Improved\nerror
-        messages.</a></li>\n<li>Builtin implementation of HMAC with formally verified
-        code from the\nHACL* project.</li>\n</ul>\n<p><small>(Hey, <strong>fellow
-        core developer,</strong> if a feature you\nfind important is missing from
-        this list, let Hugo know.)</small></p>\n<p>For more details on the changes
-        to Python 3.14, see <a href=\"https://docs.python.org/3.14/whatsnew/3.14.html\">What&#8217;s
-        new in\nPython 3.14</a>. The next pre-release of Python 3.14 will be 3.14.0b2,\nscheduled
-        for 2025-05-27.</p>\n<h2 id=\"build-changes\">Build changes</h2>\n<ul>\n<li><a
-        href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pep761\">PEP\n761</a>:
+        source.&lt;/li&gt;\n&lt;li&gt;&lt;a\nhref=&quot;https://docs.python.org/3.14/whatsnew/3.14.html#improved-error-messages&quot;&gt;Improved\nerror
+        messages.&lt;/a&gt;&lt;/li&gt;\n&lt;li&gt;Builtin implementation of HMAC with
+        formally verified code from the\nHACL* project.&lt;/li&gt;\n&lt;/ul&gt;\n&lt;p&gt;&lt;small&gt;(Hey,
+        &lt;strong&gt;fellow core developer,&lt;/strong&gt; if a feature you\nfind
+        important is missing from this list, let Hugo know.)&lt;/small&gt;&lt;/p&gt;\n&lt;p&gt;For
+        more details on the changes to Python 3.14, see &lt;a\nhref=&quot;https://docs.python.org/3.14/whatsnew/3.14.html&quot;&gt;What\u2019s
+        new in\nPython 3.14&lt;/a&gt;. The next pre-release of Python 3.14 will be
+        3.14.0b2,\nscheduled for 2025-05-27.&lt;/p&gt;\n&lt;h2 id=&quot;build-changes&quot;&gt;Build
+        changes&lt;/h2&gt;\n&lt;ul&gt;\n&lt;li&gt;&lt;a\nhref=&quot;https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pep761&quot;&gt;PEP\n761&lt;/a&gt;:
         Python 3.14 and onwards no longer provides PGP signatures for\nrelease artifacts.
-        Instead, Sigstore is recommended for verifiers.</li>\n<li>Official macOS and
-        Windows release binaries include an <a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-jit-compiler\"><em>experimental</em>\nJIT
-        compiler</a>.</li>\n</ul>\n<h2 id=\"incompatible-changes-removals-and-new-deprecations\">Incompatible\nchanges,
-        removals and new deprecations</h2>\n<ul>\n<li><a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#incompatible-changes\">Incompatible\nchanges</a></li>\n<li>Python
-        <a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#removed\">removals</a>\nand
-        <a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#deprecated\">deprecations</a></li>\n<li>C
-        API <a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#c-api-removed\">removals</a>\nand
-        <a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#c-api-deprecated\">deprecations</a></li>\n<li>Overview
-        of all <a href=\"https://docs.python.org/3.14/deprecations/index.html\">pending\ndeprecations</a></li>\n</ul>\n<h1
-        id=\"python-install-manager\">Python install manager</h1>\n<p>The installer
-        we offer for Windows is being replaced by our new\ninstall manager, which
-        can be installed from <a href=\"https://apps.microsoft.com/detail/9NQ7512CXL7T\">the
-        Windows\nStore</a> or <a href=\"https://www.python.org/ftp/python/pymanager/\">our\nFTP
-        page</a>. See <a href=\"https://docs.python.org/3.14/using/windows.html\">our\ndocumentation</a>
-        for more information. The <a href=\"https://www.python.org/ftp/python/3.14.0/windows-3.14.0b1.json\">JSON
-        file available for\n  download</a>  contains the list of all the installable
+        Instead, Sigstore is recommended for verifiers.&lt;/li&gt;\n&lt;li&gt;Official
+        macOS and Windows release binaries include an &lt;a\nhref=&quot;https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-jit-compiler&quot;&gt;&lt;em&gt;experimental&lt;/em&gt;\nJIT
+        compiler&lt;/a&gt;.&lt;/li&gt;\n&lt;/ul&gt;\n&lt;h2 id=&quot;incompatible-changes-removals-and-new-deprecations&quot;&gt;Incompatible\nchanges,
+        removals and new deprecations&lt;/h2&gt;\n&lt;ul&gt;\n&lt;li&gt;&lt;a\nhref=&quot;https://docs.python.org/3.14/whatsnew/3.14.html#incompatible-changes&quot;&gt;Incompatible\nchanges&lt;/a&gt;&lt;/li&gt;\n&lt;li&gt;Python
+        &lt;a\nhref=&quot;https://docs.python.org/3.14/whatsnew/3.14.html#removed&quot;&gt;removals&lt;/a&gt;\nand
+        &lt;a\nhref=&quot;https://docs.python.org/3.14/whatsnew/3.14.html#deprecated&quot;&gt;deprecations&lt;/a&gt;&lt;/li&gt;\n&lt;li&gt;C
+        API &lt;a\nhref=&quot;https://docs.python.org/3.14/whatsnew/3.14.html#c-api-removed&quot;&gt;removals&lt;/a&gt;\nand
+        &lt;a\nhref=&quot;https://docs.python.org/3.14/whatsnew/3.14.html#c-api-deprecated&quot;&gt;deprecations&lt;/a&gt;&lt;/li&gt;\n&lt;li&gt;Overview
+        of all &lt;a\nhref=&quot;https://docs.python.org/3.14/deprecations/index.html&quot;&gt;pending\ndeprecations&lt;/a&gt;&lt;/li&gt;\n&lt;/ul&gt;\n&lt;h1
+        id=&quot;python-install-manager&quot;&gt;Python install manager&lt;/h1&gt;\n&lt;p&gt;The
+        installer we offer for Windows is being replaced by our new\ninstall manager,
+        which can be installed from &lt;a\nhref=&quot;https://apps.microsoft.com/detail/9NQ7512CXL7T&quot;&gt;the
+        Windows\nStore&lt;/a&gt; or &lt;a href=&quot;https://www.python.org/ftp/python/pymanager/&quot;&gt;our\nFTP
+        page&lt;/a&gt;. See &lt;a\nhref=&quot;https://docs.python.org/3.14/using/windows.html&quot;&gt;our\ndocumentation&lt;/a&gt;
+        for more information. The &lt;a href=&quot;https://www.python.org/ftp/python/3.14.0/windows-3.14.0b1.json&quot;&gt;JSON
+        file available for\n  download&lt;/a&gt;  contains the list of all the installable
         packages\navailable as part of this release, including file URLs and hashes,
         but\nis not required to install the latest release. The traditional installer\nwill
-        remain available throughout the 3.14 and 3.15 releases.</p>\n<h1 id=\"more-resources\">More
-        resources</h1>\n<ul>\n<li><a href=\"https://docs.python.org/3.14/\">Online\ndocumentation</a></li>\n<li><a
-        href=\"https://peps.python.org/pep-0745/\">PEP 745</a>, 3.14\nRelease Schedule</li>\n<li>Report
-        bugs at <a href=\"https://github.com/python/cpython/issues\">github.com/python/cpython/issues</a></li>\n<li><a
-        href=\"https://www.python.org/psf/donations/\">Help fund Python and\nits community</a></li>\n</ul>\n<h1
-        id=\"note\">Note</h1>\n<p>During the release process, we discovered a test
-        that only failed\nwhen run sequentially and only when run after a certain
-        number of other\ntests. This appears to be a problem with the test itself,
-        and we will\nmake it more robust for beta 2. For details, see <a href=\"https://github.com/python/cpython/issues/133532\">python/cpython#133532</a>.</p>\n<h1
-        id=\"and-now-for-something-completely-different\">And now for\nsomething completely
-        different</h1>\n<p>The mathematical constant pi is represented by the Greek
-        letter\n<em>\u03C0</em> and represents the ratio of a circle&#8217;s circumference
-        to its\ndiameter. The first person to use <em>\u03C0</em> as a symbol for
-        this ratio\nwas Welsh self-taught mathematician William Jones in 1706. He
-        was a\nfarmer&#8217;s son born in Llanfihangel Tre&#8217;r Beirdd on Angelsy
-        (Ynys M\xF4n) in\n1675 and only received a basic education at a local charity
-        school.\nHowever, the owner of his parents&#8217; farm noticed his mathematical
-        ability\nand arranged for him to move to London to work in a bank.</p>\n<p>By
-        age 20, he served at sea in the Royal Navy, teaching sailors\nmathematics
-        and helping with the ship&#8217;s navigation. On return to London\nseven years
-        later, he became a maths teacher in coffee houses and a\nprivate tutor. In
-        1706, Jones published <em>Synopsis Palmariorum\nMatheseos</em> which used
-        the symbol <em>\u03C0</em> for the ratio of a\ncircle&#8217;s circumference
-        to diameter (hunt for it on pages <a href=\"https://archive.org/details/SynopsisPalmariorumMatheseosOrANewIntroductionToTheMathematics/page/n261/mode/1up?view=theater\">243</a>\nand
-        <a href=\"https://archive.org/details/SynopsisPalmariorumMatheseosOrANewIntroductionToTheMathematics/page/n283/mode/1up?view=theater\">263</a>\nor
-        <a href=\"https://commons.wikimedia.org/wiki/File:Synopsis_Palmariorum_Matheseos_pi.jpg\">here</a>).\nJones
-        was also the first person to realise <em>\u03C0</em> is an irrational\nnumber,
+        remain available throughout the 3.14 and 3.15 releases.&lt;/p&gt;\n&lt;h1
+        id=&quot;more-resources&quot;&gt;More resources&lt;/h1&gt;\n&lt;ul&gt;\n&lt;li&gt;&lt;a
+        href=&quot;https://docs.python.org/3.14/&quot;&gt;Online\ndocumentation&lt;/a&gt;&lt;/li&gt;\n&lt;li&gt;&lt;a
+        href=&quot;https://peps.python.org/pep-0745/&quot;&gt;PEP 745&lt;/a&gt;, 3.14\nRelease
+        Schedule&lt;/li&gt;\n&lt;li&gt;Report bugs at &lt;a\nhref=&quot;https://github.com/python/cpython/issues&quot;&gt;github.com/python/cpython/issues&lt;/a&gt;&lt;/li&gt;\n&lt;li&gt;&lt;a
+        href=&quot;https://www.python.org/psf/donations/&quot;&gt;Help fund Python
+        and\nits community&lt;/a&gt;&lt;/li&gt;\n&lt;/ul&gt;\n&lt;h1 id=&quot;note&quot;&gt;Note&lt;/h1&gt;\n&lt;p&gt;During
+        the release process, we discovered a test that only failed\nwhen run sequentially
+        and only when run after a certain number of other\ntests. This appears to
+        be a problem with the test itself, and we will\nmake it more robust for beta
+        2. For details, see &lt;a\nhref=&quot;https://github.com/python/cpython/issues/133532&quot;&gt;python/cpython#133532&lt;/a&gt;.&lt;/p&gt;\n&lt;h1
+        id=&quot;and-now-for-something-completely-different&quot;&gt;And now for\nsomething
+        completely different&lt;/h1&gt;\n&lt;p&gt;The mathematical constant pi is
+        represented by the Greek letter\n&lt;em&gt;\u03C0&lt;/em&gt; and represents
+        the ratio of a circle\u2019s circumference to its\ndiameter. The first person
+        to use &lt;em&gt;\u03C0&lt;/em&gt; as a symbol for this ratio\nwas Welsh self-taught
+        mathematician William Jones in 1706. He was a\nfarmer\u2019s son born in Llanfihangel
+        Tre\u2019r Beirdd on Angelsy (Ynys M\xF4n) in\n1675 and only received a basic
+        education at a local charity school.\nHowever, the owner of his parents\u2019
+        farm noticed his mathematical ability\nand arranged for him to move to London
+        to work in a bank.&lt;/p&gt;\n&lt;p&gt;By age 20, he served at sea in the
+        Royal Navy, teaching sailors\nmathematics and helping with the ship\u2019s
+        navigation. On return to London\nseven years later, he became a maths teacher
+        in coffee houses and a\nprivate tutor. In 1706, Jones published &lt;em&gt;Synopsis
+        Palmariorum\nMatheseos&lt;/em&gt; which used the symbol &lt;em&gt;\u03C0&lt;/em&gt;
+        for the ratio of a\ncircle\u2019s circumference to diameter (hunt for it on
+        pages &lt;a\nhref=&quot;https://archive.org/details/SynopsisPalmariorumMatheseosOrANewIntroductionToTheMathematics/page/n261/mode/1up?view=theater&quot;&gt;243&lt;/a&gt;\nand
+        &lt;a\nhref=&quot;https://archive.org/details/SynopsisPalmariorumMatheseosOrANewIntroductionToTheMathematics/page/n283/mode/1up?view=theater&quot;&gt;263&lt;/a&gt;\nor
+        &lt;a\nhref=&quot;https://commons.wikimedia.org/wiki/File:Synopsis_Palmariorum_Matheseos_pi.jpg&quot;&gt;here&lt;/a&gt;).\nJones
+        was also the first person to realise &lt;em&gt;\u03C0&lt;/em&gt; is an irrational\nnumber,
         meaning it can be written as decimal number that goes on\nforever, but cannot
-        be written as a fraction of two integers.</p>\n<p>But why <em>\u03C0</em>?
-        It&#8217;s thought Jones used the Greek letter\n<em>\u03C0</em> because it&#8217;s
-        the first letter in <em>perimetron</em> or\nperimeter. Jones was the first
-        to use <em>\u03C0</em> as our familiar ratio\nbut wasn&#8217;t the first to
-        use it in as part of the ratio. William\nOughtred, in his 1631 <em>Clavis
-        Mathematicae</em> (<em>The Key of\nMathematics</em>), used <em>\u03C0/\u03B4</em>
-        to represent what we now call pi.\nHis <em>\u03C0</em> was the circumference,
-        not the ratio of circumference to\ndiameter. James Gregory, in his 1668 <em>Geometriae
-        Pars\nUniversalis</em> (<em>The Universal Part of Geometry</em>) used\n<em>\u03C0/\u03C1</em>
-        instead, where <em>\u03C1</em> is the radius, making the ratio\n6.28&#8230;
-        or <a href=\"https://www.tauday.com/\"><em>\u03C4</em></a>. After Jones,\nLeonhard
-        Euler had used <em>\u03C0</em> for 6.28&#8230;, and also <em>p</em> for\n3.14&#8230;,
-        before settling on and popularising <em>\u03C0</em> for the famous\nratio.</p>\n<h1
-        id=\"enjoy-the-new-release\">Enjoy the new release</h1>\n<p>Thanks to all
-        of the many volunteers who help make Python Development\nand these releases
-        possible! Please consider supporting our efforts by\nvolunteering yourself
-        or through organisation contributions to the <a href=\"https://www.python.org/psf-landing/\">Python
-        Software\nFoundation</a>.</p>\n<p>Regards from Helsinki as the leaves begin
-        to appear on the trees,</p>\n<p>Your release team, <br>\n  <br>\nHugo van
-        Kemenade\n<br>\nNed Deily\n<br>\nSteve Dower\n<br>\n\u0141ukasz Langa</p>\n\n<div
-        style='clear: both;'></div>\n</div>\n<div class='post-footer'>\n<div class='post-footer-line
-        post-footer-line-1'><span class='post-author vcard'>\nPosted by\n<span class='fn'>Hugo</span>\n</span>\n<span
-        class='post-timestamp'>\nat\n<a class='timestamp-link' href='https://pythoninsider.blogspot.com/2025/05/python-3140-beta-1-is-here.html'
-        rel='bookmark' title='permanent link'><abbr class='published' title='2025-05-07T13:34:00-04:00'>1:34&#8239;PM</abbr></a>\n</span>\n<span
-        class='post-comment-link'>\n</span>\n<span class='post-icons'>\n</span>\n<div
-        class='post-share-buttons'>\n<a class='goog-inline-block share-button sb-email'
-        href='https://www.blogger.com/share-post.g?blogID=3941553907430899163&postID=7865809690778671094&target=email'
-        target='_blank' title='Email This'><span class='share-button-link-text'>Email
-        This</span></a><a class='goog-inline-block share-button sb-blog' href='https://www.blogger.com/share-post.g?blogID=3941553907430899163&postID=7865809690778671094&target=blog'
-        onclick='window.open(this.href, \"_blank\", \"height=270,width=475\"); return
-        false;' target='_blank' title='BlogThis!'><span class='share-button-link-text'>BlogThis!</span></a><a
-        class='goog-inline-block share-button sb-twitter' href='https://www.blogger.com/share-post.g?blogID=3941553907430899163&postID=7865809690778671094&target=twitter'
-        target='_blank' title='Share to X'><span class='share-button-link-text'>Share
-        to X</span></a><a class='goog-inline-block share-button sb-facebook' href='https://www.blogger.com/share-post.g?blogID=3941553907430899163&postID=7865809690778671094&target=facebook'
-        onclick='window.open(this.href, \"_blank\", \"height=430,width=640\"); return
-        false;' target='_blank' title='Share to Facebook'><span class='share-button-link-text'>Share
-        to Facebook</span></a><a class='goog-inline-block share-button sb-pinterest'
-        href='https://www.blogger.com/share-post.g?blogID=3941553907430899163&postID=7865809690778671094&target=pinterest'
-        target='_blank' title='Share to Pinterest'><span class='share-button-link-text'>Share
-        to Pinterest</span></a>\n</div>\n</div>\n<div class='post-footer-line post-footer-line-2'><span
-        class='post-labels'>\nLabels:\n<a href='https://pythoninsider.blogspot.com/search/label/releases'
-        rel='tag'>releases</a>\n</span>\n</div>\n<div class='post-footer-line post-footer-line-3'><span
-        class='post-location'>\n</span>\n</div>\n</div>\n</div>\n</div>\n\n        </div></div>\n
-        \     \n</div>\n<div class='blog-pager' id='blog-pager'>\n<span id='blog-pager-older-link'>\n<a
-        class='blog-pager-older-link' href='https://pythoninsider.blogspot.com/search?updated-max=2025-05-07T13:34:00-04:00&amp;max-results=7'
-        id='Blog1_blog-pager-older-link' title='Older Posts'>Older Posts</a>\n</span>\n<a
-        class='home-link' href='https://pythoninsider.blogspot.com/'>Home</a>\n</div>\n<div
-        class='clear'></div>\n<div class='blog-feeds'>\n<div class='feed-links'>\nSubscribe
-        to:\n<a class='feed-link' href='https://pythoninsider.blogspot.com/feeds/posts/default'
-        target='_blank' type='application/atom+xml'>Posts (Atom)</a>\n</div>\n</div>\n</div></div>\n</section>\n</div>\n<aside
-        id='cside'>\n<div class='wshad' id='sidebar1'>\n<div class='section' id='sidebar-right-1'><div
-        class='widget HTML' data-version='1' id='HTML1'>\n<h2 class='title'>Subscribe</h2>\n<div
-        class='widget-content'>\nSubscribe to Python Insider via <a href=\"https://blog.python.org/feeds/posts/default?alt=rss\">RSS</a>,
-        or <a href=\"http://twitter.com/PythonInsider\">Twitter</a>\n</div>\n<div
-        class='clear'></div>\n</div><div class='widget LinkList' data-version='1'
-        id='LinkList1'>\n<h2>Related Links</h2>\n<div class='widget-content'>\n<ul>\n<li><a
-        href='http://www.python.org/'>python.org</a></li>\n<li><a href='http://mail.python.org/mailman/listinfo/python-dev'>Python-Dev
-        mailing list</a></li>\n<li><a href='http://docs.python.org/devguide/'>Python
-        Developer's Guide</a></li>\n</ul>\n<div class='clear'></div>\n</div>\n</div><div
-        class='widget LinkList' data-version='1' id='LinkList2'>\n<h2>Translations</h2>\n<div
-        class='widget-content'>\n<ul>\n<li><a href='http://blog-cn.python.org/'>Chinese
-        (Simplified)</a></li>\n<li><a href='http://blog-tw.python.org/'>Chinese (Traditional)</a></li>\n<li><a
-        href='http://blog-fr.python.org/'>French</a></li>\n<li><a href='http://blog-de.python.org/'>German</a></li>\n<li><a
-        href='http://blog-ja.python.org/'>Japanese</a></li>\n<li><a href='http://blog-ko.python.org/'>Korean</a></li>\n<li><a
-        href='http://blog-pt.python.org/'>Portuguese</a></li>\n<li><a href='http://blog-ro.python.org/'>Romanian</a></li>\n<li><a
-        href='http://blog-ru.python.org/'>Russian</a></li>\n<li><a href='http://blog-es.python.org/'>Spanish</a></li>\n</ul>\n<div
-        class='clear'></div>\n</div>\n</div><div class='widget BlogList' data-version='1'
-        id='BlogList1'>\n<h2 class='title'>Python-Dev Blogs</h2>\n<div class='widget-content'>\n<div
-        class='blog-list-container' id='BlogList1_container'>\n<ul id='BlogList1_blogs'>\n<li
-        style='display: block;'>\n<div class='blog-icon'>\n</div>\n<div class='blog-content'>\n<div
-        class='blog-title'>\n<a href='https://eli.thegreenplace.net/' target='_blank'>\nEli
-        Bendersky</a>\n</div>\n<div class='item-content'>\n<span class='item-title'>\n<a
-        href='https://eli.thegreenplace.net/2025/notes-on-even-and-odd-functions/'
-        target='_blank'>\nNotes on even and odd functions\n</a>\n</span>\n<div class='item-time'>\n3
-        weeks ago\n</div>\n</div>\n</div>\n<div style='clear: both;'></div>\n</li>\n<li
-        style='display: block;'>\n<div class='blog-icon'>\n</div>\n<div class='blog-content'>\n<div
-        class='blog-title'>\n<a href='http://morepypy.blogspot.com/' target='_blank'>\nPyPy
-        Status Blog</a>\n</div>\n<div class='item-content'>\n<span class='item-title'>\n<a
-        href='http://morepypy.blogspot.com/2019/12/hpy-kick-off-sprint-report.html'
-        target='_blank'>\nHPy kick-off sprint report\n</a>\n</span>\n<div class='item-time'>\n5
-        years ago\n</div>\n</div>\n</div>\n<div style='clear: both;'></div>\n</li>\n<li
-        style='display: block;'>\n<div class='blog-icon'>\n</div>\n<div class='blog-content'>\n<div
-        class='blog-title'>\n<a href='http://www.wefearchange.org/' target='_blank'>\nPumpichank</a>\n</div>\n<div
-        class='item-content'>\n<span class='item-title'>\n<a href='http://www.wefearchange.org/2015/04/creating-python-snaps.html'
-        target='_blank'>\nCreating Python Snaps\n</a>\n</span>\n<div class='item-time'>\n10
-        years ago\n</div>\n</div>\n</div>\n<div style='clear: both;'></div>\n</li>\n<li
-        style='display: block;'>\n<div class='blog-icon'>\n</div>\n<div class='blog-content'>\n<div
-        class='blog-title'>\n<a href='http://ramblings.timgolden.me.uk' target='_blank'>\nTim
-        Golden</a>\n</div>\n<div class='item-content'>\n<span class='item-title'>\n<a
-        href='http://ramblings.timgolden.me.uk/2014/12/05/london-python-dojo-december-2014/'
-        target='_blank'>\nLondon Python Dojo December 2014\n</a>\n</span>\n<div class='item-time'>\n10
-        years ago\n</div>\n</div>\n</div>\n<div style='clear: both;'></div>\n</li>\n<li
-        style='display: block;'>\n<div class='blog-icon'>\n</div>\n<div class='blog-content'>\n<div
-        class='blog-title'>\n<a href='http://www.bitdance.com/blog' target='_blank'>\nR.
-        David Murray</a>\n</div>\n<div class='item-content'>\n<span class='item-title'>\n<a
-        href='http://www.bitdance.com/blog/2014/09/30_01_asycio_overview' target='_blank'>\nAsyncio
-        Implementation Overview\n</a>\n</span>\n<div class='item-time'>\n10 years
-        ago\n</div>\n</div>\n</div>\n<div style='clear: both;'></div>\n</li>\n<li
-        style='display: block;'>\n<div class='blog-icon'>\n</div>\n<div class='blog-content'>\n<div
-        class='blog-title'>\n<a href='http://www.voidspace.org.uk/python/weblog/index.shtml'
-        target='_blank'>\nThe Voidspace Techie Blog</a>\n</div>\n<div class='item-content'>\n<span
-        class='item-title'>\n<a href='http://www.voidspace.org.uk/python/weblog/arch_d7_2012_03_24.shtml#e1237'
-        target='_blank'>\nunittest.mock and mock 1.0 alpha 1\n</a>\n</span>\n<div
-        class='item-time'>\n13 years ago\n</div>\n</div>\n</div>\n<div style='clear:
-        both;'></div>\n</li>\n<li style='display: block;'>\n<div class='blog-icon'>\n</div>\n<div
-        class='blog-content'>\n<div class='blog-title'>\n<a href='https://tarekziade.wordpress.com'
-        target='_blank'>\nTarek Ziad\xE9</a>\n</div>\n<div class='item-content'>\n<span
-        class='item-title'>\n<a href='https://tarekziade.wordpress.com/2012/02/29/more-privacy-please/'
-        target='_blank'>\nMore privacy please\n</a>\n</span>\n<div class='item-time'>\n13
-        years ago\n</div>\n</div>\n</div>\n<div style='clear: both;'></div>\n</li>\n<li
-        style='display: block;'>\n<div class='blog-icon'>\n</div>\n<div class='blog-content'>\n<div
-        class='blog-title'>\n<a href='https://rhettinger.wordpress.com' target='_blank'>\nDeep
-        Thoughts by Raymond Hettinger</a>\n</div>\n<div class='item-content'>\n<span
-        class='item-title'>\n<a href='https://rhettinger.wordpress.com/2011/05/26/super-considered-super/'
-        target='_blank'>\nPython&#8217;s super() considered super!\n</a>\n</span>\n<div
-        class='item-time'>\n14 years ago\n</div>\n</div>\n</div>\n<div style='clear:
-        both;'></div>\n</li>\n<li style='display: block;'>\n<div class='blog-icon'>\n</div>\n<div
-        class='blog-content'>\n<div class='blog-title'>\n<a href='http://jessenoller.com/feed/'
-        target='_blank'>\nJesse Noller</a>\n</div>\n<div class='item-content'>\n<span
-        class='item-title'>\n<!--Can't find substitution for tag [item.itemTitle]-->\n</span>\n<div
-        class='item-time'>\n<!--Can't find substitution for tag [item.timePeriodSinceLastUpdate]-->\n</div>\n</div>\n</div>\n<div
-        style='clear: both;'></div>\n</li>\n<li style='display: block;'>\n<div class='blog-icon'>\n</div>\n<div
-        class='blog-content'>\n<div class='blog-title'>\n<a href='http://www.uthcode.com/blog/feeds/atom.xml'
-        target='_blank'>\nSenthil Kumaran</a>\n</div>\n<div class='item-content'>\n<span
-        class='item-title'>\n<!--Can't find substitution for tag [item.itemTitle]-->\n</span>\n<div
-        class='item-time'>\n<!--Can't find substitution for tag [item.timePeriodSinceLastUpdate]-->\n</div>\n</div>\n</div>\n<div
-        style='clear: both;'></div>\n</li>\n<li style='display: block;'>\n<div class='blog-icon'>\n</div>\n<div
-        class='blog-content'>\n<div class='blog-title'>\n<a href='http://feeds.feedburner.com/CoderWhoSaysPy'
-        target='_blank'>\nBrett Cannon</a>\n</div>\n<div class='item-content'>\n<span
-        class='item-title'>\n<!--Can't find substitution for tag [item.itemTitle]-->\n</span>\n<div
-        class='item-time'>\n<!--Can't find substitution for tag [item.timePeriodSinceLastUpdate]-->\n</div>\n</div>\n</div>\n<div
-        style='clear: both;'></div>\n</li>\n<li style='display: block;'>\n<div class='blog-icon'>\n</div>\n<div
-        class='blog-content'>\n<div class='blog-title'>\n<a href='http://www.boredomandlaziness.org/feeds/posts/default'
-        target='_blank'>\nBoredom & Laziness</a>\n</div>\n<div class='item-content'>\n<span
-        class='item-title'>\n<!--Can't find substitution for tag [item.itemTitle]-->\n</span>\n<div
-        class='item-time'>\n<!--Can't find substitution for tag [item.timePeriodSinceLastUpdate]-->\n</div>\n</div>\n</div>\n<div
-        style='clear: both;'></div>\n</li>\n<li style='display: block;'>\n<div class='blog-icon'>\n</div>\n<div
-        class='blog-content'>\n<div class='blog-title'>\n<a href='http://blog.briancurtin.com/feed/'
-        target='_blank'>\nBrian Curtin</a>\n</div>\n<div class='item-content'>\n<span
-        class='item-title'>\n<!--Can't find substitution for tag [item.itemTitle]-->\n</span>\n<div
-        class='item-time'>\n<!--Can't find substitution for tag [item.timePeriodSinceLastUpdate]-->\n</div>\n</div>\n</div>\n<div
-        style='clear: both;'></div>\n</li>\n</ul>\n<div class='clear'></div>\n</div>\n</div>\n</div><div
-        class='widget BlogArchive' data-version='1' id='BlogArchive1'>\n<h2>Blog Archive</h2>\n<div
-        class='widget-content'>\n<div id='ArchiveList'>\n<div id='BlogArchive1_ArchiveList'>\n<ul
-        class='hierarchy'>\n<li class='archivedate expanded'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy toggle-open'>\n\n        &#9660;&#160;\n      \n</span>\n</a>\n<a
-        class='post-count-link' href='https://pythoninsider.blogspot.com/2025/'>\n2025\n</a>\n<span
-        class='post-count' dir='ltr'>(12)</span>\n<ul class='hierarchy'>\n<li class='archivedate
-        expanded'>\n<a class='toggle' href='javascript:void(0)'>\n<span class='zippy
-        toggle-open'>\n\n        &#9660;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2025/07/'>\nJuly\n</a>\n<span class='post-count'
-        dir='ltr'>(2)</span>\n<ul class='posts'>\n<li><a href='https://pythoninsider.blogspot.com/2025/07/python-314-release-candidate-1-is-go.html'>Python
-        3.14 release candidate 1 is go!</a></li>\n<li><a href='https://pythoninsider.blogspot.com/2025/07/python-3140-beta-4-is-here.html'>Python
-        3.14.0 beta 4 is here!</a></li>\n</ul>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2025/06/'>\nJune\n</a>\n<span class='post-count'
-        dir='ltr'>(3)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li class='archivedate
-        collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span class='zippy'>\n\n
-        \       &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link' href='https://pythoninsider.blogspot.com/2025/05/'>\nMay\n</a>\n<span
-        class='post-count' dir='ltr'>(2)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2025/04/'>\nApril\n</a>\n<span class='post-count'
-        dir='ltr'>(1)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li class='archivedate
-        collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span class='zippy'>\n\n
-        \       &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link' href='https://pythoninsider.blogspot.com/2025/03/'>\nMarch\n</a>\n<span
-        class='post-count' dir='ltr'>(1)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2025/02/'>\nFebruary\n</a>\n<span
-        class='post-count' dir='ltr'>(2)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2025/01/'>\nJanuary\n</a>\n<span
-        class='post-count' dir='ltr'>(1)</span>\n</li>\n</ul>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2024/'>\n2024\n</a>\n<span class='post-count'
-        dir='ltr'>(22)</span>\n<ul class='hierarchy'>\n<li class='archivedate collapsed'>\n<a
-        class='toggle' href='javascript:void(0)'>\n<span class='zippy'>\n\n        &#9658;&#160;\n
-        \     \n</span>\n</a>\n<a class='post-count-link' href='https://pythoninsider.blogspot.com/2024/12/'>\nDecember\n</a>\n<span
-        class='post-count' dir='ltr'>(2)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2024/11/'>\nNovember\n</a>\n<span
-        class='post-count' dir='ltr'>(1)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2024/10/'>\nOctober\n</a>\n<span
-        class='post-count' dir='ltr'>(4)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2024/09/'>\nSeptember\n</a>\n<span
-        class='post-count' dir='ltr'>(1)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2024/08/'>\nAugust\n</a>\n<span class='post-count'
-        dir='ltr'>(2)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li class='archivedate
-        collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span class='zippy'>\n\n
-        \       &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link' href='https://pythoninsider.blogspot.com/2024/07/'>\nJuly\n</a>\n<span
-        class='post-count' dir='ltr'>(1)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2024/06/'>\nJune\n</a>\n<span class='post-count'
-        dir='ltr'>(3)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li class='archivedate
-        collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span class='zippy'>\n\n
-        \       &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link' href='https://pythoninsider.blogspot.com/2024/05/'>\nMay\n</a>\n<span
-        class='post-count' dir='ltr'>(1)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2024/04/'>\nApril\n</a>\n<span class='post-count'
-        dir='ltr'>(2)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li class='archivedate
-        collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span class='zippy'>\n\n
-        \       &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link' href='https://pythoninsider.blogspot.com/2024/03/'>\nMarch\n</a>\n<span
-        class='post-count' dir='ltr'>(2)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2024/02/'>\nFebruary\n</a>\n<span
-        class='post-count' dir='ltr'>(2)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2024/01/'>\nJanuary\n</a>\n<span
-        class='post-count' dir='ltr'>(1)</span>\n</li>\n</ul>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2023/'>\n2023\n</a>\n<span class='post-count'
-        dir='ltr'>(18)</span>\n<ul class='hierarchy'>\n<li class='archivedate collapsed'>\n<a
-        class='toggle' href='javascript:void(0)'>\n<span class='zippy'>\n\n        &#9658;&#160;\n
-        \     \n</span>\n</a>\n<a class='post-count-link' href='https://pythoninsider.blogspot.com/2023/12/'>\nDecember\n</a>\n<span
-        class='post-count' dir='ltr'>(2)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2023/11/'>\nNovember\n</a>\n<span
-        class='post-count' dir='ltr'>(1)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2023/10/'>\nOctober\n</a>\n<span
-        class='post-count' dir='ltr'>(3)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2023/09/'>\nSeptember\n</a>\n<span
-        class='post-count' dir='ltr'>(2)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2023/08/'>\nAugust\n</a>\n<span class='post-count'
-        dir='ltr'>(2)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li class='archivedate
-        collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span class='zippy'>\n\n
-        \       &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link' href='https://pythoninsider.blogspot.com/2023/07/'>\nJuly\n</a>\n<span
-        class='post-count' dir='ltr'>(1)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2023/06/'>\nJune\n</a>\n<span class='post-count'
-        dir='ltr'>(2)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li class='archivedate
-        collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span class='zippy'>\n\n
-        \       &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link' href='https://pythoninsider.blogspot.com/2023/05/'>\nMay\n</a>\n<span
-        class='post-count' dir='ltr'>(1)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2023/04/'>\nApril\n</a>\n<span class='post-count'
-        dir='ltr'>(1)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li class='archivedate
-        collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span class='zippy'>\n\n
-        \       &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link' href='https://pythoninsider.blogspot.com/2023/03/'>\nMarch\n</a>\n<span
-        class='post-count' dir='ltr'>(1)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2023/02/'>\nFebruary\n</a>\n<span
-        class='post-count' dir='ltr'>(1)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2023/01/'>\nJanuary\n</a>\n<span
-        class='post-count' dir='ltr'>(1)</span>\n</li>\n</ul>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2022/'>\n2022\n</a>\n<span class='post-count'
-        dir='ltr'>(23)</span>\n<ul class='hierarchy'>\n<li class='archivedate collapsed'>\n<a
-        class='toggle' href='javascript:void(0)'>\n<span class='zippy'>\n\n        &#9658;&#160;\n
-        \     \n</span>\n</a>\n<a class='post-count-link' href='https://pythoninsider.blogspot.com/2022/12/'>\nDecember\n</a>\n<span
-        class='post-count' dir='ltr'>(1)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2022/11/'>\nNovember\n</a>\n<span
-        class='post-count' dir='ltr'>(1)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2022/10/'>\nOctober\n</a>\n<span
-        class='post-count' dir='ltr'>(4)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2022/09/'>\nSeptember\n</a>\n<span
-        class='post-count' dir='ltr'>(2)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2022/08/'>\nAugust\n</a>\n<span class='post-count'
-        dir='ltr'>(2)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li class='archivedate
-        collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span class='zippy'>\n\n
-        \       &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link' href='https://pythoninsider.blogspot.com/2022/07/'>\nJuly\n</a>\n<span
-        class='post-count' dir='ltr'>(2)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2022/06/'>\nJune\n</a>\n<span class='post-count'
-        dir='ltr'>(2)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li class='archivedate
-        collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span class='zippy'>\n\n
-        \       &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link' href='https://pythoninsider.blogspot.com/2022/05/'>\nMay\n</a>\n<span
-        class='post-count' dir='ltr'>(3)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2022/04/'>\nApril\n</a>\n<span class='post-count'
-        dir='ltr'>(1)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li class='archivedate
-        collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span class='zippy'>\n\n
-        \       &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link' href='https://pythoninsider.blogspot.com/2022/03/'>\nMarch\n</a>\n<span
-        class='post-count' dir='ltr'>(3)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2022/02/'>\nFebruary\n</a>\n<span
-        class='post-count' dir='ltr'>(1)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2022/01/'>\nJanuary\n</a>\n<span
-        class='post-count' dir='ltr'>(1)</span>\n</li>\n</ul>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2021/'>\n2021\n</a>\n<span class='post-count'
-        dir='ltr'>(24)</span>\n<ul class='hierarchy'>\n<li class='archivedate collapsed'>\n<a
-        class='toggle' href='javascript:void(0)'>\n<span class='zippy'>\n\n        &#9658;&#160;\n
-        \     \n</span>\n</a>\n<a class='post-count-link' href='https://pythoninsider.blogspot.com/2021/12/'>\nDecember\n</a>\n<span
-        class='post-count' dir='ltr'>(2)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2021/11/'>\nNovember\n</a>\n<span
-        class='post-count' dir='ltr'>(2)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2021/10/'>\nOctober\n</a>\n<span
-        class='post-count' dir='ltr'>(2)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2021/09/'>\nSeptember\n</a>\n<span
-        class='post-count' dir='ltr'>(2)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2021/08/'>\nAugust\n</a>\n<span class='post-count'
-        dir='ltr'>(2)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li class='archivedate
-        collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span class='zippy'>\n\n
-        \       &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link' href='https://pythoninsider.blogspot.com/2021/07/'>\nJuly\n</a>\n<span
-        class='post-count' dir='ltr'>(1)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2021/06/'>\nJune\n</a>\n<span class='post-count'
-        dir='ltr'>(3)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li class='archivedate
-        collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span class='zippy'>\n\n
-        \       &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link' href='https://pythoninsider.blogspot.com/2021/05/'>\nMay\n</a>\n<span
-        class='post-count' dir='ltr'>(1)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2021/04/'>\nApril\n</a>\n<span class='post-count'
-        dir='ltr'>(3)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li class='archivedate
-        collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span class='zippy'>\n\n
-        \       &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link' href='https://pythoninsider.blogspot.com/2021/03/'>\nMarch\n</a>\n<span
-        class='post-count' dir='ltr'>(1)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2021/02/'>\nFebruary\n</a>\n<span
-        class='post-count' dir='ltr'>(4)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2021/01/'>\nJanuary\n</a>\n<span
-        class='post-count' dir='ltr'>(1)</span>\n</li>\n</ul>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2020/'>\n2020\n</a>\n<span class='post-count'
-        dir='ltr'>(32)</span>\n<ul class='hierarchy'>\n<li class='archivedate collapsed'>\n<a
-        class='toggle' href='javascript:void(0)'>\n<span class='zippy'>\n\n        &#9658;&#160;\n
-        \     \n</span>\n</a>\n<a class='post-count-link' href='https://pythoninsider.blogspot.com/2020/12/'>\nDecember\n</a>\n<span
-        class='post-count' dir='ltr'>(2)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2020/11/'>\nNovember\n</a>\n<span
-        class='post-count' dir='ltr'>(2)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2020/10/'>\nOctober\n</a>\n<span
-        class='post-count' dir='ltr'>(2)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2020/09/'>\nSeptember\n</a>\n<span
-        class='post-count' dir='ltr'>(3)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2020/08/'>\nAugust\n</a>\n<span class='post-count'
-        dir='ltr'>(3)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li class='archivedate
-        collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span class='zippy'>\n\n
-        \       &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link' href='https://pythoninsider.blogspot.com/2020/07/'>\nJuly\n</a>\n<span
-        class='post-count' dir='ltr'>(4)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2020/06/'>\nJune\n</a>\n<span class='post-count'
-        dir='ltr'>(4)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li class='archivedate
-        collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span class='zippy'>\n\n
-        \       &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link' href='https://pythoninsider.blogspot.com/2020/05/'>\nMay\n</a>\n<span
-        class='post-count' dir='ltr'>(2)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2020/04/'>\nApril\n</a>\n<span class='post-count'
-        dir='ltr'>(4)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li class='archivedate
-        collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span class='zippy'>\n\n
-        \       &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link' href='https://pythoninsider.blogspot.com/2020/03/'>\nMarch\n</a>\n<span
-        class='post-count' dir='ltr'>(3)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2020/02/'>\nFebruary\n</a>\n<span
-        class='post-count' dir='ltr'>(2)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2020/01/'>\nJanuary\n</a>\n<span
-        class='post-count' dir='ltr'>(1)</span>\n</li>\n</ul>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2019/'>\n2019\n</a>\n<span class='post-count'
-        dir='ltr'>(36)</span>\n<ul class='hierarchy'>\n<li class='archivedate collapsed'>\n<a
-        class='toggle' href='javascript:void(0)'>\n<span class='zippy'>\n\n        &#9658;&#160;\n
-        \     \n</span>\n</a>\n<a class='post-count-link' href='https://pythoninsider.blogspot.com/2019/12/'>\nDecember\n</a>\n<span
-        class='post-count' dir='ltr'>(3)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2019/11/'>\nNovember\n</a>\n<span
-        class='post-count' dir='ltr'>(1)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2019/10/'>\nOctober\n</a>\n<span
-        class='post-count' dir='ltr'>(8)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2019/09/'>\nSeptember\n</a>\n<span
-        class='post-count' dir='ltr'>(1)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2019/08/'>\nAugust\n</a>\n<span class='post-count'
-        dir='ltr'>(3)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li class='archivedate
-        collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span class='zippy'>\n\n
-        \       &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link' href='https://pythoninsider.blogspot.com/2019/07/'>\nJuly\n</a>\n<span
-        class='post-count' dir='ltr'>(5)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2019/06/'>\nJune\n</a>\n<span class='post-count'
-        dir='ltr'>(3)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li class='archivedate
-        collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span class='zippy'>\n\n
-        \       &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link' href='https://pythoninsider.blogspot.com/2019/05/'>\nMay\n</a>\n<span
-        class='post-count' dir='ltr'>(2)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2019/03/'>\nMarch\n</a>\n<span class='post-count'
-        dir='ltr'>(7)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li class='archivedate
-        collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span class='zippy'>\n\n
-        \       &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link' href='https://pythoninsider.blogspot.com/2019/02/'>\nFebruary\n</a>\n<span
-        class='post-count' dir='ltr'>(3)</span>\n</li>\n</ul>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2018/'>\n2018\n</a>\n<span class='post-count'
-        dir='ltr'>(24)</span>\n<ul class='hierarchy'>\n<li class='archivedate collapsed'>\n<a
-        class='toggle' href='javascript:void(0)'>\n<span class='zippy'>\n\n        &#9658;&#160;\n
-        \     \n</span>\n</a>\n<a class='post-count-link' href='https://pythoninsider.blogspot.com/2018/12/'>\nDecember\n</a>\n<span
-        class='post-count' dir='ltr'>(2)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2018/10/'>\nOctober\n</a>\n<span
-        class='post-count' dir='ltr'>(2)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2018/09/'>\nSeptember\n</a>\n<span
-        class='post-count' dir='ltr'>(1)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2018/08/'>\nAugust\n</a>\n<span class='post-count'
-        dir='ltr'>(1)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li class='archivedate
-        collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span class='zippy'>\n\n
-        \       &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link' href='https://pythoninsider.blogspot.com/2018/06/'>\nJune\n</a>\n<span
-        class='post-count' dir='ltr'>(2)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2018/05/'>\nMay\n</a>\n<span class='post-count'
-        dir='ltr'>(3)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li class='archivedate
-        collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span class='zippy'>\n\n
-        \       &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link' href='https://pythoninsider.blogspot.com/2018/04/'>\nApril\n</a>\n<span
-        class='post-count' dir='ltr'>(3)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2018/03/'>\nMarch\n</a>\n<span class='post-count'
-        dir='ltr'>(5)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li class='archivedate
-        collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span class='zippy'>\n\n
-        \       &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link' href='https://pythoninsider.blogspot.com/2018/02/'>\nFebruary\n</a>\n<span
-        class='post-count' dir='ltr'>(2)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2018/01/'>\nJanuary\n</a>\n<span
-        class='post-count' dir='ltr'>(3)</span>\n</li>\n</ul>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2017/'>\n2017\n</a>\n<span class='post-count'
-        dir='ltr'>(17)</span>\n<ul class='hierarchy'>\n<li class='archivedate collapsed'>\n<a
-        class='toggle' href='javascript:void(0)'>\n<span class='zippy'>\n\n        &#9658;&#160;\n
-        \     \n</span>\n</a>\n<a class='post-count-link' href='https://pythoninsider.blogspot.com/2017/12/'>\nDecember\n</a>\n<span
-        class='post-count' dir='ltr'>(2)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2017/10/'>\nOctober\n</a>\n<span
-        class='post-count' dir='ltr'>(2)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2017/09/'>\nSeptember\n</a>\n<span
-        class='post-count' dir='ltr'>(3)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2017/08/'>\nAugust\n</a>\n<span class='post-count'
-        dir='ltr'>(2)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li class='archivedate
-        collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span class='zippy'>\n\n
-        \       &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link' href='https://pythoninsider.blogspot.com/2017/07/'>\nJuly\n</a>\n<span
-        class='post-count' dir='ltr'>(3)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2017/06/'>\nJune\n</a>\n<span class='post-count'
-        dir='ltr'>(1)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li class='archivedate
-        collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span class='zippy'>\n\n
-        \       &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link' href='https://pythoninsider.blogspot.com/2017/03/'>\nMarch\n</a>\n<span
-        class='post-count' dir='ltr'>(2)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2017/01/'>\nJanuary\n</a>\n<span
-        class='post-count' dir='ltr'>(2)</span>\n</li>\n</ul>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2016/'>\n2016\n</a>\n<span class='post-count'
-        dir='ltr'>(18)</span>\n<ul class='hierarchy'>\n<li class='archivedate collapsed'>\n<a
-        class='toggle' href='javascript:void(0)'>\n<span class='zippy'>\n\n        &#9658;&#160;\n
-        \     \n</span>\n</a>\n<a class='post-count-link' href='https://pythoninsider.blogspot.com/2016/12/'>\nDecember\n</a>\n<span
-        class='post-count' dir='ltr'>(5)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2016/11/'>\nNovember\n</a>\n<span
-        class='post-count' dir='ltr'>(1)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2016/10/'>\nOctober\n</a>\n<span
-        class='post-count' dir='ltr'>(2)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2016/09/'>\nSeptember\n</a>\n<span
-        class='post-count' dir='ltr'>(2)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2016/08/'>\nAugust\n</a>\n<span class='post-count'
-        dir='ltr'>(1)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li class='archivedate
-        collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span class='zippy'>\n\n
-        \       &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link' href='https://pythoninsider.blogspot.com/2016/07/'>\nJuly\n</a>\n<span
-        class='post-count' dir='ltr'>(1)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2016/06/'>\nJune\n</a>\n<span class='post-count'
-        dir='ltr'>(5)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li class='archivedate
-        collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span class='zippy'>\n\n
-        \       &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link' href='https://pythoninsider.blogspot.com/2016/05/'>\nMay\n</a>\n<span
-        class='post-count' dir='ltr'>(1)</span>\n</li>\n</ul>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2015/'>\n2015\n</a>\n<span class='post-count'
-        dir='ltr'>(14)</span>\n<ul class='hierarchy'>\n<li class='archivedate collapsed'>\n<a
-        class='toggle' href='javascript:void(0)'>\n<span class='zippy'>\n\n        &#9658;&#160;\n
-        \     \n</span>\n</a>\n<a class='post-count-link' href='https://pythoninsider.blogspot.com/2015/12/'>\nDecember\n</a>\n<span
-        class='post-count' dir='ltr'>(2)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2015/11/'>\nNovember\n</a>\n<span
-        class='post-count' dir='ltr'>(1)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2015/09/'>\nSeptember\n</a>\n<span
-        class='post-count' dir='ltr'>(3)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2015/08/'>\nAugust\n</a>\n<span class='post-count'
-        dir='ltr'>(1)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li class='archivedate
-        collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span class='zippy'>\n\n
-        \       &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link' href='https://pythoninsider.blogspot.com/2015/07/'>\nJuly\n</a>\n<span
-        class='post-count' dir='ltr'>(1)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2015/06/'>\nJune\n</a>\n<span class='post-count'
-        dir='ltr'>(1)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li class='archivedate
-        collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span class='zippy'>\n\n
-        \       &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link' href='https://pythoninsider.blogspot.com/2015/05/'>\nMay\n</a>\n<span
-        class='post-count' dir='ltr'>(2)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2015/03/'>\nMarch\n</a>\n<span class='post-count'
-        dir='ltr'>(2)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li class='archivedate
-        collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span class='zippy'>\n\n
-        \       &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link' href='https://pythoninsider.blogspot.com/2015/01/'>\nJanuary\n</a>\n<span
-        class='post-count' dir='ltr'>(1)</span>\n</li>\n</ul>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2014/'>\n2014\n</a>\n<span class='post-count'
-        dir='ltr'>(8)</span>\n<ul class='hierarchy'>\n<li class='archivedate collapsed'>\n<a
-        class='toggle' href='javascript:void(0)'>\n<span class='zippy'>\n\n        &#9658;&#160;\n
-        \     \n</span>\n</a>\n<a class='post-count-link' href='https://pythoninsider.blogspot.com/2014/12/'>\nDecember\n</a>\n<span
-        class='post-count' dir='ltr'>(1)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2014/11/'>\nNovember\n</a>\n<span
-        class='post-count' dir='ltr'>(1)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2014/05/'>\nMay\n</a>\n<span class='post-count'
-        dir='ltr'>(1)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li class='archivedate
-        collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span class='zippy'>\n\n
-        \       &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link' href='https://pythoninsider.blogspot.com/2014/03/'>\nMarch\n</a>\n<span
-        class='post-count' dir='ltr'>(3)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2014/02/'>\nFebruary\n</a>\n<span
-        class='post-count' dir='ltr'>(2)</span>\n</li>\n</ul>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2013/'>\n2013\n</a>\n<span class='post-count'
-        dir='ltr'>(5)</span>\n<ul class='hierarchy'>\n<li class='archivedate collapsed'>\n<a
-        class='toggle' href='javascript:void(0)'>\n<span class='zippy'>\n\n        &#9658;&#160;\n
-        \     \n</span>\n</a>\n<a class='post-count-link' href='https://pythoninsider.blogspot.com/2013/11/'>\nNovember\n</a>\n<span
-        class='post-count' dir='ltr'>(2)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2013/10/'>\nOctober\n</a>\n<span
-        class='post-count' dir='ltr'>(1)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2013/03/'>\nMarch\n</a>\n<span class='post-count'
-        dir='ltr'>(1)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li class='archivedate
-        collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span class='zippy'>\n\n
-        \       &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link' href='https://pythoninsider.blogspot.com/2013/02/'>\nFebruary\n</a>\n<span
-        class='post-count' dir='ltr'>(1)</span>\n</li>\n</ul>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2012/'>\n2012\n</a>\n<span class='post-count'
-        dir='ltr'>(9)</span>\n<ul class='hierarchy'>\n<li class='archivedate collapsed'>\n<a
-        class='toggle' href='javascript:void(0)'>\n<span class='zippy'>\n\n        &#9658;&#160;\n
-        \     \n</span>\n</a>\n<a class='post-count-link' href='https://pythoninsider.blogspot.com/2012/12/'>\nDecember\n</a>\n<span
-        class='post-count' dir='ltr'>(1)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2012/11/'>\nNovember\n</a>\n<span
-        class='post-count' dir='ltr'>(1)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2012/10/'>\nOctober\n</a>\n<span
-        class='post-count' dir='ltr'>(2)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2012/08/'>\nAugust\n</a>\n<span class='post-count'
-        dir='ltr'>(1)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li class='archivedate
-        collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span class='zippy'>\n\n
-        \       &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link' href='https://pythoninsider.blogspot.com/2012/06/'>\nJune\n</a>\n<span
-        class='post-count' dir='ltr'>(2)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2012/05/'>\nMay\n</a>\n<span class='post-count'
-        dir='ltr'>(1)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li class='archivedate
-        collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span class='zippy'>\n\n
-        \       &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link' href='https://pythoninsider.blogspot.com/2012/03/'>\nMarch\n</a>\n<span
-        class='post-count' dir='ltr'>(1)</span>\n</li>\n</ul>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2011/'>\n2011\n</a>\n<span class='post-count'
-        dir='ltr'>(25)</span>\n<ul class='hierarchy'>\n<li class='archivedate collapsed'>\n<a
-        class='toggle' href='javascript:void(0)'>\n<span class='zippy'>\n\n        &#9658;&#160;\n
-        \     \n</span>\n</a>\n<a class='post-count-link' href='https://pythoninsider.blogspot.com/2011/08/'>\nAugust\n</a>\n<span
-        class='post-count' dir='ltr'>(2)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2011/07/'>\nJuly\n</a>\n<span class='post-count'
-        dir='ltr'>(3)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li class='archivedate
-        collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span class='zippy'>\n\n
-        \       &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link' href='https://pythoninsider.blogspot.com/2011/06/'>\nJune\n</a>\n<span
-        class='post-count' dir='ltr'>(1)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2011/05/'>\nMay\n</a>\n<span class='post-count'
-        dir='ltr'>(7)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li class='archivedate
-        collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span class='zippy'>\n\n
-        \       &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link' href='https://pythoninsider.blogspot.com/2011/04/'>\nApril\n</a>\n<span
-        class='post-count' dir='ltr'>(7)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2011/03/'>\nMarch\n</a>\n<span class='post-count'
-        dir='ltr'>(5)</span>\n</li>\n</ul>\n</li>\n</ul>\n</div>\n</div>\n<div class='clear'></div>\n</div>\n</div><div
-        class='widget Profile' data-version='1' id='Profile1'>\n<h2>Contributors</h2>\n<div
-        class='widget-content'>\n<ul>\n<li><a class='profile-name-link g-profile'
-        href='https://www.blogger.com/profile/14971120963699387108' style='background-image:
-        url(//www.blogger.com/img/logo-16.png);'>A.M. Kuchling</a></li>\n<li><a class='profile-name-link
-        g-profile' href='https://www.blogger.com/profile/02804541126912023065' style='background-image:
-        url(//www.blogger.com/img/logo-16.png);'>Alfonso de la Guarda</a></li>\n<li><a
-        class='profile-name-link g-profile' href='https://www.blogger.com/profile/03855116138400732464'
-        style='background-image: url(//www.blogger.com/img/logo-16.png);'>Anthony
-        Scopatz</a></li>\n<li><a class='profile-name-link g-profile' href='https://www.blogger.com/profile/08838587997498042260'
-        style='background-image: url(//www.blogger.com/img/logo-16.png);'>Antoine
-        P.</a></li>\n<li><a class='profile-name-link g-profile' href='https://www.blogger.com/profile/06955536323236904839'
-        style='background-image: url(//www.blogger.com/img/logo-16.png);'>Benjamin
-        Peterson</a></li>\n<li><a class='profile-name-link g-profile' href='https://www.blogger.com/profile/14604644394514192040'
-        style='background-image: url(//www.blogger.com/img/logo-16.png);'>Brian Curtin</a></li>\n<li><a
-        class='profile-name-link g-profile' href='https://www.blogger.com/profile/14913018830568213369'
-        style='background-image: url(//www.blogger.com/img/logo-16.png);'>Davidmh</a></li>\n<li><a
-        class='profile-name-link g-profile' href='https://www.blogger.com/profile/03794667532189865209'
-        style='background-image: url(//www.blogger.com/img/logo-16.png);'>Donald Stufft</a></li>\n<li><a
-        class='profile-name-link g-profile' href='https://www.blogger.com/profile/01892352754222143463'
-        style='background-image: url(//www.blogger.com/img/logo-16.png);'>Doug Hellmann</a></li>\n<li><a
-        class='profile-name-link g-profile' href='https://www.blogger.com/profile/13577459520968677064'
-        style='background-image: url(//www.blogger.com/img/logo-16.png);'>Ee Durbin</a></li>\n<li><a
-        class='profile-name-link g-profile' href='https://www.blogger.com/profile/06795605825443412201'
-        style='background-image: url(//www.blogger.com/img/logo-16.png);'>Ezio Melotti</a></li>\n<li><a
-        class='profile-name-link g-profile' href='https://www.blogger.com/profile/14973145408214215809'
-        style='background-image: url(//www.blogger.com/img/logo-16.png);'>Georg Brandl</a></li>\n<li><a
-        class='profile-name-link g-profile' href='https://www.blogger.com/profile/02811718172961252565'
-        style='background-image: url(//www.blogger.com/img/logo-16.png);'>Hugo</a></li>\n<li><a
-        class='profile-name-link g-profile' href='https://www.blogger.com/profile/07543015027323408421'
-        style='background-image: url(//www.blogger.com/img/logo-16.png);'>Jesse</a></li>\n<li><a
-        class='profile-name-link g-profile' href='https://www.blogger.com/profile/17574962105063127018'
-        style='background-image: url(//www.blogger.com/img/logo-16.png);'>Kelsey Hightower</a></li>\n<li><a
-        class='profile-name-link g-profile' href='https://www.blogger.com/profile/13232068831778121461'
-        style='background-image: url(//www.blogger.com/img/logo-16.png);'>Larry Hastings</a></li>\n<li><a
-        class='profile-name-link g-profile' href='https://www.blogger.com/profile/07757697862303956313'
-        style='background-image: url(//www.blogger.com/img/logo-16.png);'>Mathieu
-        Leduc-Hamel</a></li>\n<li><a class='profile-name-link g-profile' href='https://www.blogger.com/profile/08761481986934375758'
-        style='background-image: url(//www.blogger.com/img/logo-16.png);'>Michael
-        Markert</a></li>\n<li><a class='profile-name-link g-profile' href='https://www.blogger.com/profile/06351908417200979114'
-        style='background-image: url(//www.blogger.com/img/logo-16.png);'>Mike Driscoll</a></li>\n<li><a
-        class='profile-name-link g-profile' href='https://www.blogger.com/profile/17112379650586333719'
-        style='background-image: url(//www.blogger.com/img/logo-16.png);'>Ned Deily</a></li>\n<li><a
-        class='profile-name-link g-profile' href='https://www.blogger.com/profile/07923137967169776470'
-        style='background-image: url(//www.blogger.com/img/logo-16.png);'>Pablo Galindo</a></li>\n<li><a
-        class='profile-name-link g-profile' href='https://www.blogger.com/profile/17557923197983461835'
-        style='background-image: url(//www.blogger.com/img/logo-16.png);'>Paul Moore</a></li>\n<li><a
-        class='profile-name-link g-profile' href='https://www.blogger.com/profile/17437958274873977298'
-        style='background-image: url(//www.blogger.com/img/logo-16.png);'>Philip Jenvey</a></li>\n<li><a
-        class='profile-name-link g-profile' href='https://www.blogger.com/profile/08002085909817689325'
-        style='background-image: url(//www.blogger.com/img/logo-16.png);'>Sumana Harihareswara</a></li>\n<li><a
-        class='profile-name-link g-profile' href='https://www.blogger.com/profile/10346112333332923135'
-        style='background-image: url(//www.blogger.com/img/logo-16.png);'>Thomas Wouters</a></li>\n<li><a
-        class='profile-name-link g-profile' href='https://www.blogger.com/profile/14824694805745746190'
-        style='background-image: url(//www.blogger.com/img/logo-16.png);'>Unknown</a></li>\n<li><a
-        class='profile-name-link g-profile' href='https://www.blogger.com/profile/12361293458447621754'
-        style='background-image: url(//www.blogger.com/img/logo-16.png);'>Unknown</a></li>\n<li><a
-        class='profile-name-link g-profile' href='https://www.blogger.com/profile/01161413896843370614'
-        style='background-image: url(//www.blogger.com/img/logo-16.png);'>\u0141ukasz
-        Langa</a></li>\n<li><a class='profile-name-link g-profile' href='https://www.blogger.com/profile/10522887977715879728'
-        style='background-image: url(//www.blogger.com/img/logo-16.png);'>\xC9ric
-        Araujo</a></li>\n<li><a class='profile-name-link g-profile' href='https://www.blogger.com/profile/07473216746644389812'
-        style='background-image: url(//www.blogger.com/img/logo-16.png);'>e</a></li>\n<li><a
-        class='profile-name-link g-profile' href='https://www.blogger.com/profile/14658404449913582628'
-        style='background-image: url(//www.blogger.com/img/logo-16.png);'>haypo</a></li>\n<li><a
-        class='profile-name-link g-profile' href='https://www.blogger.com/profile/07627402554307001461'
-        style='background-image: url(//www.blogger.com/img/logo-16.png);'>tp</a></li>\n</ul>\n<div
-        class='clear'></div>\n</div>\n</div><div class='widget HTML' data-version='1'
-        id='HTML3'>\n<h2 class='title'>Copyright</h2>\n<div class='widget-content'>\n<a
-        rel=\"license\" href=\"http://creativecommons.org/licenses/by-nc-sa/3.0/\"><img
-        alt=\"Creative Commons License\" style=\"border-width:0\" src=\"https://lh3.googleusercontent.com/blogger_img_proxy/AEn0k_vNLny9gJ_IQG1Qf4JxKrpmu05hsQ2a9YpNHEhxz5icgnVuJGaLDAXKIV8r2GvIk7_RlCwnA_hN3UkzpssffI9wZ3eCjjwgrXmVrwSgqC4SjC2S_tUe7mTr=s0-d\"></a><br
-        /><span xmlns:dct=\"http://purl.org/dc/terms/\" href=\"http://purl.org/dc/dcmitype/Text\"
-        property=\"dct:title\" rel=\"dct:type\">Python Insider</span> by <a xmlns:cc=\"http://creativecommons.org/ns#\"
-        href=\"http://www.python.org/\" property=\"cc:attributionName\" rel=\"cc:attributionURL\">the
-        Python Core Developers</a> is licensed under a <a rel=\"license\" href=\"http://creativecommons.org/licenses/by-nc-sa/3.0/\">Creative
-        Commons Attribution-NonCommercial-ShareAlike 3.0 Unported License</a>.<br
-        />Based on a work at <a xmlns:dct=\"http://purl.org/dc/terms/\" href=\"http://blog.python.org/\"
-        rel=\"dct:source\">blog.python.org</a>.\n</div>\n<div class='clear'></div>\n</div></div>\n<div
-        id='attribution1'>\n<div class='section' id='attribution'><div class='widget
-        Attribution' data-version='1' id='Attribution1'>\n<div class='widget-content'
-        style='text-align: center;'>\nPowered by <a href='https://www.blogger.com'
-        target='_blank'>Blogger</a>.\n</div>\n<div class='clear'></div>\n</div></div>\n</div>\n</div>\n</aside>\n<div
-        style='clear:both'>&nbsp;</div>\n</div>\n\n<script type=\"text/javascript\"
-        src=\"https://www.blogger.com/static/v1/widgets/3000588928-widgets.js\"></script>\n<script
-        type='text/javascript'>\nwindow['__wavt'] = 'AOuZoY4ly9BmOafHTO2GRrsaLYhZTAbH9A:1753779282144';_WidgetManager._Init('//www.blogger.com/rearrange?blogID\\x3d3941553907430899163','//pythoninsider.blogspot.com/','3941553907430899163');\n_WidgetManager._SetDataContext([{'name':
-        'blog', 'data': {'blogId': '3941553907430899163', 'title': 'Python Insider',
-        'url': 'https://pythoninsider.blogspot.com/', 'canonicalUrl': 'https://pythoninsider.blogspot.com/',
-        'homepageUrl': 'https://pythoninsider.blogspot.com/', 'searchUrl': 'https://pythoninsider.blogspot.com/search',
-        'canonicalHomepageUrl': 'https://pythoninsider.blogspot.com/', 'blogspotFaviconUrl':
-        'https://pythoninsider.blogspot.com/favicon.ico', 'bloggerUrl': 'https://www.blogger.com',
-        'hasCustomDomain': false, 'httpsEnabled': true, 'enabledCommentProfileImages':
-        true, 'gPlusViewType': 'FILTERED_POSTMOD', 'adultContent': false, 'analyticsAccountNumber':
-        '', 'encoding': 'UTF-8', 'locale': 'en', 'localeUnderscoreDelimited': 'en',
-        'languageDirection': 'ltr', 'isPrivate': false, 'isMobile': false, 'isMobileRequest':
-        false, 'mobileClass': '', 'isPrivateBlog': false, 'isDynamicViewsAvailable':
-        false, 'feedLinks': '\\x3clink rel\\x3d\\x22alternate\\x22 type\\x3d\\x22application/atom+xml\\x22
-        title\\x3d\\x22Python Insider - Atom\\x22 href\\x3d\\x22https://pythoninsider.blogspot.com/feeds/posts/default\\x22
-        /\\x3e\\n\\x3clink rel\\x3d\\x22alternate\\x22 type\\x3d\\x22application/rss+xml\\x22
-        title\\x3d\\x22Python Insider - RSS\\x22 href\\x3d\\x22https://pythoninsider.blogspot.com/feeds/posts/default?alt\\x3drss\\x22
-        /\\x3e\\n\\x3clink rel\\x3d\\x22service.post\\x22 type\\x3d\\x22application/atom+xml\\x22
-        title\\x3d\\x22Python Insider - Atom\\x22 href\\x3d\\x22https://www.blogger.com/feeds/3941553907430899163/posts/default\\x22
-        /\\x3e\\n', 'meTag': '', 'adsenseHostId': 'ca-host-pub-1556223355139109',
-        'adsenseHasAds': false, 'adsenseAutoAds': false, 'boqCommentIframeForm': true,
-        'loginRedirectParam': '', 'view': '', 'dynamicViewsCommentsSrc': '//www.blogblog.com/dynamicviews/4224c15c4e7c9321/js/comments.js',
-        'dynamicViewsScriptSrc': '//www.blogblog.com/dynamicviews/aec9a2fc4235c5ac',
-        'plusOneApiSrc': 'https://apis.google.com/js/platform.js', 'disableGComments':
-        true, 'interstitialAccepted': false, 'sharing': {'platforms': [{'name': 'Get
-        link', 'key': 'link', 'shareMessage': 'Get link', 'target': ''}, {'name':
-        'Facebook', 'key': 'facebook', 'shareMessage': 'Share to Facebook', 'target':
-        'facebook'}, {'name': 'BlogThis!', 'key': 'blogThis', 'shareMessage': 'BlogThis!',
-        'target': 'blog'}, {'name': 'X', 'key': 'twitter', 'shareMessage': 'Share
-        to X', 'target': 'twitter'}, {'name': 'Pinterest', 'key': 'pinterest', 'shareMessage':
-        'Share to Pinterest', 'target': 'pinterest'}, {'name': 'Email', 'key': 'email',
-        'shareMessage': 'Email', 'target': 'email'}], 'disableGooglePlus': true, 'googlePlusShareButtonWidth':
-        0, 'googlePlusBootstrap': '\\x3cscript type\\x3d\\x22text/javascript\\x22\\x3ewindow.___gcfg
-        \\x3d {\\x27lang\\x27: \\x27en\\x27};\\x3c/script\\x3e'}, 'hasCustomJumpLinkMessage':
-        false, 'jumpLinkMessage': 'Read more', 'pageType': 'index', 'pageName': '',
-        'pageTitle': 'Python Insider'}}, {'name': 'features', 'data': {}}, {'name':
-        'messages', 'data': {'edit': 'Edit', 'linkCopiedToClipboard': 'Link copied
-        to clipboard!', 'ok': 'Ok', 'postLink': 'Post Link'}}, {'name': 'template',
-        'data': {'name': 'custom', 'localizedName': 'Custom', 'isResponsive': false,
-        'isAlternateRendering': false, 'isCustom': true}}, {'name': 'view', 'data':
-        {'classic': {'name': 'classic', 'url': '?view\\x3dclassic'}, 'flipcard': {'name':
-        'flipcard', 'url': '?view\\x3dflipcard'}, 'magazine': {'name': 'magazine',
-        'url': '?view\\x3dmagazine'}, 'mosaic': {'name': 'mosaic', 'url': '?view\\x3dmosaic'},
-        'sidebar': {'name': 'sidebar', 'url': '?view\\x3dsidebar'}, 'snapshot': {'name':
-        'snapshot', 'url': '?view\\x3dsnapshot'}, 'timeslide': {'name': 'timeslide',
-        'url': '?view\\x3dtimeslide'}, 'isMobile': false, 'title': 'Python Insider',
-        'description': 'Python core development news and information.', 'url': 'https://pythoninsider.blogspot.com/',
-        'type': 'feed', 'isSingleItem': false, 'isMultipleItems': true, 'isError':
-        false, 'isPage': false, 'isPost': false, 'isHomepage': true, 'isArchive':
-        false, 'isLabelSearch': false}}]);\n_WidgetManager._RegisterWidget('_NavbarView',
-        new _WidgetInfo('Navbar1', 'navbar', document.getElementById('Navbar1'), {},
-        'displayModeFull'));\n_WidgetManager._RegisterWidget('_HeaderView', new _WidgetInfo('Header1',
-        'header', document.getElementById('Header1'), {}, 'displayModeFull'));\n_WidgetManager._RegisterWidget('_BlogView',
-        new _WidgetInfo('Blog1', 'main', document.getElementById('Blog1'), {'cmtInteractionsEnabled':
-        false, 'lightboxEnabled': true, 'lightboxModuleUrl': 'https://www.blogger.com/static/v1/jsbin/249874-lbx.js',
-        'lightboxCssUrl': 'https://www.blogger.com/static/v1/v-css/123180807-lightbox_bundle.css'},
-        'displayModeFull'));\n_WidgetManager._RegisterWidget('_HTMLView', new _WidgetInfo('HTML1',
-        'sidebar-right-1', document.getElementById('HTML1'), {}, 'displayModeFull'));\n_WidgetManager._RegisterWidget('_LinkListView',
-        new _WidgetInfo('LinkList1', 'sidebar-right-1', document.getElementById('LinkList1'),
-        {}, 'displayModeFull'));\n_WidgetManager._RegisterWidget('_LinkListView',
-        new _WidgetInfo('LinkList2', 'sidebar-right-1', document.getElementById('LinkList2'),
-        {}, 'displayModeFull'));\n_WidgetManager._RegisterWidget('_BlogListView',
-        new _WidgetInfo('BlogList1', 'sidebar-right-1', document.getElementById('BlogList1'),
-        {'numItemsToShow': 0, 'totalItems': 13}, 'displayModeFull'));\n_WidgetManager._RegisterWidget('_BlogArchiveView',
-        new _WidgetInfo('BlogArchive1', 'sidebar-right-1', document.getElementById('BlogArchive1'),
-        {'languageDirection': 'ltr', 'loadingMessage': 'Loading\\x26hellip;'}, 'displayModeFull'));\n_WidgetManager._RegisterWidget('_ProfileView',
-        new _WidgetInfo('Profile1', 'sidebar-right-1', document.getElementById('Profile1'),
-        {}, 'displayModeFull'));\n_WidgetManager._RegisterWidget('_HTMLView', new
-        _WidgetInfo('HTML3', 'sidebar-right-1', document.getElementById('HTML3'),
-        {}, 'displayModeFull'));\n_WidgetManager._RegisterWidget('_AttributionView',
-        new _WidgetInfo('Attribution1', 'attribution', document.getElementById('Attribution1'),
-        {}, 'displayModeFull'));\n</script>\n</body>\n</html>"
+        be written as a fraction of two integers.&lt;/p&gt;\n&lt;p&gt;But why &lt;em&gt;\u03C0&lt;/em&gt;?
+        It\u2019s thought Jones used the Greek letter\n&lt;em&gt;\u03C0&lt;/em&gt;
+        because it\u2019s the first letter in &lt;em&gt;perimetron&lt;/em&gt; or\nperimeter.
+        Jones was the first to use &lt;em&gt;\u03C0&lt;/em&gt; as our familiar ratio\nbut
+        wasn\u2019t the first to use it in as part of the ratio. William\nOughtred,
+        in his 1631 &lt;em&gt;Clavis Mathematicae&lt;/em&gt; (&lt;em&gt;The Key of\nMathematics&lt;/em&gt;),
+        used &lt;em&gt;\u03C0/\u03B4&lt;/em&gt; to represent what we now call pi.\nHis
+        &lt;em&gt;\u03C0&lt;/em&gt; was the circumference, not the ratio of circumference
+        to\ndiameter. James Gregory, in his 1668 &lt;em&gt;Geometriae Pars\nUniversalis&lt;/em&gt;
+        (&lt;em&gt;The Universal Part of Geometry&lt;/em&gt;) used\n&lt;em&gt;\u03C0/\u03C1&lt;/em&gt;
+        instead, where &lt;em&gt;\u03C1&lt;/em&gt; is the radius, making the ratio\n6.28\u2026
+        or &lt;a href=&quot;https://www.tauday.com/&quot;&gt;&lt;em&gt;\u03C4&lt;/em&gt;&lt;/a&gt;.
+        After Jones,\nLeonhard Euler had used &lt;em&gt;\u03C0&lt;/em&gt; for 6.28\u2026,
+        and also &lt;em&gt;p&lt;/em&gt; for\n3.14\u2026, before settling on and popularising
+        &lt;em&gt;\u03C0&lt;/em&gt; for the famous\nratio.&lt;/p&gt;\n&lt;h1 id=&quot;enjoy-the-new-release&quot;&gt;Enjoy
+        the new release&lt;/h1&gt;\n&lt;p&gt;Thanks to all of the many volunteers
+        who help make Python Development\nand these releases possible! Please consider
+        supporting our efforts by\nvolunteering yourself or through organisation contributions
+        to the &lt;a\nhref=&quot;https://www.python.org/psf-landing/&quot;&gt;Python
+        Software\nFoundation&lt;/a&gt;.&lt;/p&gt;\n&lt;p&gt;Regards from Helsinki
+        as the leaves begin to appear on the trees,&lt;/p&gt;\n&lt;p&gt;Your release
+        team, &lt;br&gt;\n  &lt;br&gt;\nHugo van Kemenade\n&lt;br&gt;\nNed Deily\n&lt;br&gt;\nSteve
+        Dower\n&lt;br&gt;\n\u0141ukasz Langa&lt;/p&gt;\n\n</content><link rel='edit'
+        type='application/atom+xml' href='https://www.blogger.com/feeds/3941553907430899163/posts/default/7865809690778671094'/><link
+        rel='self' type='application/atom+xml' href='https://www.blogger.com/feeds/3941553907430899163/posts/default/7865809690778671094'/><link
+        rel='alternate' type='text/html' href='https://pythoninsider.blogspot.com/2025/05/python-3140-beta-1-is-here.html'
+        title='Python 3.14.0 beta 1 is here!'/><author><name>Hugo</name><uri>http://www.blogger.com/profile/02811718172961252565</uri><email>noreply@blogger.com</email><gd:image
+        rel='http://schemas.google.com/g/2005#thumbnail' width='16' height='16' src='https://img1.blogblog.com/img/b16-rounded.gif'/></author></entry><entry><id>tag:blogger.com,1999:blog-3941553907430899163.post-1894902319549652010</id><published>2025-04-08T15:15:00.002-04:00</published><updated>2025-04-08T15:27:21.777-04:00</updated><category
+        scheme=\"http://www.blogger.com/atom/ns#\" term=\"releases\"/><title type='text'>Python
+        3.14.0a7, 3.13.3, 3.12.10, 3.11.12, 3.10.17 and 3.9.22 are now available</title><content
+        type='html'>&lt;p&gt;Not one, not two, not three, not four, not five, but
+        six releases! Is\nthis the most in a single day?&lt;/p&gt;\n&lt;p&gt;3.12-3.14
+        were regularly scheduled, and we had some security fixes to\nrelease in 3.9-3.11
+        so let\u2019s make a big day of it. This also marks the\nlast bugfix release
+        of 3.12 as it enters the security-only phase. See &lt;a\nhref=&quot;https://devguide.python.org/versions/&quot;&gt;devguide.python.org/versions/&lt;/a&gt;\nfor
+        a chart.&lt;/p&gt;\n&lt;h1 id=&quot;python-3.14.0a7&quot;&gt;Python 3.14.0a7&lt;/h1&gt;\n&lt;p&gt;Here
+        comes the final alpha! This means we have just four weeks until\nthe first
+        beta to get those last features into 3.14 before the feature\nfreeze on 2025-05-06!&lt;/p&gt;\n&lt;p&gt;&lt;a
+        href=&quot;https://www.python.org/downloads/release/python-3140a7/&quot;&gt;https://www.python.org/downloads/release/python-3140a7/&lt;/a&gt;&lt;/p&gt;\n&lt;p&gt;&lt;strong&gt;This
+        is an early developer preview of Python\n3.14&lt;/strong&gt;&lt;/p&gt;\n&lt;h2
+        id=&quot;major-new-features-of-the-3.14-series-compared-to-3.13&quot;&gt;Major\nnew
+        features of the 3.14 series, compared to 3.13&lt;/h2&gt;\n&lt;p&gt;Python
+        3.14 is still in development. This release, 3.14.0a7, is the\nlast of seven
+        planned alpha releases.&lt;/p&gt;\n&lt;p&gt;Alpha releases are intended to
+        make it easier to test the current\nstate of new features and bug fixes and
+        to test the release process.&lt;/p&gt;\n&lt;p&gt;During the alpha phase, features
+        may be added up until the start of\nthe beta phase (2025-05-06) and, if necessary,
+        may be modified or\ndeleted up until the release candidate phase (2025-07-22).
+        Please keep\nin mind that this is a preview release and its use is\n&lt;strong&gt;not&lt;/strong&gt;
+        recommended for production environments.&lt;/p&gt;\n&lt;p&gt;Many new features
+        for Python 3.14 are still being planned and\nwritten. Among the new major
+        new features and changes so far:&lt;/p&gt;\n&lt;ul&gt;\n&lt;li&gt;&lt;a\nhref=&quot;https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pep649&quot;&gt;PEP\n649&lt;/a&gt;:
+        deferred evaluation of annotations&lt;/li&gt;\n&lt;li&gt;&lt;a\nhref=&quot;https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pep741&quot;&gt;PEP\n741&lt;/a&gt;:
+        Python configuration C API&lt;/li&gt;\n&lt;li&gt;&lt;a\nhref=&quot;https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pep758&quot;&gt;PEP\n758&lt;/a&gt;:
+        Allow except and except* expressions without parentheses&lt;/li&gt;\n&lt;li&gt;&lt;a\nhref=&quot;https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pep761&quot;&gt;PEP\n761&lt;/a&gt;:
+        Python 3.14 and onwards no longer provides PGP signatures for\nrelease artifacts.
+        Instead, Sigstore is recommended for verifiers.&lt;/li&gt;\n&lt;li&gt;&lt;a\nhref=&quot;https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pep765&quot;&gt;PEP\n765&lt;/a&gt;:
+        disallow\n&lt;code&gt;return&lt;/code&gt;/&lt;code&gt;break&lt;/code&gt;/&lt;code&gt;continue&lt;/code&gt;
+        that exit a\n&lt;code&gt;finally&lt;/code&gt; block&lt;/li&gt;\n&lt;li&gt;&lt;a\nhref=&quot;https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pep768&quot;&gt;PEP\n768&lt;/a&gt;:
+        Safe external debugger interface for CPython&lt;/li&gt;\n&lt;li&gt;A &lt;a\nhref=&quot;https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-tail-call&quot;&gt;new\ntype
+        of interpreter&lt;/a&gt;. For certain newer compilers, this interpreter\nprovides
+        significantly better performance. Opt-in for now, requires\nbuilding from
+        source.&lt;/li&gt;\n&lt;li&gt;&lt;a href=&quot;https://docs.python.org/3.14/whatsnew/3.14.html#uuid&quot;&gt;UUID\nversions
+        6-8&lt;/a&gt; are now supported by the &lt;code&gt;uuid&lt;/code&gt; module,
+        and\ngeneration of versions 3-5 and 8 are up to 40% faster.&lt;/li&gt;\n&lt;li&gt;&lt;a\nhref=&quot;https://docs.python.org/3.14/whatsnew/3.14.html#improved-error-messages&quot;&gt;Improved\nerror
+        messages&lt;/a&gt;&lt;/li&gt;\n&lt;li&gt;Python &lt;a\nhref=&quot;https://docs.python.org/3.14/whatsnew/3.14.html#removed&quot;&gt;removals&lt;/a&gt;\nand
+        &lt;a\nhref=&quot;https://docs.python.org/3.14/whatsnew/3.14.html#deprecated&quot;&gt;deprecations&lt;/a&gt;&lt;/li&gt;\n&lt;li&gt;C
+        API &lt;a\nhref=&quot;https://docs.python.org/3.14/whatsnew/3.14.html#c-api-removed&quot;&gt;removals&lt;/a&gt;\nand
+        &lt;a\nhref=&quot;https://docs.python.org/3.14/whatsnew/3.14.html#c-api-deprecated&quot;&gt;deprecations&lt;/a&gt;&lt;/li&gt;\n&lt;li&gt;&lt;small&gt;(Hey,
+        &lt;strong&gt;fellow core developer,&lt;/strong&gt; if a feature\nyou find
+        important is missing from this list, let Hugo\nknow.)&lt;/small&gt;&lt;/li&gt;\n&lt;/ul&gt;\n&lt;p&gt;The
+        next pre-release of Python 3.14 will be the first beta, 3.14.0b1,\ncurrently
+        scheduled for 2025-05-06. After this, no new features can be\nadded but bug
+        fixes and docs improvements are allowed \u2013 and\nencouraged!&lt;/p&gt;\n&lt;h1
+        id=&quot;python-3.13.3&quot;&gt;Python 3.13.3&lt;/h1&gt;\n&lt;p&gt;This is
+        the third maintenance release of Python 3.13.&lt;/p&gt;\n&lt;p&gt;Python 3.13
+        is the newest major release of the Python programming\nlanguage, and it contains
+        many new features and optimizations compared\nto Python 3.12. 3.13.3 is the
+        latest maintenance release, containing\nalmost 320 bugfixes, build improvements
+        and documentation changes since\n3.13.2.&lt;/p&gt;\n&lt;p&gt;&lt;a href=&quot;https://www.python.org/downloads/release/python-3133/&quot;&gt;https://www.python.org/downloads/release/python-3133/&lt;/a&gt;&lt;/p&gt;\n&lt;h1
+        id=&quot;python-3.12.10&quot;&gt;Python 3.12.10&lt;/h1&gt;\n&lt;p&gt;This
+        is the tenth maintenance release of Python 3.12.&lt;/p&gt;\n&lt;p&gt;Python
+        3.12.10 is the latest maintenance release of Python 3.12, and\nthe last full
+        maintenance release. Subsequent releases of 3.12 will be\nsecurity-fixes only.
+        This last maintenance release contains about 230\nbug fixes, build improvements
+        and documentation changes since\n3.12.9.&lt;/p&gt;\n&lt;p&gt;&lt;a href=&quot;https://www.python.org/downloads/release/python-31210/&quot;&gt;https://www.python.org/downloads/release/python-31210/&lt;/a&gt;&lt;/p&gt;\n&lt;h1
+        id=&quot;python-3.11.12&quot;&gt;Python 3.11.12&lt;/h1&gt;\n&lt;p&gt;This
+        is a security release of Python 3.11:&lt;/p&gt;\n&lt;ul&gt;\n&lt;li&gt;&lt;a\nhref=&quot;https://github.com/python/cpython/issues/106883&quot;&gt;gh-106883&lt;/a&gt;:\nFix
+        deadlock in threaded application when using sys._current_frames&lt;/li&gt;\n&lt;li&gt;&lt;a\nhref=&quot;https://github.com/python/cpython/issues/131809&quot;&gt;gh-131809&lt;/a&gt;:\nUpgrade
+        vendored expat to 2.7.1&lt;/li&gt;\n&lt;li&gt;&lt;a\nhref=&quot;https://github.com/python/cpython/issues/80222&quot;&gt;gh-80222&lt;/a&gt;:\nFolding
+        of quoted string in display_name violates RFC&lt;/li&gt;\n&lt;li&gt;&lt;a\nhref=&quot;https://github.com/python/cpython/issues/121284&quot;&gt;gh-121284&lt;/a&gt;:\nInvalid
+        RFC 2047 address header after refolding with\nemail.policy.default&lt;/li&gt;\n&lt;li&gt;&lt;a\nhref=&quot;https://github.com/python/cpython/issues/131261&quot;&gt;gh-131261&lt;/a&gt;:\nUpdate
+        libexpat to 2.7.0&lt;/li&gt;\n&lt;li&gt;&lt;a\nhref=&quot;https://github.com/python/cpython/issues/105704&quot;&gt;gh-105704&lt;/a&gt;:\n[CVE-2025-0938]
+        urlparse does not flag hostname &lt;em&gt;containing&lt;/em&gt; [ or\n] as
+        incorrect&lt;/li&gt;\n&lt;li&gt;&lt;a\nhref=&quot;https://github.com/python/cpython/issues/119511&quot;&gt;gh-119511&lt;/a&gt;:\nOOM
+        vulnerability in the imaplib module&lt;/li&gt;\n&lt;/ul&gt;\n&lt;p&gt;&lt;a
+        href=&quot;https://www.python.org/downloads/release/python-31112/&quot;&gt;https://www.python.org/downloads/release/python-31112/&lt;/a&gt;&lt;/p&gt;\n&lt;h1
+        id=&quot;python-3.10.17&quot;&gt;Python 3.10.17&lt;/h1&gt;\n&lt;p&gt;This
+        is a security release of Python 3.10:&lt;/p&gt;\n&lt;ul&gt;\n&lt;li&gt;&lt;a\nhref=&quot;https://github.com/python/cpython/issues/131809&quot;&gt;gh-131809&lt;/a&gt;:\nUpgrade
+        vendored expat to 2.7.1&lt;/li&gt;\n&lt;li&gt;&lt;a\nhref=&quot;https://github.com/python/cpython/issues/80222&quot;&gt;gh-80222&lt;/a&gt;:\nFolding
+        of quoted string in display_name violates RFC&lt;/li&gt;\n&lt;li&gt;&lt;a\nhref=&quot;https://github.com/python/cpython/issues/121284&quot;&gt;gh-121284&lt;/a&gt;:\nInvalid
+        RFC 2047 address header after refolding with\nemail.policy.default&lt;/li&gt;\n&lt;li&gt;&lt;a\nhref=&quot;https://github.com/python/cpython/issues/131261&quot;&gt;gh-131261&lt;/a&gt;:\nUpdate
+        libexpat to 2.7.0&lt;/li&gt;\n&lt;li&gt;&lt;a\nhref=&quot;https://github.com/python/cpython/issues/105704&quot;&gt;gh-105704&lt;/a&gt;:
+        &lt;a\nhref=&quot;https://nvd.nist.gov/vuln/detail/CVE-2025-0938&quot;&gt;CVE-2025-0938&lt;/a&gt;\nurlparse
+        does not flag hostname &lt;em&gt;containing&lt;/em&gt; [ or ] as\nincorrect&lt;/li&gt;\n&lt;li&gt;&lt;a\nhref=&quot;https://github.com/python/cpython/issues/119511&quot;&gt;gh-119511&lt;/a&gt;:\nOOM
+        vulnerability in the imaplib module&lt;/li&gt;\n&lt;/ul&gt;\n&lt;p&gt;&lt;a
+        href=&quot;https://www.python.org/downloads/release/python-31017/&quot;&gt;https://www.python.org/downloads/release/python-31017/&lt;/a&gt;&lt;/p&gt;\n&lt;h1
+        id=&quot;python-3.9.22&quot;&gt;Python 3.9.22&lt;/h1&gt;\n&lt;p&gt;This is
+        a security release of Python 3.9:&lt;/p&gt;\n&lt;ul&gt;\n&lt;li&gt;&lt;a\nhref=&quot;https://github.com/python/cpython/issues/131809&quot;&gt;gh-131809&lt;/a&gt;
+        and\n&lt;a href=&quot;https://github.com/python/cpython/issues/131261&quot;&gt;gh-131261&lt;/a&gt;:\nUpgrade
+        vendored expat to 2.7.1&lt;/li&gt;\n&lt;li&gt;&lt;a\nhref=&quot;https://github.com/python/cpython/issues/121284&quot;&gt;gh-121284&lt;/a&gt;:\nInvalid
+        RFC 2047 address header after refolding with\nemail.policy.default&lt;/li&gt;\n&lt;li&gt;&lt;a\nhref=&quot;https://github.com/python/cpython/issues/105704&quot;&gt;gh-105704&lt;/a&gt;:
+        &lt;a\nhref=&quot;https://nvd.nist.gov/vuln/detail/CVE-2025-0938&quot;&gt;CVE-2025-0938&lt;/a&gt;\nurlparse
+        does not flag hostname &lt;em&gt;containing&lt;/em&gt; [ or ] as\nincorrect&lt;/li&gt;\n&lt;li&gt;&lt;a\nhref=&quot;https://github.com/python/cpython/issues/119511&quot;&gt;gh-119511&lt;/a&gt;:\nOOM
+        vulnerability in the imaplib module&lt;/li&gt;\n&lt;/ul&gt;\n&lt;p&gt;&lt;a
+        href=&quot;https://www.python.org/downloads/release/python-3922/&quot;&gt;https://www.python.org/downloads/release/python-3922/&lt;/a&gt;&lt;/p&gt;\n&lt;h1
+        id=&quot;please-upgrade-please-test&quot;&gt;Please upgrade! Please test!&lt;/h1&gt;\n&lt;p&gt;We
+        highly recommend upgrading 3.9-3.13 and we encourage you to test\n3.14.&lt;/p&gt;\n&lt;h1
+        id=&quot;and-now-for-something-completely-different&quot;&gt;And now for\nsomething
+        completely different&lt;/h1&gt;\n&lt;p&gt;On Saturday, 5th April, 3.141592653589793
+        months of the year had\nelapsed.&lt;/p&gt;\n&lt;h1 id=&quot;enjoy-the-new-releases&quot;&gt;Enjoy
+        the new releases&lt;/h1&gt;\n&lt;p&gt;Thanks to all of the many volunteers
+        who help make Python Development\nand these releases possible! Please consider
+        supporting our efforts by\nvolunteering yourself or through organisation contributions
+        to the &lt;a\nhref=&quot;https://www.python.org/psf-landing/&quot;&gt;Python
+        Software\nFoundation&lt;/a&gt;.&lt;/p&gt;\n&lt;p&gt;Regards from a sunny and
+        cold Helsinki springtime,&lt;/p&gt;\n&lt;p&gt;Your full release team,&lt;/p&gt;\n&lt;p&gt;Hugo
+        van Kemenade&lt;br&gt;Thomas Wouters&lt;br&gt;Pablo Galindo Salgado&lt;br&gt;\u0141ukasz
+        Langa\n&lt;br&gt;Ned Deily&lt;br&gt;Steve Dower&lt;/p&gt;\n</content><link
+        rel='edit' type='application/atom+xml' href='https://www.blogger.com/feeds/3941553907430899163/posts/default/1894902319549652010'/><link
+        rel='self' type='application/atom+xml' href='https://www.blogger.com/feeds/3941553907430899163/posts/default/1894902319549652010'/><link
+        rel='alternate' type='text/html' href='https://pythoninsider.blogspot.com/2025/04/python-3140a7-3133-31210-31112-31017.html'
+        title='Python 3.14.0a7, 3.13.3, 3.12.10, 3.11.12, 3.10.17 and 3.9.22 are now
+        available'/><author><name>Hugo</name><uri>http://www.blogger.com/profile/02811718172961252565</uri><email>noreply@blogger.com</email><gd:image
+        rel='http://schemas.google.com/g/2005#thumbnail' width='16' height='16' src='https://img1.blogblog.com/img/b16-rounded.gif'/></author></entry><entry><id>tag:blogger.com,1999:blog-3941553907430899163.post-5082617227190601944</id><published>2025-03-14T13:27:00.001-04:00</published><updated>2025-04-08T15:28:09.160-04:00</updated><category
+        scheme=\"http://www.blogger.com/atom/ns#\" term=\"releases\"/><title type='text'>Python
+        3.14.0 alpha 6 is out</title><content type='html'>&lt;p&gt;Here comes the
+        penultimate alpha.&lt;/p&gt;\n&lt;p&gt;&lt;a href=&quot;https://www.python.org/downloads/release/python-3140a6/&quot;\nclass=&quot;uri&quot;&gt;https://www.python.org/downloads/release/python-3140a6/&lt;/a&gt;&lt;/p&gt;\n&lt;p&gt;&lt;strong&gt;This
+        is an early developer preview of Python\n3.14&lt;/strong&gt;&lt;/p&gt;\n&lt;h1
+        id=&quot;major-new-features-of-the-3.14-series-compared-to-3.13&quot;&gt;Major\nnew
+        features of the 3.14 series, compared to 3.13&lt;/h1&gt;\n&lt;p&gt;Python
+        3.14 is still in development. This release, 3.14.0a6, is the\nsixth of seven
+        planned alpha releases.&lt;/p&gt;\n&lt;p&gt;Alpha releases are intended to
+        make it easier to test the current\nstate of new features and bug fixes and
+        to test the release process.&lt;/p&gt;\n&lt;p&gt;During the alpha phase, features
+        may be added up until the start of\nthe beta phase (2025-05-06) and, if necessary,
+        may be modified or\ndeleted up until the release candidate phase (2025-07-22).
+        Please keep\nin mind that this is a preview release and its use is\n&lt;strong&gt;not&lt;/strong&gt;
+        recommended for production environments.&lt;/p&gt;\n&lt;p&gt;Many new features
+        for Python 3.14 are still being planned and\nwritten. Among the new major
+        new features and changes so far:&lt;/p&gt;\n&lt;ul&gt;\n&lt;li&gt;&lt;a href=&quot;https://peps.python.org/pep-0649/&quot;&gt;PEP
+        649&lt;/a&gt;: &lt;a\nhref=&quot;https://docs.python.org/3.14/whatsnew/3.14.html#pep-649-deferred-evaluation-of-annotations&quot;&gt;deferred\nevaluation
+        of annotations&lt;/a&gt;&lt;/li&gt;\n&lt;li&gt;&lt;a href=&quot;https://peps.python.org/pep-0741/&quot;&gt;PEP
+        741&lt;/a&gt;: Python\nconfiguration C API&lt;/li&gt;\n&lt;li&gt;&lt;a href=&quot;https://peps.python.org/pep-0761/&quot;&gt;PEP
+        761&lt;/a&gt;: Python 3.14\nand onwards no longer provides PGP signatures
+        for release artifacts.\nInstead, Sigstore is recommended for verifiers.&lt;/li&gt;\n&lt;li&gt;&lt;a\nhref=&quot;https://docs.python.org/3.14/whatsnew/3.14.html#improved-error-messages&quot;&gt;Improved\nerror
+        messages&lt;/a&gt;&lt;/li&gt;\n&lt;li&gt;A &lt;a\nhref=&quot;https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-tail-call&quot;&gt;new\ntype
+        of interpreter&lt;/a&gt;. For certain newer compilers, this interpreter\nprovides
+        significantly better performance. Opt-in for now, requires\nbuilding from
+        source.&lt;/li&gt;\n&lt;li&gt;&lt;a href=&quot;https://docs.python.org/3.14/whatsnew/3.14.html#uuid&quot;&gt;UUID\nversions
+        6-8&lt;/a&gt; are now supported by the &lt;code&gt;uuid&lt;/code&gt; module,
+        and\ngeneration of versions 3-5 and 8 are up to 40% faster.&lt;/li&gt;\n&lt;li&gt;Python
+        &lt;a\nhref=&quot;https://docs.python.org/3.14/whatsnew/3.14.html#removed&quot;&gt;removals&lt;/a&gt;\nand
+        &lt;a\nhref=&quot;https://docs.python.org/3.14/whatsnew/3.14.html#deprecated&quot;&gt;deprecations&lt;/a&gt;&lt;/li&gt;\n&lt;li&gt;C
+        API &lt;a\nhref=&quot;https://docs.python.org/3.14/whatsnew/3.14.html#c-api-removed&quot;&gt;removals&lt;/a&gt;\nand
+        &lt;a\nhref=&quot;https://docs.python.org/3.14/whatsnew/3.14.html#c-api-deprecated&quot;&gt;deprecations&lt;/a&gt;&lt;/li&gt;\n&lt;li&gt;&lt;small&gt;(Hey,
+        &lt;strong&gt;fellow core developer,&lt;/strong&gt; if a feature\nyou find
+        important is missing from this list, let Hugo\nknow.)&lt;/small&gt;&lt;/li&gt;\n&lt;/ul&gt;\n&lt;p&gt;The
+        next pre-release of Python 3.14 will be the final alpha,\n3.14.0a7, currently
+        scheduled for 2025-04-08.&lt;/p&gt;\n&lt;h1 id=&quot;more-resources&quot;&gt;More
+        resources&lt;/h1&gt;\n&lt;ul&gt;\n&lt;li&gt;&lt;a href=&quot;https://docs.python.org/3.14/&quot;&gt;Online\ndocumentation&lt;/a&gt;&lt;/li&gt;\n&lt;li&gt;&lt;a
+        href=&quot;https://peps.python.org/pep-0745/&quot;&gt;PEP 745&lt;/a&gt;, 3.14\nRelease
+        Schedule&lt;/li&gt;\n&lt;li&gt;Report bugs at &lt;a\nhref=&quot;https://github.com/python/cpython/issues&quot;&gt;github.com/python/cpython/issues&lt;/a&gt;&lt;/li&gt;\n&lt;li&gt;&lt;a
+        href=&quot;https://www.python.org/psf/donations/&quot;&gt;Help fund Python
+        and\nits community&lt;/a&gt;&lt;/li&gt;\n&lt;/ul&gt;\n&lt;h1 id=&quot;and-now-for-something-completely-different&quot;&gt;And
+        now for\nsomething completely different&lt;/h1&gt;\n&lt;p&gt;March 14 is celebrated
+        as &lt;a\nhref=&quot;https://www.exploratorium.edu/pi&quot;&gt;pi day&lt;/a&gt;,
+        because 3.14 is an\napproximation of \u03C0. The day is observed by eating
+        pies (savoury and/or\nsweet) and celebrating \u03C0. The first pi day was
+        organised by physicist\nand tinkerer Larry Shaw of the San Francisco &lt;a\nhref=&quot;https://annex.exploratorium.edu/learning_studio/pi/&quot;&gt;Exploratorium&lt;/a&gt;\nin
+        1988. It is also the &lt;a href=&quot;https://www.idm314.org/&quot;&gt;International\nDay
+        of Mathematics&lt;/a&gt; and Albert Einstein\u2019s birthday. Let\u2019s all
+        eat\nsome pie, recite some \u03C0, install and test some py, and wish a happy\nbirthday
+        to Albert, Loren and all the other pi day children!&lt;/p&gt;\n&lt;h1 id=&quot;enjoy-the-new-release&quot;&gt;Enjoy
+        the new release&lt;/h1&gt;\n&lt;p&gt;Thanks to all of the many volunteers
+        who help make Python Development\nand these releases possible! Please consider
+        supporting our efforts by\nvolunteering yourself or through organisation contributions
+        to the &lt;a\nhref=&quot;https://www.python.org/psf-landing/&quot;&gt;Python
+        Software\nFoundation&lt;/a&gt;.&lt;/p&gt;\n&lt;p&gt;Regards from Helsinki
+        as fresh snow falls,&lt;/p&gt;\n&lt;p&gt;Your release team, &lt;br&gt;Hugo
+        van Kemenade&lt;br&gt;Ned Deily&lt;br&gt;Steve Dower&lt;br&gt;\u0141ukasz
+        Langa&lt;/p&gt;\n</content><link rel='edit' type='application/atom+xml' href='https://www.blogger.com/feeds/3941553907430899163/posts/default/5082617227190601944'/><link
+        rel='self' type='application/atom+xml' href='https://www.blogger.com/feeds/3941553907430899163/posts/default/5082617227190601944'/><link
+        rel='alternate' type='text/html' href='https://pythoninsider.blogspot.com/2025/03/python-3140-alpha-6-is-out.html'
+        title='Python 3.14.0 alpha 6 is out'/><author><name>Hugo</name><uri>http://www.blogger.com/profile/02811718172961252565</uri><email>noreply@blogger.com</email><gd:image
+        rel='http://schemas.google.com/g/2005#thumbnail' width='16' height='16' src='https://img1.blogblog.com/img/b16-rounded.gif'/></author></entry><entry><id>tag:blogger.com,1999:blog-3941553907430899163.post-3156790103960610237</id><published>2025-02-11T14:41:00.004-05:00</published><updated>2025-02-11T16:25:58.012-05:00</updated><category
+        scheme=\"http://www.blogger.com/atom/ns#\" term=\"releases\"/><title type='text'>Python
+        3.14.0 alpha 5 is out</title><content type='html'>&lt;p&gt;Here comes the
+        antepenultimate alpha.&lt;/p&gt;\n&lt;p&gt;&lt;a href=&quot;https://www.python.org/downloads/release/python-3140a5/&quot;\nclass=&quot;uri&quot;&gt;https://www.python.org/downloads/release/python-3140a5/&lt;/a&gt;&lt;/p&gt;\n&lt;p&gt;&lt;strong&gt;This
+        is an early developer preview of Python\n3.14&lt;/strong&gt;&lt;/p&gt;\n&lt;h1
+        id=&quot;major-new-features-of-the-3.14-series-compared-to-3.13&quot;&gt;Major\nnew
+        features of the 3.14 series, compared to 3.13&lt;/h1&gt;\n&lt;p&gt;Python
+        3.14 is still in development. This release, 3.14.0a5, is the\nfifth of seven
+        planned alpha releases.&lt;/p&gt;\n&lt;p&gt;Alpha releases are intended to
+        make it easier to test the current\nstate of new features and bug fixes and
+        to test the release process.&lt;/p&gt;\n&lt;p&gt;During the alpha phase, features
+        may be added up until the start of\nthe beta phase (2025-05-06) and, if necessary,
+        may be modified or\ndeleted up until the release candidate phase (2025-07-22).
+        Please keep\nin mind that this is a preview release and its use is\n&lt;strong&gt;not&lt;/strong&gt;
+        recommended for production environments.&lt;/p&gt;\n&lt;p&gt;Many new features
+        for Python 3.14 are still being planned and\nwritten. Among the new major
+        new features and changes so far:&lt;/p&gt;\n&lt;ul&gt;\n&lt;li&gt;&lt;a href=&quot;https://peps.python.org/pep-0649/&quot;&gt;PEP
+        649&lt;/a&gt;: &lt;a\nhref=&quot;https://docs.python.org/3.14/whatsnew/3.14.html#pep-649-deferred-evaluation-of-annotations&quot;&gt;deferred\nevaluation
+        of annotations&lt;/a&gt;&lt;/li&gt;\n&lt;li&gt;&lt;a href=&quot;https://peps.python.org/pep-0741/&quot;&gt;PEP
+        741&lt;/a&gt;: Python\nconfiguration C API&lt;/li&gt;\n&lt;li&gt;&lt;a href=&quot;https://peps.python.org/pep-0761/&quot;&gt;PEP
+        761&lt;/a&gt;: Python 3.14\nand onwards no longer provides PGP signatures
+        for release artifacts.\nInstead, Sigstore is recommended for verifiers.&lt;/li&gt;\n&lt;li&gt;&lt;a\nhref=&quot;https://docs.python.org/3.14/whatsnew/3.14.html#improved-error-messages&quot;&gt;Improved\nerror
+        messages&lt;/a&gt;&lt;/li&gt;\n&lt;li&gt;A &lt;a\nhref=&quot;https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-tail-call&quot;&gt;new\ntype
+        of interpreter&lt;/a&gt;. For certain newer compilers, this interpreter\nprovides
+        significantly better performance. Opt-in for now, requires\nbuilding from
+        source.&lt;/li&gt;\n&lt;li&gt;Python &lt;a\nhref=&quot;https://docs.python.org/3.14/whatsnew/3.14.html#removed&quot;&gt;removals&lt;/a&gt;\nand
+        &lt;a\nhref=&quot;https://docs.python.org/3.14/whatsnew/3.14.html#deprecated&quot;&gt;deprecations&lt;/a&gt;&lt;/li&gt;\n&lt;li&gt;C
+        API &lt;a\nhref=&quot;https://docs.python.org/3.14/whatsnew/3.14.html#c-api-removed&quot;&gt;removals&lt;/a&gt;\nand
+        &lt;a\nhref=&quot;https://docs.python.org/3.14/whatsnew/3.14.html#c-api-deprecated&quot;&gt;deprecations&lt;/a&gt;&lt;/li&gt;\n&lt;li&gt;&lt;small&gt;(Hey,
+        &lt;strong&gt;fellow core developer,&lt;/strong&gt; if a feature\nyou find
+        important is missing from this list, let Hugo\nknow.)&lt;/small&gt;&lt;/li&gt;\n&lt;/ul&gt;\n&lt;p&gt;The
+        next pre-release of Python 3.14 will be the penultimate alpha,\n3.14.0a6,
+        currently scheduled for 2025-03-14.&lt;/p&gt;\n&lt;h1 id=&quot;more-resources&quot;&gt;More
+        resources&lt;/h1&gt;\n&lt;ul&gt;\n&lt;li&gt;&lt;a href=&quot;https://docs.python.org/3.14/&quot;&gt;Online\ndocumentation&lt;/a&gt;&lt;/li&gt;\n&lt;li&gt;&lt;a
+        href=&quot;https://peps.python.org/pep-0745/&quot;&gt;PEP 745&lt;/a&gt;, 3.14\nRelease
+        Schedule&lt;/li&gt;\n&lt;li&gt;Report bugs at &lt;a\nhref=&quot;https://github.com/python/cpython/issues&quot;&gt;github.com/python/cpython/issues&lt;/a&gt;&lt;/li&gt;\n&lt;li&gt;&lt;a
+        href=&quot;https://www.python.org/psf/donations/&quot;&gt;Help fund Python
+        and\nits community&lt;/a&gt;&lt;/li&gt;\n&lt;/ul&gt;\n&lt;h1 id=&quot;and-now-for-something-completely-different&quot;&gt;And
+        now for\nsomething completely different&lt;/h1&gt;\n&lt;p&gt;2025-01-29 marked
+        the start of a new lunar year, the Year of the\nSnake \U0001F40D (and the
+        Year of Python?).&lt;/p&gt;\n&lt;p&gt;For centuries, \u03C0 was often approximated
+        as 3 in China. Some time\nbetween the years 1 and 5 CE, astronomer, librarian,
+        mathematician and\npolitician Liu Xin (\u5289\u6B46) calculated \u03C0 as
+        3.154.&lt;/p&gt;\n&lt;p&gt;Around 130 CE, mathematician, astronomer, and geographer
+        Zhang Heng\n(\u5F35\u8861, 78\u2013139) compared the celestial circle with
+        the diameter of the\nearth as 736:232 to get 3.1724. He also came up with
+        a formula for the\nratio between a cube and inscribed sphere as 8:5, implying
+        the ratio of\na square\u2019s area to an inscribed circle is \u221A8:\u221A5.
+        From this, he\ncalculated \u03C0 as \u221A10 (~3.162).&lt;/p&gt;\n&lt;p&gt;Third
+        century mathematician Liu Hui (\u5218\u5FBD) came up with an algorithm\nfor
+        calculating \u03C0 iteratively: calculate the area of a polygon inscribed\nin
+        a circle, then as the number of sides of the polygon is increased,\nthe area
+        becomes closer to that of the circle, from which you can\napproximate \u03C0.&lt;/p&gt;\n&lt;p&gt;This
+        algorithm is similar to the method used by Archimedes in the 3rd\ncentury
+        BCE and Ludolph van Ceulen in the 16th century CE (see &lt;a href=&quot;https://blog.python.org/2024/11/python-3140-alpha-2-released.html&quot;&gt;3.14.0a2\n
+        \ release notes&lt;/a&gt;), but Archimedes only went up to a 96-sided polygon\n(96-gon).
+        Liu Hui went up to a 192-gon to approximate \u03C0 as 157/50 (3.14)\nand later
+        a 3072-gon for 3.14159.&lt;/p&gt;\n&lt;p&gt;Liu Hu wrote a commentary on the
+        book The Nine Chapters on the\nMathematical Art which included his \u03C0
+        approximations.&lt;/p&gt;\n&lt;p&gt;In the fifth century, astronomer, inventor,
+        mathematician,\npolitician, and writer Zu Chongzhi (\u7956\u6C96\u4E4B, 429\u2013500)
+        used Liu Hui\u2019s\nalgorithm to inscribe a 12,288-gon to compute \u03C0
+        between 3.1415926 and\n3.1415927, correct to seven decimal places. This was
+        more accurate than\nHellenistic calculations and wouldn\u2019t be improved
+        upon for 900\nyears.&lt;/p&gt;\n&lt;p&gt;Happy Year of the Snake!&lt;/p&gt;\n&lt;h1
+        id=&quot;enjoy-the-new-release&quot;&gt;Enjoy the new release&lt;/h1&gt;\n&lt;p&gt;Thanks
+        to all of the many volunteers who help make Python Development\nand these
+        releases possible! Please consider supporting our efforts by\nvolunteering
+        yourself or through organisation contributions to the &lt;a\nhref=&quot;https://www.python.org/psf-landing/&quot;&gt;Python
+        Software\nFoundation&lt;/a&gt;.&lt;/p&gt;\n&lt;p&gt;Regards from a remarkably
+        snowless Helsinki,&lt;/p&gt;\n&lt;p&gt;Your release team, &lt;br&gt;Hugo van
+        Kemenade&lt;br&gt;Ned Deily&lt;br&gt;Steve Dower&lt;br&gt;\u0141ukasz Langa&lt;/p&gt;\n</content><link
+        rel='edit' type='application/atom+xml' href='https://www.blogger.com/feeds/3941553907430899163/posts/default/3156790103960610237'/><link
+        rel='self' type='application/atom+xml' href='https://www.blogger.com/feeds/3941553907430899163/posts/default/3156790103960610237'/><link
+        rel='alternate' type='text/html' href='https://pythoninsider.blogspot.com/2025/02/python-3140-alpha-5-is-out.html'
+        title='Python 3.14.0 alpha 5 is out'/><author><name>Hugo</name><uri>http://www.blogger.com/profile/02811718172961252565</uri><email>noreply@blogger.com</email><gd:image
+        rel='http://schemas.google.com/g/2005#thumbnail' width='16' height='16' src='https://img1.blogblog.com/img/b16-rounded.gif'/></author></entry><entry><id>tag:blogger.com,1999:blog-3941553907430899163.post-4587222047235451262</id><published>2025-02-04T14:58:00.000-05:00</published><updated>2025-02-04T14:58:14.631-05:00</updated><title
+        type='text'>Python 3.13.2 and 3.12.9 now available!</title><content type='html'>&lt;p&gt;&amp;nbsp;&lt;/p&gt;&lt;p&gt;A
+        small release day today! That is to say the releases are relatively \nsmall;
+        the day itself was of average size, as most days are.&lt;/p&gt;&lt;div class=&quot;cooked&quot;&gt;\n&lt;h1
+        style=&quot;text-align: left;&quot;&gt;Python 3.13.2&lt;/h1&gt;\n&lt;p&gt;Python
+        3.13\u2019s second maintenance release. About 250 changes went into \nthis
+        update, and can be yours for free if you just upgrade now.&lt;/p&gt;&lt;p&gt;&lt;a
+        href=&quot;https://www.python.org/downloads/release/python-3132/&quot;&gt;https://www.python.org/downloads/release/python-3132/&lt;/a&gt;&lt;/p&gt;&lt;h1
+        style=&quot;text-align: left;&quot;&gt;Python 3.12.9&lt;/h1&gt;\n&lt;p&gt;Python
+        3.12\u2019s &lt;em&gt;ninth&lt;/em&gt; maintenance release already. Just 180
+        changes for 3.12, but it\u2019s still worth upgrading.&lt;/p&gt;&lt;p&gt;&lt;/p&gt;\n&lt;aside
+        class=&quot;onebox allowlistedgeneric&quot; data-onebox-src=&quot;https://www.python.org/downloads/release/python-3128/&quot;&gt;&lt;a
+        href=&quot;https://www.python.org/downloads/release/python-3129/&quot;&gt;https://www.python.org/downloads/release/python-3129/&lt;/a&gt;&lt;/aside&gt;&lt;aside
+        class=&quot;onebox allowlistedgeneric&quot; data-onebox-src=&quot;https://www.python.org/downloads/release/python-3128/&quot;&gt;&lt;br
+        /&gt;&lt;div class=&quot;onebox-metadata&quot;&gt;\n    \n    \n  &lt;/div&gt;\n\n
+        \ &lt;div style=&quot;clear: both;&quot;&gt;&lt;/div&gt;\n&lt;/aside&gt;\n\n&lt;h1
+        style=&quot;text-align: left;&quot;&gt;&lt;a class=&quot;anchor&quot; href=&quot;https://discuss.python.org/t/python-3-13-1-3-12-8-3-11-11-3-10-16-and-3-9-21-are-now-available/73214#p-211771-enjoy-the-new-releases-7&quot;
+        name=&quot;p-211771-enjoy-the-new-releases-7&quot;&gt;&lt;/a&gt;Enjoy the
+        new releases&lt;/h1&gt;\n&lt;p&gt;Thanks to all of the many volunteers who
+        help make Python Development\n and these releases possible! Please consider
+        supporting our efforts by \nvolunteering yourself or through organization
+        contributions to the \nPython Software Foundation.&lt;/p&gt;\n&lt;p&gt;Regards
+        from your tireless, tireless release team,&lt;br /&gt;\nThomas Wouters &lt;br
+        /&gt;\nNed Deily &lt;br /&gt;\nSteve Dower &lt;br /&gt;\n\u0141ukasz Langa
+        &lt;br /&gt;&lt;/p&gt;&lt;/div&gt;</content><link rel='edit' type='application/atom+xml'
+        href='https://www.blogger.com/feeds/3941553907430899163/posts/default/4587222047235451262'/><link
+        rel='self' type='application/atom+xml' href='https://www.blogger.com/feeds/3941553907430899163/posts/default/4587222047235451262'/><link
+        rel='alternate' type='text/html' href='https://pythoninsider.blogspot.com/2025/02/python-3132-and-3129-now-available.html'
+        title='Python 3.13.2 and 3.12.9 now available!'/><author><name>Thomas Wouters</name><uri>http://www.blogger.com/profile/10346112333332923135</uri><email>noreply@blogger.com</email><gd:image
+        rel='http://schemas.google.com/g/2005#thumbnail' width='16' height='16' src='https://img1.blogblog.com/img/b16-rounded.gif'/></author></entry><entry><id>tag:blogger.com,1999:blog-3941553907430899163.post-2297926885172515581</id><published>2025-01-14T11:46:00.001-05:00</published><updated>2025-02-25T06:50:29.859-05:00</updated><category
+        scheme=\"http://www.blogger.com/atom/ns#\" term=\"releases\"/><title type='text'>Python
+        3.14.0 alpha 4 is out</title><content type='html'>&lt;p&gt;Hello, three dot
+        fourteen dot zero alpha four!&lt;/p&gt;\n&lt;p&gt;&lt;a href=&quot;https://www.python.org/downloads/release/python-3140a4/&quot;\nclass=&quot;uri&quot;&gt;https://www.python.org/downloads/release/python-3140a4/&lt;/a&gt;&lt;/p&gt;\n&lt;p&gt;&lt;strong&gt;This
+        is an early developer preview of Python\n3.14&lt;/strong&gt;&lt;/p&gt;\n&lt;h1
+        id=&quot;major-new-features-of-the-3.14-series-compared-to-3.13&quot;&gt;Major\nnew
+        features of the 3.14 series, compared to 3.13&lt;/h1&gt;\n&lt;p&gt;Python
+        3.14 is still in development. This release, 3.14.0a4, is the\nfourth of seven
+        planned alpha releases.&lt;/p&gt;\n&lt;p&gt;Alpha releases are intended to
+        make it easier to test the current\nstate of new features and bug fixes and
+        to test the release process.&lt;/p&gt;\n&lt;p&gt;During the alpha phase, features
+        may be added up until the start of\nthe beta phase (2025-05-06) and, if necessary,
+        may be modified or\ndeleted up until the release candidate phase (2025-07-22).
+        Please keep\nin mind that this is a preview release and its use is\n&lt;strong&gt;not&lt;/strong&gt;
+        recommended for production environments.&lt;/p&gt;\n&lt;p&gt;Many new features
+        for Python 3.14 are still being planned and\nwritten. Among the new major
+        new features and changes so far:&lt;/p&gt;\n&lt;ul&gt;\n&lt;li&gt;&lt;a href=&quot;https://peps.python.org/pep-0649/&quot;&gt;PEP
+        649&lt;/a&gt;: &lt;a\nhref=&quot;https://docs.python.org/3.14/whatsnew/3.14.html#pep-649-deferred-evaluation-of-annotations&quot;&gt;deferred\nevaluation
+        of annotations&lt;/a&gt;&lt;/li&gt;\n&lt;li&gt;&lt;a href=&quot;https://peps.python.org/pep-0741/&quot;&gt;PEP
+        741&lt;/a&gt;: Python\nconfiguration C API&lt;/li&gt;\n&lt;li&gt;&lt;a href=&quot;https://peps.python.org/pep-0761/&quot;&gt;PEP
+        761&lt;/a&gt;: Python 3.14\nand onwards no longer provides PGP signatures
+        for release artifacts.\nInstead, Sigstore is recommended for verifiers.&lt;/li&gt;\n&lt;li&gt;&lt;a\nhref=&quot;https://docs.python.org/3.14/whatsnew/3.14.html#improved-error-messages&quot;&gt;Improved\nerror
+        messages&lt;/a&gt;&lt;/li&gt;\n&lt;li&gt;&lt;a\nhref=&quot;https://docs.python.org/3.14/whatsnew/3.14.html#removed&quot;&gt;Many\nremovals&lt;/a&gt;
+        of deprecated classes, functions, methods and parameters in\nvarious standard
+        library modules.&lt;/li&gt;\n&lt;li&gt;&lt;a\nhref=&quot;https://docs.python.org/3.14/whatsnew/3.14.html#deprecated&quot;&gt;New\ndeprecations&lt;/a&gt;,
+        many of which are scheduled for removal from Python\n3.16&lt;/li&gt;\n&lt;li&gt;C
+        API &lt;a\nhref=&quot;https://docs.python.org/3.14/whatsnew/3.14.html#id13&quot;&gt;removals&lt;/a&gt;\nand
+        &lt;a\nhref=&quot;https://docs.python.org/3.14/whatsnew/3.14.html#id10&quot;&gt;deprecations&lt;/a&gt;&lt;/li&gt;\n&lt;li&gt;&lt;small&gt;(Hey,
+        &lt;strong&gt;fellow core developer,&lt;/strong&gt; if a feature\nyou find
+        important is missing from this list, let Hugo\nknow.)&lt;/small&gt;&lt;/li&gt;\n&lt;/ul&gt;\n&lt;p&gt;The
+        next pre-release of Python 3.14 will be 3.14.0a5, currently\nscheduled for
+        2025-02-11.&lt;/p&gt;\n&lt;h1 id=&quot;more-resources&quot;&gt;More resources&lt;/h1&gt;\n&lt;ul&gt;\n&lt;li&gt;&lt;a
+        href=&quot;https://docs.python.org/3.14/&quot;&gt;Online\ndocumentation&lt;/a&gt;&lt;/li&gt;\n&lt;li&gt;&lt;a
+        href=&quot;https://peps.python.org/pep-0745/&quot;&gt;PEP 745&lt;/a&gt;, 3.14\nRelease
+        Schedule&lt;/li&gt;\n&lt;li&gt;Report bugs at &lt;a\nhref=&quot;https://github.com/python/cpython/issues&quot;&gt;https://github.com/python/cpython/issues&lt;/a&gt;&lt;/li&gt;\n&lt;li&gt;&lt;a
+        href=&quot;https://www.python.org/psf/donations/&quot;&gt;Help fund Python
+        and\nits community&lt;/a&gt;&lt;/li&gt;\n&lt;/ul&gt;\n&lt;h1 id=&quot;and-now-for-something-completely-different&quot;&gt;And
+        now for\nsomething completely different&lt;/h1&gt;\n&lt;p&gt;In Python, you
+        can use Greek letters as constants. For example:&lt;/p&gt;\n&lt;div class=&quot;sourceCode&quot;
+        id=&quot;cb1&quot;&gt;&lt;pre\nclass=&quot;sourceCode python&quot;&gt;&lt;code
+        class=&quot;sourceCode python&quot;&gt;&lt;span id=&quot;cb1-1&quot;&gt;&lt;a
+        href=&quot;#cb1-1&quot; aria-hidden=&quot;true&quot; tabindex=&quot;-1&quot;&gt;&lt;/a&gt;&lt;span
+        class=&quot;im&quot;&gt;from&lt;/span&gt; math &lt;span class=&quot;im&quot;&gt;import&lt;/span&gt;
+        pi &lt;span class=&quot;im&quot;&gt;as&lt;/span&gt; \u03C0&lt;/span&gt;\n&lt;span
+        id=&quot;cb1-2&quot;&gt;&lt;a href=&quot;#cb1-2&quot; aria-hidden=&quot;true&quot;
+        tabindex=&quot;-1&quot;&gt;&lt;/a&gt;&lt;/span&gt;\n&lt;span id=&quot;cb1-3&quot;&gt;&lt;a
+        href=&quot;#cb1-3&quot; aria-hidden=&quot;true&quot; tabindex=&quot;-1&quot;&gt;&lt;/a&gt;&lt;span
+        class=&quot;kw&quot;&gt;def&lt;/span&gt; circumference(radius: &lt;span class=&quot;bu&quot;&gt;float&lt;/span&gt;)
+        &lt;span class=&quot;op&quot;&gt;-&amp;gt;&lt;/span&gt; &lt;span class=&quot;bu&quot;&gt;float&lt;/span&gt;:&lt;/span&gt;\n&lt;span
+        id=&quot;cb1-4&quot;&gt;&lt;a href=&quot;#cb1-4&quot; aria-hidden=&quot;true&quot;
+        tabindex=&quot;-1&quot;&gt;&lt;/a&gt;    &lt;span class=&quot;cf&quot;&gt;return&lt;/span&gt;
+        &lt;span class=&quot;dv&quot;&gt;2&lt;/span&gt; &lt;span class=&quot;op&quot;&gt;*&lt;/span&gt;
+        \u03C0 &lt;span class=&quot;op&quot;&gt;*&lt;/span&gt; radius&lt;/span&gt;\n&lt;span
+        id=&quot;cb1-5&quot;&gt;&lt;a href=&quot;#cb1-5&quot; aria-hidden=&quot;true&quot;
+        tabindex=&quot;-1&quot;&gt;&lt;/a&gt;&lt;/span&gt;\n&lt;span id=&quot;cb1-6&quot;&gt;&lt;a
+        href=&quot;#cb1-6&quot; aria-hidden=&quot;true&quot; tabindex=&quot;-1&quot;&gt;&lt;/a&gt;&lt;span
+        class=&quot;bu&quot;&gt;print&lt;/span&gt;(circumference(&lt;span class=&quot;fl&quot;&gt;6378.137&lt;/span&gt;))
+        \ &lt;span class=&quot;co&quot;&gt;# 40075.016685578485&lt;/span&gt;&lt;/span&gt;&lt;/code&gt;&lt;/pre&gt;&lt;/div&gt;\n&lt;h1
+        id=&quot;enjoy-the-new-release&quot;&gt;Enjoy the new release&lt;/h1&gt;\n&lt;p&gt;Thanks
+        to all of the many volunteers who help make Python Development\nand these
+        releases possible! Please consider supporting our efforts by\nvolunteering
+        yourself or through organisation contributions to the &lt;a\nhref=&quot;https://www.python.org/psf-landing/&quot;&gt;Python
+        Software\nFoundation&lt;/a&gt;.&lt;/p&gt;\n&lt;p&gt;Regards from a slushy,
+        slippery Helsinki,&lt;/p&gt;\n&lt;p&gt;Your release team,&lt;br&gt;\n  Hugo
+        van Kemenade&lt;br&gt;\n  Ned Deily&lt;br&gt;\n  Steve Dower&lt;br&gt;\n  \u0141ukasz
+        Langa\n&lt;/p&gt;\n</content><link rel='edit' type='application/atom+xml'
+        href='https://www.blogger.com/feeds/3941553907430899163/posts/default/2297926885172515581'/><link
+        rel='self' type='application/atom+xml' href='https://www.blogger.com/feeds/3941553907430899163/posts/default/2297926885172515581'/><link
+        rel='alternate' type='text/html' href='https://pythoninsider.blogspot.com/2025/01/python-3140-alpha-4-is-out.html'
+        title='Python 3.14.0 alpha 4 is out'/><author><name>Hugo</name><uri>http://www.blogger.com/profile/02811718172961252565</uri><email>noreply@blogger.com</email><gd:image
+        rel='http://schemas.google.com/g/2005#thumbnail' width='16' height='16' src='https://img1.blogblog.com/img/b16-rounded.gif'/></author></entry><entry><id>tag:blogger.com,1999:blog-3941553907430899163.post-2698828126193070080</id><published>2024-12-17T11:20:00.001-05:00</published><updated>2024-12-17T11:30:16.880-05:00</updated><category
+        scheme=\"http://www.blogger.com/atom/ns#\" term=\"releases\"/><title type='text'>Python
+        3.14.0 alpha 3 is out</title><content type='html'>&lt;p&gt;O Alpha 3, O Alpha
+        3, how lovely are your branches!&lt;/p&gt;\n&lt;p&gt;&lt;a href=&quot;https://www.python.org/downloads/release/python-3140a3/&quot;\nclass=&quot;uri&quot;&gt;https://www.python.org/downloads/release/python-3140a3/&lt;/a&gt;&lt;/p&gt;\n&lt;p&gt;&lt;strong&gt;This
+        is an early developer preview of Python\n3.14&lt;/strong&gt;&lt;/p&gt;\n&lt;h1
+        id=&quot;major-new-features-of-the-3.14-series-compared-to-3.13&quot;&gt;Major\nnew
+        features of the 3.14 series, compared to 3.13&lt;/h1&gt;\n&lt;p&gt;Python
+        3.14 is still in development. This release, 3.14.0a3, is the\nthird of seven
+        planned alpha releases.&lt;/p&gt;\n&lt;p&gt;Alpha releases are intended to
+        make it easier to test the current\nstate of new features and bug fixes and
+        to test the release process.&lt;/p&gt;\n&lt;p&gt;During the alpha phase, features
+        may be added up until the start of\nthe beta phase (2025-05-06) and, if necessary,
+        may be modified or\ndeleted up until the release candidate phase (2025-07-22).
+        Please keep\nin mind that this is a preview release and its use is\n&lt;strong&gt;not&lt;/strong&gt;
+        recommended for production environments.&lt;/p&gt;\n&lt;p&gt;Many new features
+        for Python 3.14 are still being planned and\nwritten. Among the new major
+        new features and changes so far:&lt;/p&gt;\n&lt;ul&gt;\n&lt;li&gt;&lt;a href=&quot;https://peps.python.org/pep-0649/&quot;&gt;PEP
+        649&lt;/a&gt;: &lt;a\nhref=&quot;https://docs.python.org/3.14/whatsnew/3.14.html#pep-649-deferred-evaluation-of-annotations&quot;&gt;deferred\nevaluation
+        of annotations&lt;/a&gt;&lt;/li&gt;\n&lt;li&gt;&lt;a href=&quot;https://peps.python.org/pep-0741/&quot;&gt;PEP
+        741&lt;/a&gt;: Python\nconfiguration C API&lt;/li&gt;\n&lt;li&gt;&lt;a href=&quot;https://peps.python.org/pep-0761/&quot;&gt;PEP
+        761&lt;/a&gt;: Python 3.14\nand onwards no longer provides PGP signatures
+        for release artifacts.\nInstead, Sigstore is recommended for verifiers.&lt;/li&gt;\n&lt;li&gt;&lt;a\nhref=&quot;https://docs.python.org/3.14/whatsnew/3.14.html#improved-error-messages&quot;&gt;Improved\nerror
+        messages&lt;/a&gt;&lt;/li&gt;\n&lt;li&gt;&lt;small&gt;(Hey, &lt;strong&gt;fellow
+        core developer,&lt;/strong&gt; if a feature\nyou find important is missing
+        from this list, let Hugo\nknow.)&lt;/small&gt;&lt;/li&gt;\n&lt;/ul&gt;\n&lt;p&gt;The
+        next pre-release of Python 3.14 will be 3.14.0a4, currently\nscheduled for
+        2025-01-14.&lt;/p&gt;\n&lt;h1 id=&quot;more-resources&quot;&gt;More resources&lt;/h1&gt;\n&lt;ul&gt;\n&lt;li&gt;&lt;a
+        href=&quot;https://docs.python.org/3.14/&quot;&gt;Online\ndocumentation&lt;/a&gt;&lt;/li&gt;\n&lt;li&gt;&lt;a
+        href=&quot;https://peps.python.org/pep-0745/&quot;&gt;PEP 745&lt;/a&gt;, 3.14\nRelease
+        Schedule&lt;/li&gt;\n&lt;li&gt;Report bugs at &lt;a\nhref=&quot;https://github.com/python/cpython/issues&quot;&gt;https://github.com/python/cpython/issues&lt;/a&gt;&lt;/li&gt;\n&lt;li&gt;&lt;a
+        href=&quot;https://www.python.org/psf/donations/&quot;&gt;Help fund Python
+        and\nits community&lt;/a&gt;&lt;/li&gt;\n&lt;/ul&gt;\n&lt;h1 id=&quot;and-now-for-something-completely-different&quot;&gt;And
+        now for\nsomething completely different&lt;/h1&gt;\n&lt;p&gt;A mince pie is
+        a small, round covered tart filled with \u201Cmincemeat\u201D,\nusually eaten
+        during the Christmas season \u2013 the UK consumes some 800\nmillion each
+        Christmas. Mincemeat is a mixture of things like apple,\ndried fruits, candied
+        peel and spices, and originally would have\ncontained meat chopped small,
+        but rarely nowadays. They are often served\nwarm with brandy butter.&lt;/p&gt;\n&lt;p&gt;According
+        to the Oxford English Dictionary, the earliest mention of\nChristmas mince
+        pies is by Thomas Dekker, writing in the aftermath of\nthe &lt;a href=&quot;https://en.wikipedia.org/wiki/1603_London_plague&quot;&gt;1603\nLondon
+        plague&lt;/a&gt;, in &lt;a\nhref=&quot;https://archive.org/details/bim_early-english-books-1475-1640_newes-from-graues-end-s_gravesend_1604/page/n10/mode/1up?q=mince+pyes&quot;&gt;&lt;em&gt;Newes\nfrom
+        Graues-end: Sent to Nobody&lt;/em&gt;&lt;/a&gt; (1604):&lt;/p&gt;\n&lt;blockquote&gt;\n&lt;p&gt;Ten
+        thousand in London swore to feast their neighbors with nothing\nbut plum-porredge,
+        and mince-pyes all Christmas.&lt;/p&gt;\n&lt;/blockquote&gt;\n&lt;p&gt;Here\u2019s
+        a meaty recipe from &lt;a\nhref=&quot;https://www.google.com/books/edition/Rare_and_Excellent_Receipts/PZfbqUrHykwC?hl=en&amp;amp;gbpv=1&amp;amp;dq=%22mince+pies%22&amp;amp;pg=PA9&amp;amp;printsec=frontcover&quot;&gt;&lt;em&gt;Rare\nand
+        Excellent Receipts, Experienc\u2019d and Taught by Mrs Mary Tillinghast\nand
+        now Printed for the Use of her Scholars Only&lt;/em&gt;&lt;/a&gt; (1678):&lt;/p&gt;\n&lt;blockquote&gt;\n&lt;ol
+        start=&quot;15&quot; type=&quot;I&quot;&gt;\n&lt;li&gt;&lt;em&gt;How to make
+        Mince-pies.&lt;/em&gt;&lt;/li&gt;\n&lt;/ol&gt;\n&lt;p&gt;To every pound of
+        Meat, take two pound of beef Suet, a pound of\nCorrants, and a quarter of
+        an Ounce of Cinnamon, one Nutmeg, a little\nbeaten Mace, some beaten Colves,
+        a little Sack &amp;amp; Rose-water, two\nlarge Pippins, some Orange and Lemon
+        peel cut very thin, and shred very\nsmall, a few beaten Carraway-seeds, if
+        you love them the Juyce of half a\nLemon squez\u2019d into this quantity of
+        meat; for Sugar, sweeten it to your\nrelish; then mix all these together and
+        fill your Pie. The best meat for\nPies is Neats-Tongues, or a leg of Veal;
+        you may make them of a leg of\nMutton if you please; the meat must be parboyl\u2019d
+        if you do not spend it\npresently; but if it be for present use, you may do
+        it raw, and the Pies\nwill be the better.&lt;/p&gt;\n&lt;/blockquote&gt;\n&lt;h1
+        id=&quot;enjoy-the-new-release&quot;&gt;Enjoy the new release&lt;/h1&gt;\n&lt;p&gt;Thanks
+        to all of the many volunteers who help make Python Development\nand these
+        releases possible! Please consider supporting our efforts by\nvolunteering
+        yourself or through organisation contributions to the &lt;a\nhref=&quot;https://www.python.org/psf-landing/&quot;&gt;Python
+        Software\nFoundation&lt;/a&gt;.&lt;/p&gt;\n&lt;p&gt;Regards from a snowy and
+        slippery Helsinki,&lt;/p&gt;\n&lt;p&gt;Your release team, &lt;br&gt;Hugo van
+        Kemenade\n  &lt;br&gt;Ned Deily\n  &lt;br&gt;Steve Dower\n  &lt;br&gt;\u0141ukasz
+        Langa \n&lt;/p&gt;\n</content><link rel='edit' type='application/atom+xml'
+        href='https://www.blogger.com/feeds/3941553907430899163/posts/default/2698828126193070080'/><link
+        rel='self' type='application/atom+xml' href='https://www.blogger.com/feeds/3941553907430899163/posts/default/2698828126193070080'/><link
+        rel='alternate' type='text/html' href='https://pythoninsider.blogspot.com/2024/12/python-3140-alpha-3-is-out.html'
+        title='Python 3.14.0 alpha 3 is out'/><author><name>Hugo</name><uri>http://www.blogger.com/profile/02811718172961252565</uri><email>noreply@blogger.com</email><gd:image
+        rel='http://schemas.google.com/g/2005#thumbnail' width='16' height='16' src='https://img1.blogblog.com/img/b16-rounded.gif'/></author></entry><entry><id>tag:blogger.com,1999:blog-3941553907430899163.post-5636659574795883046</id><published>2024-12-03T19:01:00.000-05:00</published><updated>2024-12-03T19:01:10.698-05:00</updated><title
+        type='text'>Python 3.13.1, 3.12.8, 3.11.11, 3.10.16 and 3.9.21 are now available</title><content
+        type='html'>&lt;p&gt;Another big release day! Python 3.13.1 and 3.12.8\n were
+        regularly scheduled releases, but they do contain a few security \nfixes.
+        That makes it a nice time to release the security-fix-only \nversions too,
+        so everything is as secure as we can make it.&lt;/p&gt;&lt;div class=&quot;cooked&quot;&gt;\n&lt;h1
+        style=&quot;text-align: left;&quot;&gt;&lt;a class=&quot;anchor&quot; href=&quot;https://discuss.python.org/t/python-3-13-1-3-12-8-3-11-11-3-10-16-and-3-9-21-are-now-available/73214#p-211771-python-3131-1&quot;
+        name=&quot;p-211771-python-3131-1&quot;&gt;&lt;/a&gt;Python 3.13.1&lt;/h1&gt;\n&lt;p&gt;Python
+        3.13\u2019s first maintenance release. My child is all growed up \nnow, I
+        guess! Almost 400 bugfixes, build improvements and documentation \nchanges
+        went in since 3.13.0, making this the very best Python release \nto date.&lt;/p&gt;&lt;p&gt;&lt;a
+        href=&quot;https://www.python.org/downloads/release/python-3131/&quot;&gt;https://www.python.org/downloads/release/python-3131/&lt;/a&gt;&lt;/p&gt;&lt;h1
+        style=&quot;text-align: left;&quot;&gt;Python 3.12.8&lt;/h1&gt;\n&lt;p&gt;Python
+        3.12 might be slowly reaching middle age, but still received \nover 250 bugfixes,
+        build improvements and documentation changes since \n3.12.7.&lt;/p&gt;\n&lt;aside
+        class=&quot;onebox allowlistedgeneric&quot; data-onebox-src=&quot;https://www.python.org/downloads/release/python-3128/&quot;&gt;&lt;a
+        href=&quot;https://www.python.org/downloads/release/python-3128/&quot;&gt;https://www.python.org/downloads/release/python-3128/&lt;/a&gt;&lt;/aside&gt;&lt;aside
+        class=&quot;onebox allowlistedgeneric&quot; data-onebox-src=&quot;https://www.python.org/downloads/release/python-3128/&quot;&gt;&lt;br
+        /&gt;&lt;div class=&quot;onebox-metadata&quot;&gt;\n    \n    \n  &lt;/div&gt;\n\n
+        \ &lt;div style=&quot;clear: both;&quot;&gt;&lt;/div&gt;\n&lt;/aside&gt;\n\n&lt;h1
+        style=&quot;text-align: left;&quot;&gt;&lt;a class=&quot;anchor&quot; href=&quot;https://discuss.python.org/t/python-3-13-1-3-12-8-3-11-11-3-10-16-and-3-9-21-are-now-available/73214#p-211771-python-31111-3&quot;
+        name=&quot;p-211771-python-31111-3&quot;&gt;&lt;/a&gt;Python 3.11.11&lt;/h1&gt;\n&lt;p&gt;I
+        know it\u2019s probably hard to hear, but this is the &lt;em&gt;second&lt;/em&gt;
+        \nsecurity-only release of Python 3.11. Yes, really! Oh yes, I know, I \nknow,
+        but it\u2019s true! Only 11 commits went in since 3.11.10.&lt;/p&gt;\n&lt;aside
+        class=&quot;onebox allowlistedgeneric&quot; data-onebox-src=&quot;https://www.python.org/downloads/release/python-31111/&quot;&gt;&lt;a
+        href=&quot;https://www.python.org/downloads/release/python-31111/&quot;&gt;https://www.python.org/downloads/release/python-31111/&lt;/a&gt;&lt;/aside&gt;&lt;aside
+        class=&quot;onebox allowlistedgeneric&quot; data-onebox-src=&quot;https://www.python.org/downloads/release/python-31111/&quot;&gt;&lt;br
+        /&gt;&lt;div class=&quot;onebox-metadata&quot;&gt;\n    \n    \n  &lt;/div&gt;\n\n
+        \ &lt;div style=&quot;clear: both;&quot;&gt;&lt;/div&gt;\n&lt;/aside&gt;\n\n&lt;h1
+        style=&quot;text-align: left;&quot;&gt;&lt;a class=&quot;anchor&quot; href=&quot;https://discuss.python.org/t/python-3-13-1-3-12-8-3-11-11-3-10-16-and-3-9-21-are-now-available/73214#p-211771-python-31016-4&quot;
+        name=&quot;p-211771-python-31016-4&quot;&gt;&lt;/a&gt;Python 3.10.16&lt;/h1&gt;\n&lt;p&gt;Python
+        3.10 received a total of 14 commits since 3.10.15. Why more \nthan 3.11? Because
+        it needed a little bit of extra attention to keep \nworking with current GitHub
+        practices, I guess.&lt;/p&gt;\n&lt;aside class=&quot;onebox allowlistedgeneric&quot;
+        data-onebox-src=&quot;https://www.python.org/downloads/release/python-31016/&quot;&gt;&lt;a
+        href=&quot;https://www.python.org/downloads/release/python-31016/&quot;&gt;https://www.python.org/downloads/release/python-31016/&lt;/a&gt;&lt;/aside&gt;&lt;aside
+        class=&quot;onebox allowlistedgeneric&quot; data-onebox-src=&quot;https://www.python.org/downloads/release/python-31016/&quot;&gt;&lt;br
+        /&gt;&lt;div class=&quot;onebox-metadata&quot;&gt;\n    \n    \n  &lt;/div&gt;\n\n
+        \ &lt;div style=&quot;clear: both;&quot;&gt;&lt;/div&gt;\n&lt;/aside&gt;\n\n&lt;h1
+        style=&quot;text-align: left;&quot;&gt;&lt;a class=&quot;anchor&quot; href=&quot;https://discuss.python.org/t/python-3-13-1-3-12-8-3-11-11-3-10-16-and-3-9-21-are-now-available/73214#p-211771-python-3921-5&quot;
+        name=&quot;p-211771-python-3921-5&quot;&gt;&lt;/a&gt;Python 3.9.21&lt;/h1&gt;\n&lt;p&gt;Python
+        3.9 isn\u2019t quite ready for pasture yet, as it\u2019s set to receive \nsecurity
+        fixes for at least another 10 months. Very similarly to 3.10, \nit received
+        14 commits since 3.9.20.&lt;/p&gt;\n&lt;aside class=&quot;onebox allowlistedgeneric&quot;
+        data-onebox-src=&quot;https://www.python.org/downloads/release/python-3921/&quot;&gt;&lt;a
+        href=&quot;https://www.python.org/downloads/release/python-3921/&quot;&gt;https://www.python.org/downloads/release/python-3921/&lt;/a&gt;&lt;/aside&gt;&lt;aside
+        class=&quot;onebox allowlistedgeneric&quot; data-onebox-src=&quot;https://www.python.org/downloads/release/python-3921/&quot;&gt;&lt;br
+        /&gt;&lt;div class=&quot;onebox-metadata&quot;&gt;\n    \n    \n  &lt;/div&gt;\n\n
+        \ &lt;div style=&quot;clear: both;&quot;&gt;&lt;/div&gt;\n&lt;/aside&gt;\n\n&lt;h1
+        style=&quot;text-align: left;&quot;&gt;&lt;a class=&quot;anchor&quot; href=&quot;https://discuss.python.org/t/python-3-13-1-3-12-8-3-11-11-3-10-16-and-3-9-21-are-now-available/73214#p-211771-stay-safe-and-upgrade-6&quot;
+        name=&quot;p-211771-stay-safe-and-upgrade-6&quot;&gt;&lt;/a&gt;Stay safe and
+        upgrade!&lt;/h1&gt;\n&lt;p&gt;As always, upgrading is highly recommended to
+        all users of affected versions.&lt;/p&gt;\n&lt;h1 style=&quot;text-align:
+        left;&quot;&gt;&lt;a class=&quot;anchor&quot; href=&quot;https://discuss.python.org/t/python-3-13-1-3-12-8-3-11-11-3-10-16-and-3-9-21-are-now-available/73214#p-211771-enjoy-the-new-releases-7&quot;
+        name=&quot;p-211771-enjoy-the-new-releases-7&quot;&gt;&lt;/a&gt;Enjoy the
+        new releases&lt;/h1&gt;\n&lt;p&gt;Thanks to all of the many volunteers who
+        help make Python Development\n and these releases possible! Please consider
+        supporting our efforts by \nvolunteering yourself or through organization
+        contributions to the \nPython Software Foundation.&lt;/p&gt;\n&lt;p&gt;Regards
+        from your tireless, tireless release team,&lt;br /&gt;\nThomas Wouters &lt;br
+        /&gt;\nNed Deily &lt;br /&gt;\nSteve Dower &lt;br /&gt;\nPablo Galindo Salgado
+        &lt;br /&gt;\n\u0141ukasz Langa&amp;nbsp;&lt;/p&gt;&lt;/div&gt;</content><link
+        rel='edit' type='application/atom+xml' href='https://www.blogger.com/feeds/3941553907430899163/posts/default/5636659574795883046'/><link
+        rel='self' type='application/atom+xml' href='https://www.blogger.com/feeds/3941553907430899163/posts/default/5636659574795883046'/><link
+        rel='alternate' type='text/html' href='https://pythoninsider.blogspot.com/2024/12/python-3131-3128-31111-31016-and-3921.html'
+        title='Python 3.13.1, 3.12.8, 3.11.11, 3.10.16 and 3.9.21 are now available'/><author><name>Thomas
+        Wouters</name><uri>http://www.blogger.com/profile/10346112333332923135</uri><email>noreply@blogger.com</email><gd:image
+        rel='http://schemas.google.com/g/2005#thumbnail' width='16' height='16' src='https://img1.blogblog.com/img/b16-rounded.gif'/></author></entry><entry><id>tag:blogger.com,1999:blog-3941553907430899163.post-1669506710109511614</id><published>2024-11-19T16:03:00.001-05:00</published><updated>2024-11-19T16:03:49.199-05:00</updated><category
+        scheme=\"http://www.blogger.com/atom/ns#\" term=\"releases\"/><title type='text'>Python
+        3.14.0 alpha 2 released</title><content type='html'>&lt;p&gt;Alpha 2? But
+        Alpha 1 only just came out!&lt;/p&gt;\n&lt;p&gt;&lt;a href=&quot;https://www.python.org/downloads/release/python-3140a2/&quot;&gt;https://www.python.org/downloads/release/python-3140a2/&lt;/a&gt;&lt;/p&gt;\n&lt;p&gt;&lt;strong&gt;This
+        is an early developer preview of Python\n3.14&lt;/strong&gt;&lt;/p&gt;\n&lt;h1
+        id=&quot;major-new-features-of-the-3.14-series-compared-to-3.13&quot;&gt;Major\nnew
+        features of the 3.14 series, compared to 3.13&lt;/h1&gt;\n&lt;p&gt;Python
+        3.14 is still in development. This release, 3.14.0a2 is the\nsecond of seven
+        planned alpha releases.&lt;/p&gt;\n&lt;p&gt;Alpha releases are intended to
+        make it easier to test the current\nstate of new features and bug fixes and
+        to test the release process.&lt;/p&gt;\n&lt;p&gt;During the alpha phase, features
+        may be added up until the start of\nthe beta phase (2025-05-06) and, if necessary,
+        may be modified or\ndeleted up until the release candidate phase (2025-07-22).
+        Please keep\nin mind that this is a preview release and its use is\n&lt;strong&gt;not&lt;/strong&gt;
+        recommended for production environments.&lt;/p&gt;\n&lt;p&gt;Many new features
+        for Python 3.14 are still being planned and\nwritten. Among the new major
+        new features and changes so far:&lt;/p&gt;\n&lt;ul&gt;\n&lt;li&gt;&lt;a href=&quot;https://peps.python.org/pep-0649/&quot;&gt;PEP
+        649&lt;/a&gt;: &lt;a\nhref=&quot;https://docs.python.org/3.14/whatsnew/3.14.html#pep-649-deferred-evaluation-of-annotations&quot;&gt;deferred\nevaluation
+        of annotations&lt;/a&gt;&lt;/li&gt;\n&lt;li&gt;&lt;a href=&quot;https://peps.python.org/pep-0741/&quot;&gt;PEP
+        741&lt;/a&gt;: Python\nconfiguration C API&lt;/li&gt;\n&lt;li&gt;&lt;a href=&quot;https://peps.python.org/pep-0761/&quot;&gt;PEP
+        761&lt;/a&gt;: Python 3.14\nand onwards no longer provides PGP signatures
+        for release artifacts.\nInstead, Sigstore is recommended for verifiers.&lt;/li&gt;\n&lt;li&gt;&lt;a\nhref=&quot;https://docs.python.org/3.14/whatsnew/3.14.html#improved-error-messages&quot;&gt;Improved\nerror
+        messages&lt;/a&gt;&lt;/li&gt;\n&lt;li&gt;&lt;small&gt;(Hey, &lt;strong&gt;fellow
+        core developer,&lt;/strong&gt; if a feature\nyou find important is missing
+        from this list, let Hugo\nknow.)&lt;/small&gt;&lt;/li&gt;\n&lt;/ul&gt;\n&lt;p&gt;The
+        next pre-release of Python 3.14 will be 3.14.0a3, currently\nscheduled for
+        2024-12-17.&lt;/p&gt;\n&lt;h1 id=&quot;more-resources&quot;&gt;More resources&lt;/h1&gt;\n&lt;ul&gt;\n&lt;li&gt;&lt;a
+        href=&quot;https://docs.python.org/3.14/&quot;&gt;Online\ndocumentation&lt;/a&gt;&lt;/li&gt;\n&lt;li&gt;&lt;a
+        href=&quot;https://peps.python.org/pep-0745/&quot;&gt;PEP 745&lt;/a&gt;, 3.14\nRelease
+        Schedule&lt;/li&gt;\n&lt;li&gt;Report bugs at &lt;a\nhref=&quot;https://github.com/python/cpython/issues&quot;&gt;https://github.com/python/cpython/issues&lt;/a&gt;&lt;/li&gt;\n&lt;li&gt;&lt;a
+        href=&quot;https://www.python.org/psf/donations/&quot;&gt;Help fund Python
+        and\nits community&lt;/a&gt;&lt;/li&gt;\n&lt;/ul&gt;\n&lt;h1 id=&quot;enjoy-the-new-release&quot;&gt;Enjoy
+        the new release&lt;/h1&gt;\n&lt;p&gt;Thanks to all of the many volunteers
+        who help make Python Development\nand these releases possible! Please consider
+        supporting our efforts by\nvolunteering yourself or through organisation contributions
+        to the &lt;a\nhref=&quot;https://www.python.org/psf-landing/&quot;&gt;Python
+        Software\nFoundation&lt;/a&gt;.&lt;/p&gt;\n&lt;p&gt;Regards from a chilly
+        Helsinki with snow on the way,&lt;/p&gt;\n&lt;p&gt;Your release team,&lt;br&gt;\n
+        \ Hugo van Kemenade&lt;br&gt;\n  Ned Deily&lt;br&gt;\n  Steve Dower&lt;br&gt;\n
+        \ \u0141ukasz Langa\n&lt;/p&gt;\n</content><link rel='edit' type='application/atom+xml'
+        href='https://www.blogger.com/feeds/3941553907430899163/posts/default/1669506710109511614'/><link
+        rel='self' type='application/atom+xml' href='https://www.blogger.com/feeds/3941553907430899163/posts/default/1669506710109511614'/><link
+        rel='alternate' type='text/html' href='https://pythoninsider.blogspot.com/2024/11/python-3140-alpha-2-released.html'
+        title='Python 3.14.0 alpha 2 released'/><author><name>Hugo</name><uri>http://www.blogger.com/profile/02811718172961252565</uri><email>noreply@blogger.com</email><gd:image
+        rel='http://schemas.google.com/g/2005#thumbnail' width='16' height='16' src='https://img1.blogblog.com/img/b16-rounded.gif'/></author><georss:featurename>Helsinki,
+        Finland</georss:featurename><georss:point>60.169855699999992 24.938379</georss:point><georss:box>31.859621863821147
+        -10.217870999999999 88.480089536178838 60.094629</georss:box></entry><entry><id>tag:blogger.com,1999:blog-3941553907430899163.post-7129115822304213680</id><published>2024-10-15T19:31:00.002-04:00</published><updated>2024-10-16T14:17:44.240-04:00</updated><category
+        scheme=\"http://www.blogger.com/atom/ns#\" term=\"releases\"/><title type='text'>Python
+        3.14.0 alpha 1 is now available</title><content type='html'>&lt;p&gt;It&#39;s
+        now time for a new alpha of a new version of Python!\n&lt;p&gt;&lt;a href=&quot;https://www.python.org/downloads/release/python-3140a1/&quot;&gt;https://www.python.org/downloads/release/python-3140a1/&lt;/a&gt;\n&lt;p&gt;&lt;strong&gt;This
+        is an early developer preview of Python\n3.14&lt;/strong&gt;&lt;/p&gt;\n&lt;h1
+        id=&quot;major-new-features-of-the-3.14-series-compared-to-3.13&quot;&gt;Major\nnew
+        features of the 3.14 series, compared to 3.13&lt;/h1&gt;\n&lt;p&gt;Python
+        3.14 is still in development. This release, 3.14.0a1 is the\nfirst of seven
+        planned alpha releases.&lt;/p&gt;\n&lt;p&gt;Alpha releases are intended to
+        make it easier to test the current\nstate of new features and bug fixes and
+        to test the release process.&lt;/p&gt;\n&lt;p&gt;During the alpha phase, features
+        may be added up until the start of\nthe beta phase (2025-05-06) and, if necessary,
+        may be modified or\ndeleted up until the release candidate phase (2025-07-22).
+        Please keep\nin mind that this is a preview release and its use is\n&lt;strong&gt;not&lt;/strong&gt;
+        recommended for production environments.&lt;/p&gt;\n&lt;p&gt;Many new features
+        for Python 3.14 are still being planned and\nwritten. Among the new major
+        new features and changes so far:&lt;/p&gt;\n&lt;ul&gt;\n&lt;li&gt;&lt;a href=&quot;https://peps.python.org/pep-0649/&quot;&gt;PEP
+        649&lt;/a&gt;: &lt;a\nhref=&quot;https://docs.python.org/3.14/whatsnew/3.14.html#pep-649-deferred-evaluation-of-annotations&quot;&gt;deferred\nevaluation
+        of annotations&lt;/a&gt;&lt;/li&gt;\n&lt;li&gt;&lt;a\nhref=&quot;https://docs.python.org/3.14/whatsnew/3.14.html#improved-error-messages&quot;&gt;Improved\nerror
+        messages&lt;/a&gt;&lt;/li&gt;\n&lt;li&gt;&lt;small&gt;(Hey, &lt;strong&gt;fellow
+        core developer,&lt;/strong&gt; if a feature\nyou find important is missing
+        from this list, &lt;a\nhref=&quot;mailto:hugo@python.org&quot;&gt;let Hugo
+        know&lt;/a&gt;.)&lt;/small&gt;&lt;/li&gt;\n&lt;/ul&gt;\n&lt;p&gt;The next
+        pre-release of Python 3.14 will be 3.14.0a2, currently\nscheduled for 2024-11-19.&lt;/p&gt;\n&lt;h1
+        id=&quot;more-resources&quot;&gt;More resources&lt;/h1&gt;\n&lt;ul&gt;\n&lt;li&gt;&lt;a
+        href=&quot;https://docs.python.org/3.14/&quot;&gt;Online\ndocumentation&lt;/a&gt;&lt;/li&gt;\n&lt;li&gt;&lt;a
+        href=&quot;https://peps.python.org/pep-0745/&quot;&gt;PEP 745&lt;/a&gt;, 3.14\nRelease
+        Schedule&lt;/li&gt;\n&lt;li&gt;Report bugs at &lt;a\nhref=&quot;https://github.com/python/cpython/issues&quot;&gt;https://github.com/python/cpython/issues&lt;/a&gt;&lt;/li&gt;\n&lt;li&gt;&lt;a
+        href=&quot;/psf/donations/&quot;&gt;Help fund Python and its\ncommunity&lt;/a&gt;&lt;/li&gt;\n&lt;/ul&gt;\n&lt;h1
+        id=&quot;enjoy-the-new-release&quot;&gt;Enjoy the new release&lt;/h1&gt;\n&lt;p&gt;Thanks
+        to all of the many volunteers who help make Python Development\nand these
+        releases possible! Please consider supporting our efforts by\nvolunteering
+        yourself or through organization contributions to the\nPython Software Foundation.&lt;/p&gt;\n&lt;p&gt;Regards
+        from a grey yet colourful Helsinki,&lt;/p&gt;\n&lt;p&gt;Your release team,&lt;br&gt;\nHugo
+        van Kemenade&lt;br&gt;\nNed Deily&lt;br&gt;\nSteve Dower&lt;br&gt;\n\u0141ukasz
+        Langa&lt;/p&gt;\n</content><link rel='edit' type='application/atom+xml' href='https://www.blogger.com/feeds/3941553907430899163/posts/default/7129115822304213680'/><link
+        rel='self' type='application/atom+xml' href='https://www.blogger.com/feeds/3941553907430899163/posts/default/7129115822304213680'/><link
+        rel='alternate' type='text/html' href='https://pythoninsider.blogspot.com/2024/10/python-3140-alpha-1-is-now-available.html'
+        title='Python 3.14.0 alpha 1 is now available'/><author><name>Hugo</name><uri>http://www.blogger.com/profile/02811718172961252565</uri><email>noreply@blogger.com</email><gd:image
+        rel='http://schemas.google.com/g/2005#thumbnail' width='16' height='16' src='https://img1.blogblog.com/img/b16-rounded.gif'/></author></entry><entry><id>tag:blogger.com,1999:blog-3941553907430899163.post-3359053619160159818</id><published>2024-10-07T14:21:00.004-04:00</published><updated>2024-10-07T14:56:16.422-04:00</updated><title
+        type='text'>Python 3.13.0 (final) released</title><content type='html'>&lt;p&gt;&amp;nbsp;&lt;/p&gt;&lt;h1
+        style=&quot;background-color: white; color: #222222; font-family: Arial, sans-serif;
+        font-size: var(--font-up-3-rem); line-height: var(--line-height-medium); margin:
+        2rem 0px 0.67rem; text-align: left;&quot;&gt;Python 3.13.0 is now available&lt;/h1&gt;&lt;div&gt;&lt;br
+        /&gt;&lt;/div&gt;&lt;div&gt;&lt;a href=&quot;https://www.python.org/downloads/release/python-3130/&quot;&gt;https://www.python.org/downloads/release/python-3130/&lt;/a&gt;&lt;/div&gt;&lt;div&gt;&lt;br
+        /&gt;&lt;/div&gt;&lt;div&gt;&lt;h1 style=&quot;background-color: white; color:
+        #222222; font-family: Arial, sans-serif; font-size: var(--font-up-3-rem);
+        line-height: var(--line-height-medium); margin: 2rem 0px 0.67rem; text-align:
+        left;&quot;&gt;This is the stable release of Python 3.13.0&lt;/h1&gt;&lt;p
+        style=&quot;background-color: white; color: #222222; font-family: Arial, sans-serif;
+        font-size: 16px; margin-top: 0px;&quot;&gt;Python 3.13.0 is the newest major
+        release of the Python programming language, and it contains many new features
+        and optimizations compared to Python 3.12. (Compared to the last release candidate,
+        3.13.0rc3, 3.13.0 contains two small bug fixes and some documentation and
+        testing changes.)&lt;/p&gt;&lt;h1 style=&quot;background-color: white; color:
+        #222222; font-family: Arial, sans-serif; font-size: var(--font-up-3-rem);
+        line-height: var(--line-height-medium); margin: 2rem 0px 0.67rem; text-align:
+        left;&quot;&gt;&lt;a class=&quot;anchor&quot; href=&quot;https://discuss.python.org/t/python-3-13-0-final-has-been-released/66972#p-196505-major-new-features-of-the-313-series-compared-to-312-3&quot;
+        name=&quot;p-196505-major-new-features-of-the-313-series-compared-to-312-3&quot;
+        style=&quot;background-color: rgba(0, 0, 0, 0); cursor: pointer; opacity:
+        0; overflow-wrap: break-word; text-decoration-line: none; transition: opacity
+        0.25s;&quot;&gt;&lt;/a&gt;Major new features of the 3.13 series, compared
+        to 3.12&lt;/h1&gt;&lt;p style=&quot;background-color: white; color: #222222;
+        font-family: Arial, sans-serif; font-size: 16px; margin-top: 0px;&quot;&gt;Some
+        of the new major new features and changes in Python 3.13 are:&lt;/p&gt;&lt;h2
+        style=&quot;background-color: white; color: #222222; font-family: Arial, sans-serif;
+        font-size: var(--font-up-2-rem); line-height: var(--line-height-medium); margin:
+        2rem 0px 0.67rem;&quot;&gt;&lt;a class=&quot;anchor&quot; href=&quot;https://discuss.python.org/t/python-3-13-0-final-has-been-released/66972#p-196505-new-features-4&quot;
+        name=&quot;p-196505-new-features-4&quot; style=&quot;background-color: rgba(0,
+        0, 0, 0); cursor: pointer; opacity: 0; overflow-wrap: break-word; text-decoration-line:
+        none; transition: opacity 0.25s;&quot;&gt;&lt;/a&gt;New features&lt;/h2&gt;&lt;ul
+        style=&quot;background-color: white; clear: both; color: #222222; font-family:
+        Arial, sans-serif; font-size: 16px; margin: 1em 0px 1em 1.25em; padding: 0px
+        0px 0px 1.25em;&quot;&gt;&lt;li&gt;A&amp;nbsp;&lt;a href=&quot;https://docs.python.org/3.13/whatsnew/3.13.html#a-better-interactive-interpreter&quot;&gt;new
+        and improved interactive interpreter&lt;/a&gt;, based on&amp;nbsp;&lt;a href=&quot;https://pypy.org/&quot;&gt;PyPy&lt;/a&gt;\u2019s,
+        featuring multi-line editing and color support, as well as &lt;a href=&quot;https://docs.python.org/3.13/whatsnew/3.13.html#improved-error-messages&quot;&gt;colorized&amp;nbsp;exception
+        tracebacks&lt;/a&gt;.&lt;/li&gt;&lt;li&gt;An&amp;nbsp;&lt;a href=&quot;https://docs.python.org/3.13/whatsnew/3.13.html#whatsnew313-free-threaded-cpython&quot;&gt;&lt;em&gt;experimental&lt;/em&gt;&amp;nbsp;free-threaded
+        build mode&lt;/a&gt;, which disables the Global Interpreter Lock, allowing
+        threads to run more concurrently. The build mode is available as an experimental
+        feature in the Windows and macOS installers as well.&lt;/li&gt;&lt;li&gt;A&amp;nbsp;&lt;a
+        href=&quot;https://docs.python.org/3.13/whatsnew/3.13.html#an-experimental-just-in-time-jit-compiler&quot;&gt;preliminary,&amp;nbsp;&lt;em&gt;experimental&lt;/em&gt;&amp;nbsp;JIT&lt;/a&gt;,
+        providing the ground work for significant performance improvements.&lt;/li&gt;&lt;li&gt;The&amp;nbsp;&lt;code
+        style=&quot;background: var(--hljs-bg); color: var(--primary-very-high); font-family:
+        var(--d-font-family--monospace); font-size: 1em; white-space-collapse: preserve;&quot;&gt;locals()&lt;/code&gt;&amp;nbsp;builtin
+        function (and its C equivalent) now has&amp;nbsp;&lt;a href=&quot;https://docs.python.org/3.13/whatsnew/3.13.html#defined-mutation-semantics-for-locals&quot;&gt;well-defined
+        semantics when mutating the returned mapping&lt;/a&gt;, which allows debuggers
+        to operate more consistently.&lt;/li&gt;&lt;li&gt;A modified version of&amp;nbsp;&lt;a
+        href=&quot;https://github.com/microsoft/mimalloc&quot;&gt;mimalloc&lt;/a&gt;&amp;nbsp;is
+        now included, optional but enabled by default if supported by the platform,
+        and required for the free-threaded build mode.&lt;/li&gt;&lt;li&gt;Docstrings
+        now have&amp;nbsp;&lt;a href=&quot;https://docs.python.org/3.13/whatsnew/3.13.html#other-language-changes&quot;&gt;their
+        leading indentation stripped&lt;/a&gt;, reducing memory use and the size of
+        .pyc files. (Most tools handling docstrings already strip leading indentation.)&lt;/li&gt;&lt;li&gt;The&amp;nbsp;&lt;a
+        href=&quot;https://docs.python.org/3.13/library/dbm.html&quot;&gt;dbm module&lt;/a&gt;&amp;nbsp;has
+        a new&amp;nbsp;&lt;a href=&quot;https://docs.python.org/3.13/whatsnew/3.13.html#dbm&quot;&gt;dbm.sqlite3
+        backend&lt;/a&gt;&amp;nbsp;that is used by default when creating new files.&lt;/li&gt;&lt;li&gt;The
+        minimum supported macOS version was changed from 10.9 to&amp;nbsp;&lt;span
+        style=&quot;font-weight: bolder;&quot;&gt;10.13 (High Sierra)&lt;/span&gt;.
+        Older macOS versions will not be supported going forward.&lt;/li&gt;&lt;li&gt;WASI
+        is now a&amp;nbsp;&lt;a href=&quot;https://peps.python.org/pep-0011/#tier-2&quot;&gt;Tier
+        2 supported platform&lt;/a&gt;. Emscripten is no longer an&amp;nbsp;&lt;a
+        href=&quot;https://peps.python.org/pep-0011/#no-longer-supported-platforms&quot;&gt;officially
+        supported platform&lt;/a&gt;&amp;nbsp;(but&amp;nbsp;&lt;a href=&quot;https://pyodide.org/&quot;&gt;Pyodide&lt;/a&gt;&amp;nbsp;continues
+        to support Emscripten).&lt;/li&gt;&lt;li&gt;iOS is now a&amp;nbsp;&lt;a href=&quot;https://peps.python.org/pep-0730/&quot;&gt;Tier
+        3 supported platform&lt;/a&gt;.&lt;/li&gt;&lt;li&gt;Android is now a&amp;nbsp;&lt;a
+        href=&quot;https://peps.python.org/pep-0738/&quot;&gt;Tier 3 supported platform&lt;/a&gt;.&lt;/li&gt;&lt;/ul&gt;&lt;h2
+        style=&quot;background-color: white; color: #222222; font-family: Arial, sans-serif;
+        font-size: var(--font-up-2-rem); line-height: var(--line-height-medium); margin:
+        2rem 0px 0.67rem;&quot;&gt;&lt;a class=&quot;anchor&quot; href=&quot;https://discuss.python.org/t/python-3-13-0-final-has-been-released/66972#p-196505-typing-5&quot;
+        name=&quot;p-196505-typing-5&quot; style=&quot;background-color: rgba(0, 0,
+        0, 0); cursor: pointer; opacity: 0; overflow-wrap: break-word; text-decoration-line:
+        none; transition: opacity 0.25s;&quot;&gt;&lt;/a&gt;Typing&lt;/h2&gt;&lt;ul
+        style=&quot;background-color: white; clear: both; color: #222222; font-family:
+        Arial, sans-serif; font-size: 16px; margin: 1em 0px 1em 1.25em; padding: 0px
+        0px 0px 1.25em;&quot;&gt;&lt;li&gt;Support for&amp;nbsp;&lt;a href=&quot;https://peps.python.org/pep-0696/&quot;&gt;type
+        defaults in type parameters&lt;/a&gt;.&lt;/li&gt;&lt;li&gt;A&amp;nbsp;new
+        &lt;a href=&quot;https://peps.python.org/pep-0742/&quot;&gt;type narrowing
+        annotation&lt;/a&gt;,&amp;nbsp;&lt;code style=&quot;background: var(--hljs-bg);
+        color: var(--primary-very-high); font-family: var(--d-font-family--monospace);
+        font-size: 1em; white-space-collapse: preserve;&quot;&gt;typing.TypeIs&lt;/code&gt;.&lt;/li&gt;&lt;li&gt;A
+        new annotation for&amp;nbsp;&lt;a href=&quot;https://peps.python.org/pep-0705/&quot;&gt;read-only
+        items in TypeDicts&lt;/a&gt;.&lt;/li&gt;&lt;li&gt;A new annotation for&amp;nbsp;&lt;a
+        href=&quot;https://peps.python.org/pep-0702&quot;&gt;marking deprecations
+        in the type system&lt;/a&gt;.&lt;/li&gt;&lt;/ul&gt;&lt;h2 style=&quot;background-color:
+        white; color: #222222; font-family: Arial, sans-serif; font-size: var(--font-up-2-rem);
+        line-height: var(--line-height-medium); margin: 2rem 0px 0.67rem;&quot;&gt;&lt;a
+        class=&quot;anchor&quot; href=&quot;https://discuss.python.org/t/python-3-13-0-final-has-been-released/66972#p-196505-removals-and-new-deprecations-6&quot;
+        name=&quot;p-196505-removals-and-new-deprecations-6&quot; style=&quot;background-color:
+        rgba(0, 0, 0, 0); cursor: pointer; opacity: 0; overflow-wrap: break-word;
+        text-decoration-line: none; transition: opacity 0.25s;&quot;&gt;&lt;/a&gt;Removals
+        and new deprecations&lt;/h2&gt;&lt;ul style=&quot;background-color: white;
+        clear: both; color: #222222; font-family: Arial, sans-serif; font-size: 16px;
+        margin: 1em 0px 1em 1.25em; padding: 0px 0px 0px 1.25em;&quot;&gt;&lt;li&gt;&lt;a
+        href=&quot;https://peps.python.org/pep-0594/&quot;&gt;PEP 594 (Removing dead
+        batteries from the standard library)&lt;/a&gt;&amp;nbsp;scheduled removals
+        of many deprecated modules:&amp;nbsp;&lt;code style=&quot;background: var(--hljs-bg);
+        color: var(--primary-very-high); font-family: var(--d-font-family--monospace);
+        font-size: 1em; white-space-collapse: preserve;&quot;&gt;aifc&lt;/code&gt;,&amp;nbsp;&lt;code
+        style=&quot;background: var(--hljs-bg); color: var(--primary-very-high); font-family:
+        var(--d-font-family--monospace); font-size: 1em; white-space-collapse: preserve;&quot;&gt;audioop&lt;/code&gt;,&amp;nbsp;&lt;code
+        style=&quot;background: var(--hljs-bg); color: var(--primary-very-high); font-family:
+        var(--d-font-family--monospace); font-size: 1em; white-space-collapse: preserve;&quot;&gt;chunk&lt;/code&gt;,&amp;nbsp;&lt;code
+        style=&quot;background: var(--hljs-bg); color: var(--primary-very-high); font-family:
+        var(--d-font-family--monospace); font-size: 1em; white-space-collapse: preserve;&quot;&gt;cgi&lt;/code&gt;,&amp;nbsp;&lt;code
+        style=&quot;background: var(--hljs-bg); color: var(--primary-very-high); font-family:
+        var(--d-font-family--monospace); font-size: 1em; white-space-collapse: preserve;&quot;&gt;cgitb&lt;/code&gt;,&amp;nbsp;&lt;code
+        style=&quot;background: var(--hljs-bg); color: var(--primary-very-high); font-family:
+        var(--d-font-family--monospace); font-size: 1em; white-space-collapse: preserve;&quot;&gt;crypt&lt;/code&gt;,&amp;nbsp;&lt;code
+        style=&quot;background: var(--hljs-bg); color: var(--primary-very-high); font-family:
+        var(--d-font-family--monospace); font-size: 1em; white-space-collapse: preserve;&quot;&gt;imghdr&lt;/code&gt;,&amp;nbsp;&lt;code
+        style=&quot;background: var(--hljs-bg); color: var(--primary-very-high); font-family:
+        var(--d-font-family--monospace); font-size: 1em; white-space-collapse: preserve;&quot;&gt;mailcap&lt;/code&gt;,&amp;nbsp;&lt;code
+        style=&quot;background: var(--hljs-bg); color: var(--primary-very-high); font-family:
+        var(--d-font-family--monospace); font-size: 1em; white-space-collapse: preserve;&quot;&gt;msilib&lt;/code&gt;,&amp;nbsp;&lt;code
+        style=&quot;background: var(--hljs-bg); color: var(--primary-very-high); font-family:
+        var(--d-font-family--monospace); font-size: 1em; white-space-collapse: preserve;&quot;&gt;nis&lt;/code&gt;,&amp;nbsp;&lt;code
+        style=&quot;background: var(--hljs-bg); color: var(--primary-very-high); font-family:
+        var(--d-font-family--monospace); font-size: 1em; white-space-collapse: preserve;&quot;&gt;nntplib&lt;/code&gt;,&amp;nbsp;&lt;code
+        style=&quot;background: var(--hljs-bg); color: var(--primary-very-high); font-family:
+        var(--d-font-family--monospace); font-size: 1em; white-space-collapse: preserve;&quot;&gt;ossaudiodev&lt;/code&gt;,&amp;nbsp;&lt;code
+        style=&quot;background: var(--hljs-bg); color: var(--primary-very-high); font-family:
+        var(--d-font-family--monospace); font-size: 1em; white-space-collapse: preserve;&quot;&gt;pipes&lt;/code&gt;,&amp;nbsp;&lt;code
+        style=&quot;background: var(--hljs-bg); color: var(--primary-very-high); font-family:
+        var(--d-font-family--monospace); font-size: 1em; white-space-collapse: preserve;&quot;&gt;sndhdr&lt;/code&gt;,&amp;nbsp;&lt;code
+        style=&quot;background: var(--hljs-bg); color: var(--primary-very-high); font-family:
+        var(--d-font-family--monospace); font-size: 1em; white-space-collapse: preserve;&quot;&gt;spwd&lt;/code&gt;,&amp;nbsp;&lt;code
+        style=&quot;background: var(--hljs-bg); color: var(--primary-very-high); font-family:
+        var(--d-font-family--monospace); font-size: 1em; white-space-collapse: preserve;&quot;&gt;sunau&lt;/code&gt;,&amp;nbsp;&lt;code
+        style=&quot;background: var(--hljs-bg); color: var(--primary-very-high); font-family:
+        var(--d-font-family--monospace); font-size: 1em; white-space-collapse: preserve;&quot;&gt;telnetlib&lt;/code&gt;,&amp;nbsp;&lt;code
+        style=&quot;background: var(--hljs-bg); color: var(--primary-very-high); font-family:
+        var(--d-font-family--monospace); font-size: 1em; white-space-collapse: preserve;&quot;&gt;uu&lt;/code&gt;,&amp;nbsp;&lt;code
+        style=&quot;background: var(--hljs-bg); color: var(--primary-very-high); font-family:
+        var(--d-font-family--monospace); font-size: 1em; white-space-collapse: preserve;&quot;&gt;xdrlib&lt;/code&gt;,&amp;nbsp;&lt;code
+        style=&quot;background: var(--hljs-bg); color: var(--primary-very-high); font-family:
+        var(--d-font-family--monospace); font-size: 1em; white-space-collapse: preserve;&quot;&gt;lib2to3&lt;/code&gt;.&lt;/li&gt;&lt;li&gt;&lt;a
+        href=&quot;https://docs.python.org/3.13/whatsnew/3.13.html#removed-modules-and-apis&quot;&gt;Many
+        other removals&lt;/a&gt;&amp;nbsp;of deprecated classes, functions and methods
+        in various standard library modules.&lt;/li&gt;&lt;li&gt;C API&amp;nbsp;&lt;a
+        href=&quot;https://docs.python.org/3.13/whatsnew/3.13.html#removed-c-apis&quot;&gt;removals&lt;/a&gt;&amp;nbsp;and&amp;nbsp;&lt;a
+        href=&quot;https://docs.python.org/3.13/whatsnew/3.13.html#deprecated-c-apis&quot;&gt;deprecations&lt;/a&gt;.
+        (Some removals present in alpha 1 were reverted in alpha 2, as the removals
+        were deemed too disruptive at this time.)&lt;/li&gt;&lt;li&gt;&lt;a href=&quot;https://docs.python.org/3.13/whatsnew/3.13.html#new-deprecations&quot;&gt;New
+        deprecations&lt;/a&gt;, most of which are scheduled for removal from Python
+        3.15 or 3.16.&lt;/li&gt;&lt;/ul&gt;&lt;p style=&quot;background-color: white;
+        color: #222222; font-family: Arial, sans-serif; font-size: 16px;&quot;&gt;For
+        more details on the changes to Python 3.13, see&amp;nbsp;&lt;a href=&quot;https://docs.python.org/3.13/whatsnew/3.13.html&quot;&gt;What\u2019s
+        new in Python 3.13&lt;/a&gt;.&lt;/p&gt;&lt;h1 style=&quot;background-color:
+        white; color: #222222; font-family: Arial, sans-serif; font-size: var(--font-up-3-rem);
+        line-height: var(--line-height-medium); margin: 2rem 0px 0.67rem;&quot;&gt;&lt;a
+        class=&quot;anchor&quot; href=&quot;https://discuss.python.org/t/python-3-13-0-final-has-been-released/66972#p-196505-more-resources-7&quot;
+        name=&quot;p-196505-more-resources-7&quot; style=&quot;background-color: rgba(0,
+        0, 0, 0); cursor: pointer; opacity: 0; overflow-wrap: break-word; text-decoration-line:
+        none; transition: opacity 0.25s;&quot;&gt;&lt;/a&gt;More resources&lt;/h1&gt;&lt;ul
+        style=&quot;background-color: white; clear: both; color: #222222; font-family:
+        Arial, sans-serif; font-size: 16px; margin: 1em 0px 1em 1.25em; padding: 0px
+        0px 0px 1.25em;&quot;&gt;&lt;li&gt;&lt;a href=&quot;https://docs.python.org/3.13/&quot;&gt;Online
+        Documentation&lt;/a&gt;&lt;/li&gt;&lt;li&gt;&lt;a href=&quot;https://peps.python.org/pep-0719/&quot;&gt;PEP
+        719&lt;/a&gt;, 3.13 Release Schedule&lt;/li&gt;&lt;li&gt;Report bugs via&amp;nbsp;&lt;a
+        href=&quot;https://github.com/python/cpython/issues&quot;&gt;GitHub Issues&lt;/a&gt;.&lt;/li&gt;&lt;li&gt;&lt;a
+        href=&quot;https://www.python.org/psf/donations/python-dev/&quot;&gt;Help
+        fund Python directly&lt;/a&gt;&amp;nbsp;(or&amp;nbsp;via &lt;a href=&quot;https://github.com/sponsors/python&quot;&gt;GitHub
+        Sponsors&lt;/a&gt;), and support&amp;nbsp;&lt;a href=&quot;https://www.python.org/psf/donations/&quot;&gt;the
+        Python community&lt;/a&gt;.&lt;/li&gt;&lt;/ul&gt;&lt;h1 style=&quot;background-color:
+        white; color: #222222; font-family: Arial, sans-serif; font-size: var(--font-up-3-rem);
+        line-height: var(--line-height-medium); margin: 2rem 0px 0.67rem;&quot;&gt;&lt;a
+        class=&quot;anchor&quot; href=&quot;https://discuss.python.org/t/python-3-13-0-final-has-been-released/66972#p-196505-we-hope-you-enjoy-the-new-releases-8&quot;
+        name=&quot;p-196505-we-hope-you-enjoy-the-new-releases-8&quot; style=&quot;background-color:
+        rgba(0, 0, 0, 0); cursor: pointer; opacity: 0; overflow-wrap: break-word;
+        text-decoration-line: none; transition: opacity 0.25s;&quot;&gt;&lt;/a&gt;We
+        hope you enjoy the new releases!&lt;/h1&gt;&lt;p style=&quot;background-color:
+        white; color: #222222; font-family: Arial, sans-serif; font-size: 16px; margin-top:
+        0px;&quot;&gt;Thanks to all of the many volunteers who help make Python Development
+        and these releases possible! Please consider supporting our efforts by volunteering
+        yourself or through organization contributions to&amp;nbsp;&lt;a href=&quot;https://www.python.org/psf-landing/&quot;&gt;the
+        Python Software Foundation&lt;/a&gt;.&lt;/p&gt;&lt;p style=&quot;background-color:
+        white; color: #222222; font-family: Arial, sans-serif; font-size: 16px;&quot;&gt;Choo-choo
+        from the release train,&lt;/p&gt;&lt;p style=&quot;background-color: white;
+        color: #222222; font-family: Arial, sans-serif; font-size: 16px;&quot;&gt;Your
+        release team,&lt;br /&gt;Thomas Wouters&amp;nbsp;&lt;br /&gt;Ned Deily&amp;nbsp;&lt;br
+        /&gt;Steve Dower&amp;nbsp;&lt;br /&gt;\u0141ukasz Langa&amp;nbsp;&lt;/p&gt;&lt;/div&gt;</content><link
+        rel='edit' type='application/atom+xml' href='https://www.blogger.com/feeds/3941553907430899163/posts/default/3359053619160159818'/><link
+        rel='self' type='application/atom+xml' href='https://www.blogger.com/feeds/3941553907430899163/posts/default/3359053619160159818'/><link
+        rel='alternate' type='text/html' href='https://pythoninsider.blogspot.com/2024/10/python-3130-final-released.html'
+        title='Python 3.13.0 (final) released'/><author><name>Thomas Wouters</name><uri>http://www.blogger.com/profile/10346112333332923135</uri><email>noreply@blogger.com</email><gd:image
+        rel='http://schemas.google.com/g/2005#thumbnail' width='16' height='16' src='https://img1.blogblog.com/img/b16-rounded.gif'/></author></entry><entry><id>tag:blogger.com,1999:blog-3941553907430899163.post-8571898513389757416</id><published>2024-10-01T12:32:00.002-04:00</published><updated>2024-10-01T12:32:34.889-04:00</updated><title
+        type='text'>Python 3.12.7 released</title><content type='html'>&lt;p&gt;&amp;nbsp;&amp;nbsp;&lt;/p&gt;&lt;p&gt;I&#39;m
+        pleased to announce the release of Python 3.12.7:&lt;br /&gt;&lt;br /&gt;&lt;a
+        href=&quot;https://www.python.org/downloads/release/python-3127/&quot;&gt;https://www.python.org/downloads/release/python-3127/&lt;br
+        /&gt;&lt;/a&gt;&lt;/p&gt;&lt;h1&gt;&amp;nbsp;&lt;/h1&gt;&lt;h1&gt;This is
+        the seventh maintenance release of Python 3.12&lt;/h1&gt;&lt;p&gt;Python 3.12
+        is the&amp;nbsp;&lt;span style=&quot;font-family: inherit;&quot;&gt;newest&amp;nbsp;&lt;/span&gt;major
+        release of the Python programming language, and it contains many new features
+        and optimizations. 3.12.7 is the latest maintenance release, containing more
+        than 100 bugfixes, build improvements and documentation changes since 3.12.6.&lt;/p&gt;&lt;h1&gt;&lt;a
+        class=&quot;anchor&quot; href=&quot;https://discuss.python.org/t/python-3-12-4-now-available/55128#major-new-features-of-the-312-series-compared-to-311-2&quot;
+        name=&quot;major-new-features-of-the-312-series-compared-to-311-2&quot;&gt;&lt;/a&gt;&amp;nbsp;&lt;/h1&gt;&lt;h1&gt;Major
+        new features of the 3.12 series, compared to 3.11&lt;/h1&gt;&lt;h2&gt;&lt;a
+        class=&quot;anchor&quot; href=&quot;https://discuss.python.org/t/python-3-12-4-now-available/55128#new-features-3&quot;
+        name=&quot;new-features-3&quot;&gt;&lt;/a&gt;&amp;nbsp;&lt;/h2&gt;&lt;h2&gt;New
+        features&lt;/h2&gt;&lt;ul&gt;&lt;li&gt;&lt;a href=&quot;https://docs.python.org/3.12/whatsnew/3.12.html#pep-701-syntactic-formalization-of-f-strings&quot;&gt;More
+        flexible f-string parsing&lt;/a&gt;, allowing many things previously disallowed
+        (&lt;a href=&quot;https://peps.python.org/pep-0701/&quot;&gt;PEP 701&lt;/a&gt;).&lt;/li&gt;&lt;li&gt;&lt;a
+        href=&quot;https://docs.python.org/3.12/whatsnew/3.12.html#pep-688-making-the-buffer-protocol-accessible-in-python&quot;&gt;Support
+        for the buffer protocol&lt;/a&gt;&amp;nbsp;in Python code (&lt;a href=&quot;https://peps.python.org/pep-0688/&quot;&gt;PEP
+        688&lt;/a&gt;).&lt;/li&gt;&lt;li&gt;&lt;a href=&quot;https://docs.python.org/3.12/whatsnew/3.12.html#pep-669-low-impact-monitoring-for-cpython&quot;&gt;A
+        new debugging/profiling API&lt;/a&gt;&amp;nbsp;(&lt;a href=&quot;https://peps.python.org/pep-0669/&quot;&gt;PEP
+        669&lt;/a&gt;).&lt;/li&gt;&lt;li&gt;&lt;a href=&quot;https://docs.python.org/3.12/whatsnew/3.12.html#pep-684-a-per-interpreter-gil&quot;&gt;Support
+        for isolated subinterpreters&lt;/a&gt;&amp;nbsp;with separate Global Interpreter
+        Locks (&lt;a href=&quot;https://peps.python.org/pep-0684&quot;&gt;PEP 684&lt;/a&gt;).&lt;/li&gt;&lt;li&gt;&lt;a
+        href=&quot;https://docs.python.org/3.12/whatsnew/3.12.html#improved-error-messages&quot;&gt;Even
+        more improved error messages&lt;/a&gt;. More exceptions potentially caused
+        by typos now make suggestions to the user.&lt;/li&gt;&lt;li&gt;&lt;a href=&quot;https://docs.python.org/3.12/howto/perf_profiling.html&quot;&gt;Support
+        for the Linux&amp;nbsp;&lt;code&gt;perf&lt;/code&gt;&amp;nbsp;profiler&lt;/a&gt;&amp;nbsp;to
+        report Python function names in traces.&lt;/li&gt;&lt;li&gt;&lt;a href=&quot;https://docs.python.org/3.12/whatsnew/3.12.html#optimizations&quot;&gt;Many
+        large and small performance improvements&lt;/a&gt;&amp;nbsp;(like&amp;nbsp;&lt;a
+        href=&quot;https://peps.python.org/pep-0709/&quot;&gt;PEP 709&lt;/a&gt;&amp;nbsp;and
+        support for the BOLT binary optimizer), delivering an estimated 5% overall
+        performance improvement.&lt;/li&gt;&lt;/ul&gt;&lt;h2&gt;&lt;a class=&quot;anchor&quot;
+        href=&quot;https://discuss.python.org/t/python-3-12-4-now-available/55128#type-annotations-4&quot;
+        name=&quot;type-annotations-4&quot;&gt;&lt;/a&gt;Type annotations&lt;/h2&gt;&lt;ul&gt;&lt;li&gt;&lt;a
+        href=&quot;https://docs.python.org/3.12/whatsnew/3.12.html#pep-695-type-parameter-syntax&quot;&gt;New
+        type annotation syntax&lt;/a&gt;&amp;nbsp;for generic classes (&lt;a href=&quot;https://peps.python.org/pep-0695/&quot;&gt;PEP
+        695&lt;/a&gt;).&lt;/li&gt;&lt;li&gt;&lt;a href=&quot;https://docs.python.org/3.12/whatsnew/3.12.html#pep-698-override-decorator-for-static-typing&quot;&gt;New
+        override decorator&lt;/a&gt;&amp;nbsp;for methods (&lt;a href=&quot;https://peps.python.org/pep-0698&quot;&gt;PEP
+        698&lt;/a&gt;).&lt;/li&gt;&lt;/ul&gt;&lt;h2&gt;&lt;a class=&quot;anchor&quot;
+        href=&quot;https://discuss.python.org/t/python-3-12-4-now-available/55128#deprecations-5&quot;
+        name=&quot;deprecations-5&quot;&gt;&lt;/a&gt;Deprecations&lt;/h2&gt;&lt;ul&gt;&lt;li&gt;The
+        deprecated&amp;nbsp;&lt;code&gt;wstr&lt;/code&gt;&amp;nbsp;and&amp;nbsp;&lt;code&gt;wstr_length&lt;/code&gt;&amp;nbsp;members
+        of the C implementation of unicode objects were removed, per&amp;nbsp;&lt;a
+        href=&quot;https://peps.python.org/pep-0623/&quot;&gt;PEP 623&lt;/a&gt;.&lt;/li&gt;&lt;li&gt;In
+        the&amp;nbsp;&lt;code&gt;unittest&lt;/code&gt;&amp;nbsp;module, a number of
+        long deprecated methods and classes were removed. (They had been deprecated
+        since Python 3.1 or 3.2).&lt;/li&gt;&lt;li&gt;The deprecated&amp;nbsp;&lt;code&gt;smtpd&lt;/code&gt;&amp;nbsp;and&amp;nbsp;&lt;code&gt;distutils&lt;/code&gt;&amp;nbsp;modules
+        have been removed (see&amp;nbsp;&lt;a href=&quot;https://peps.python.org/pep-0594/&quot;&gt;PEP
+        594&lt;/a&gt;&amp;nbsp;and&amp;nbsp;&lt;a href=&quot;https://peps.python.org/pep-0632/&quot;&gt;PEP
+        632&lt;/a&gt;. The&amp;nbsp;&lt;code&gt;setuptools&lt;/code&gt;&amp;nbsp;package
+        continues to provide the&amp;nbsp;&lt;code&gt;distutils&lt;/code&gt;&amp;nbsp;module.&lt;/li&gt;&lt;li&gt;&lt;a
+        href=&quot;https://docs.python.org/3.12/whatsnew/3.12.html#removed&quot;&gt;A
+        number of other old, broken and deprecated functions, classes and methods&lt;/a&gt;&amp;nbsp;have
+        been removed.&lt;/li&gt;&lt;li&gt;Invalid backslash escape sequences in strings
+        now warn with&amp;nbsp;&lt;code&gt;SyntaxWarning&lt;/code&gt;&amp;nbsp;instead
+        of&amp;nbsp;&lt;code&gt;DeprecationWarning&lt;/code&gt;, making them more
+        visible. (They will become syntax errors in the future.)&lt;/li&gt;&lt;li&gt;The
+        internal representation of integers has changed in preparation for performance
+        enhancements. (This should not affect most users as it is an internal detail,
+        but it may cause problems for Cython-generated code.)&lt;/li&gt;&lt;/ul&gt;&lt;p&gt;For
+        more details on the changes to Python 3.12, see&amp;nbsp;&lt;a href=&quot;https://docs.python.org/3.12/whatsnew/3.12.html&quot;&gt;What\u2019s
+        new in Python 3.12&lt;/a&gt;.&lt;/p&gt;&lt;h1&gt;&lt;a class=&quot;anchor&quot;
+        href=&quot;https://discuss.python.org/t/python-3-12-4-now-available/55128#more-resources-6&quot;
+        name=&quot;more-resources-6&quot;&gt;&lt;/a&gt;&amp;nbsp;&lt;/h1&gt;&lt;h1&gt;More
+        resources&lt;/h1&gt;&lt;ul&gt;&lt;li&gt;&lt;a href=&quot;https://docs.python.org/3.12/&quot;&gt;Online
+        Documentation&lt;/a&gt;.&lt;/li&gt;&lt;li&gt;&lt;a href=&quot;https://www.python.org/dev/peps/pep-0693/&quot;&gt;PEP
+        693&lt;/a&gt;, the Python 3.12 Release Schedule.&lt;/li&gt;&lt;li&gt;Report
+        bugs via&amp;nbsp;&lt;a href=&quot;https://github.com/python/cpython/issues&quot;&gt;GitHub
+        Issues&lt;/a&gt;.&lt;/li&gt;&lt;li&gt;&lt;a href=&quot;https://www.python.org/psf/donations/python-dev/&quot;&gt;Help
+        fund Python directly&lt;/a&gt;&amp;nbsp;or&amp;nbsp;&lt;a href=&quot;https://github.com/sponsors/python&quot;&gt;via
+        GitHub Sponsors&lt;/a&gt;, and support&amp;nbsp;&lt;a href=&quot;https://www.python.org/psf/donations/&quot;&gt;the
+        Python community&lt;/a&gt;.&lt;/li&gt;&lt;/ul&gt;&lt;h1&gt;&lt;a class=&quot;anchor&quot;
+        href=&quot;https://discuss.python.org/t/python-3-12-4-now-available/55128#enjoy-the-new-releases-7&quot;
+        name=&quot;enjoy-the-new-releases-7&quot;&gt;&lt;/a&gt;&amp;nbsp;&lt;/h1&gt;&lt;h1&gt;Enjoy
+        the new releases&lt;/h1&gt;&lt;p&gt;Thanks to all of the many volunteers who
+        help make Python Development and these releases possible! Please consider
+        supporting our efforts by volunteering yourself or through organization contributions
+        to the Python Software Foundation.&lt;/p&gt;&lt;p&gt;&lt;br /&gt;&lt;/p&gt;&lt;p&gt;Your
+        release team,&lt;br /&gt;Thomas Wouters&lt;br /&gt;\u0141ukasz Langa&lt;br
+        /&gt;Ned Deily&lt;br /&gt;Steve Dower&lt;/p&gt;</content><link rel='edit'
+        type='application/atom+xml' href='https://www.blogger.com/feeds/3941553907430899163/posts/default/8571898513389757416'/><link
+        rel='self' type='application/atom+xml' href='https://www.blogger.com/feeds/3941553907430899163/posts/default/8571898513389757416'/><link
+        rel='alternate' type='text/html' href='https://pythoninsider.blogspot.com/2024/10/python-3127-released.html'
+        title='Python 3.12.7 released'/><author><name>Thomas Wouters</name><uri>http://www.blogger.com/profile/10346112333332923135</uri><email>noreply@blogger.com</email><gd:image
+        rel='http://schemas.google.com/g/2005#thumbnail' width='16' height='16' src='https://img1.blogblog.com/img/b16-rounded.gif'/></author></entry><entry><id>tag:blogger.com,1999:blog-3941553907430899163.post-6169827174856335099</id><published>2024-10-01T12:29:00.000-04:00</published><updated>2024-10-01T12:29:30.960-04:00</updated><title
+        type='text'>Python 3.13.0 release candidate 3 released</title><content type='html'>&lt;p&gt;I&#39;m
+        pleased to announce the release of Python 3.13&amp;nbsp;&lt;b&gt;release candidate
+        3&lt;/b&gt;&amp;nbsp;(instead of the expected final release).&lt;br /&gt;&lt;br
+        /&gt;&lt;a href=&quot;https://www.python.org/downloads/release/python-3130rc3/&quot;&gt;https://www.python.org/downloads/release/python-3130rc3/&lt;/a&gt;&lt;/p&gt;&lt;p&gt;&amp;nbsp;&lt;/p&gt;&lt;h1&gt;This
+        is the final release candidate of Python 3.13.0&lt;/h1&gt;&lt;p&gt;This release,
+        &lt;b&gt;3.13.0rc3&lt;/b&gt;, is the final release preview (no really) of
+        3.13. This release is expected to become the final 3.13.0 release, barring
+        any critical bugs being discovered. The official release of 3.13.0 is now
+        scheduled for Monday, 2024-10-07.&lt;/p&gt;&lt;p&gt;This extra, unplanned
+        release candidate exists because of a couple of last minute issues, primarily
+        a significant performance regression in specific workloads due to the incremental
+        cyclic garbage collector (introduced in the alpha releases). We decided to
+        roll back the garbage collector change in 3.13 (and continuing work in 3.14
+        to improve it), apply a number of other important bug fixes, and roll out
+        a new release candidate.&lt;/p&gt;&lt;p&gt;There will be &lt;b&gt;no ABI changes&lt;/b&gt;
+        from this point forward in the 3.13 series (and there haven&#39;t been any
+        since the beta releases).&lt;/p&gt;&lt;h3&gt;&lt;a class=&quot;anchor&quot;
+        href=&quot;https://discuss.python.org/t/python-3-13-0-release-candidate-1-released/59703#p-181511-call-to-action-2&quot;
+        name=&quot;p-181511-call-to-action-2&quot;&gt;&lt;/a&gt;Call to action&lt;/h3&gt;&lt;p&gt;We
+        strongly encourage maintainers of Python projects to prepare their projects
+        for 3.13 compatibilities during this phase, and where necessary publish Python
+        3.13 wheels on PyPI to be ready for the final release of 3.13.0. Any binary
+        wheels built against Python 3.13.0rc1 and later&amp;nbsp;&lt;strong&gt;will
+        work&lt;/strong&gt;&amp;nbsp;with future versions of Python 3.13. As always,
+        report any issues to&amp;nbsp;&lt;a href=&quot;https://github.com/python/cpython/issues&quot;&gt;the
+        Python bug tracker&lt;/a&gt;.&lt;/p&gt;&lt;p&gt;Please keep in mind that this
+        is a preview release and while it\u2019s as close to the final release as
+        we can get it, its use is&amp;nbsp;&lt;strong&gt;not&lt;/strong&gt;&amp;nbsp;recommended
+        for production environments.&lt;/p&gt;&lt;h3&gt;&lt;a class=&quot;anchor&quot;
+        href=&quot;https://discuss.python.org/t/python-3-13-0-release-candidate-1-released/59703#p-181511-core-developers-time-to-work-on-documentation-now-3&quot;
+        name=&quot;p-181511-core-developers-time-to-work-on-documentation-now-3&quot;&gt;&lt;/a&gt;Core
+        developers: time to work on documentation now&lt;/h3&gt;&lt;ul&gt;&lt;li&gt;Are
+        all your changes properly documented?&lt;/li&gt;&lt;li&gt;Are they mentioned
+        in&amp;nbsp;&lt;a href=&quot;https://docs.python.org/3.13/whatsnew/3.13.html&quot;&gt;What\u2019s
+        New&lt;/a&gt;?&lt;/li&gt;&lt;li&gt;Did you notice other changes you know of
+        to have insufficient documentation?&lt;/li&gt;&lt;/ul&gt;&lt;h1&gt;&lt;a class=&quot;anchor&quot;
+        href=&quot;https://discuss.python.org/t/python-3-13-0-release-candidate-1-released/59703#p-181511-major-new-features-of-the-313-series-compared-to-312-4&quot;
+        name=&quot;p-181511-major-new-features-of-the-313-series-compared-to-312-4&quot;&gt;&lt;/a&gt;&amp;nbsp;&lt;/h1&gt;&lt;h1&gt;Major
+        new features of the 3.13 series, compared to 3.12&lt;/h1&gt;&lt;p&gt;Some
+        of the new major new features and changes in Python 3.13 are:&lt;/p&gt;&lt;h2&gt;&lt;a
+        class=&quot;anchor&quot; href=&quot;https://discuss.python.org/t/python-3-13-0-release-candidate-1-released/59703#p-181511-new-features-5&quot;
+        name=&quot;p-181511-new-features-5&quot;&gt;&lt;/a&gt;New features&lt;/h2&gt;&lt;ul&gt;&lt;li&gt;A&amp;nbsp;&lt;a
+        href=&quot;https://docs.python.org/3.13/whatsnew/3.13.html#a-better-interactive-interpreter&quot;&gt;new
+        and improved interactive interpreter&lt;/a&gt;, based on&amp;nbsp;&lt;a href=&quot;https://pypy.org&quot;&gt;PyPy&lt;/a&gt;\u2019s,
+        featuring multi-line editing and color support, as well as colorized&amp;nbsp;&lt;a
+        href=&quot;https://docs.python.org/3.13/whatsnew/3.13.html#improved-error-messages&quot;&gt;exception
+        tracebacks&lt;/a&gt;.&lt;/li&gt;&lt;li&gt;An&amp;nbsp;&lt;a href=&quot;https://docs.python.org/3.13/whatsnew/3.13.html#an-experimental-just-in-time-jit-compiler&quot;&gt;&lt;em&gt;experimental&lt;/em&gt;&amp;nbsp;free-threaded
+        build mode&lt;/a&gt;, which disables the Global Interpreter Lock, allowing
+        threads to run more concurrently. The build mode is available as an experimental
+        feature in the Windows and macOS installers as well.&lt;/li&gt;&lt;li&gt;A&amp;nbsp;&lt;a
+        href=&quot;https://docs.python.org/3.13/whatsnew/3.13.html#an-experimental-just-in-time-jit-compiler&quot;&gt;preliminary,&amp;nbsp;&lt;em&gt;experimental&lt;/em&gt;&amp;nbsp;JIT&lt;/a&gt;,
+        providing the ground work for significant performance improvements.&lt;/li&gt;&lt;li&gt;The&amp;nbsp;&lt;code&gt;locals()&lt;/code&gt;&amp;nbsp;builtin
+        function (and its C equivalent) now has&amp;nbsp;&lt;a href=&quot;https://docs.python.org/3.13/whatsnew/3.13.html#defined-mutation-semantics-for-locals&quot;&gt;well-defined
+        semantics when mutating the returned mapping&lt;/a&gt;, which allows debuggers
+        to operate more consistently.&lt;/li&gt;&lt;li&gt;A modified version of&amp;nbsp;&lt;a
+        href=&quot;https://github.com/microsoft/mimalloc&quot;&gt;mimalloc&lt;/a&gt;&amp;nbsp;is
+        now included, optional but enabled by default if supported by the platform,
+        and required for the free-threaded build mode.&lt;/li&gt;&lt;li&gt;Docstrings
+        now have&amp;nbsp;&lt;a href=&quot;https://docs.python.org/3.13/whatsnew/3.13.html#other-language-changes&quot;&gt;their
+        leading indentation stripped&lt;/a&gt;, reducing memory use and the size of
+        .pyc files. (Most tools handling docstrings already strip leading indentation.)&lt;/li&gt;&lt;li&gt;The&amp;nbsp;&lt;a
+        href=&quot;https://docs.python.org/3.13/library/dbm.html&quot;&gt;dbm module&lt;/a&gt;&amp;nbsp;has
+        a new&amp;nbsp;&lt;a href=&quot;https://docs.python.org/3.13/whatsnew/3.13.html#dbm&quot;&gt;dbm.sqlite3
+        backend&lt;/a&gt;&amp;nbsp;that is used by default when creating new files.&lt;/li&gt;&lt;li&gt;The
+        minimum supported macOS version was changed from 10.9 to&amp;nbsp;&lt;strong&gt;10.13
+        (High Sierra)&lt;/strong&gt;. Older macOS versions will not be supported going
+        forward.&lt;/li&gt;&lt;li&gt;WASI is now a&amp;nbsp;&lt;a href=&quot;https://peps.python.org/pep-0011/#tier-2&quot;&gt;Tier
+        2 supported platform&lt;/a&gt;. Emscripten is no longer an&amp;nbsp;&lt;a
+        href=&quot;https://peps.python.org/pep-0011/#no-longer-supported-platforms&quot;&gt;officially
+        supported platform&lt;/a&gt;&amp;nbsp;(but&amp;nbsp;&lt;a href=&quot;https://pyodide.org&quot;&gt;Pyodide&lt;/a&gt;&amp;nbsp;continues
+        to support Emscripten).&lt;/li&gt;&lt;li&gt;iOS is now a&amp;nbsp;&lt;a href=&quot;https://peps.python.org/pep-0730/&quot;&gt;Tier
+        3 supported platform&lt;/a&gt;&lt;/li&gt;&lt;li&gt;Android is now a &lt;a
+        href=&quot;https://peps.python.org/pep-0738/&quot;&gt;Tier 3 supported platform&lt;/a&gt;
+        as well.&lt;/li&gt;&lt;/ul&gt;&lt;h2&gt;&lt;a class=&quot;anchor&quot; href=&quot;https://discuss.python.org/t/python-3-13-0-release-candidate-1-released/59703#p-181511-typing-6&quot;
+        name=&quot;p-181511-typing-6&quot;&gt;&lt;/a&gt;Typing&lt;/h2&gt;&lt;ul&gt;&lt;li&gt;Support
+        for&amp;nbsp;&lt;a href=&quot;https://peps.python.org/pep-0696/&quot;&gt;type
+        defaults in type parameters&lt;/a&gt;.&lt;/li&gt;&lt;li&gt;A&amp;nbsp;&lt;a
+        href=&quot;https://peps.python.org/pep-0742/&quot;&gt;new type narrowing annotation&lt;/a&gt;,&amp;nbsp;&lt;code&gt;typing.TypeIs&lt;/code&gt;.&lt;/li&gt;&lt;li&gt;A
+        new annotation for&amp;nbsp;&lt;a href=&quot;https://peps.python.org/pep-0705/&quot;&gt;read-only
+        items in TypeDicts&lt;/a&gt;.&lt;/li&gt;&lt;li&gt;A new annotation for&amp;nbsp;&lt;a
+        href=&quot;https://peps.python.org/pep-0702&quot;&gt;marking deprecations
+        in the type system&lt;/a&gt;.&lt;/li&gt;&lt;/ul&gt;&lt;h2&gt;&lt;a class=&quot;anchor&quot;
+        href=&quot;https://discuss.python.org/t/python-3-13-0-release-candidate-1-released/59703#p-181511-removals-and-new-deprecations-7&quot;
+        name=&quot;p-181511-removals-and-new-deprecations-7&quot;&gt;&lt;/a&gt;Removals
+        and new deprecations&lt;/h2&gt;&lt;ul&gt;&lt;li&gt;&lt;a href=&quot;https://peps.python.org/pep-0594/&quot;&gt;PEP
+        594 (Removing dead batteries from the standard library)&lt;/a&gt;&amp;nbsp;scheduled
+        removals of many deprecated modules:&amp;nbsp;&lt;code&gt;aifc&lt;/code&gt;,&amp;nbsp;&lt;code&gt;audioop&lt;/code&gt;,&amp;nbsp;&lt;code&gt;chunk&lt;/code&gt;,&amp;nbsp;&lt;code&gt;cgi&lt;/code&gt;,&amp;nbsp;&lt;code&gt;cgitb&lt;/code&gt;,&amp;nbsp;&lt;code&gt;crypt&lt;/code&gt;,&amp;nbsp;&lt;code&gt;imghdr&lt;/code&gt;,&amp;nbsp;&lt;code&gt;mailcap&lt;/code&gt;,&amp;nbsp;&lt;code&gt;msilib&lt;/code&gt;,&amp;nbsp;&lt;code&gt;nis&lt;/code&gt;,&amp;nbsp;&lt;code&gt;nntplib&lt;/code&gt;,&amp;nbsp;&lt;code&gt;ossaudiodev&lt;/code&gt;,&amp;nbsp;&lt;code&gt;pipes&lt;/code&gt;,&amp;nbsp;&lt;code&gt;sndhdr&lt;/code&gt;,&amp;nbsp;&lt;code&gt;spwd&lt;/code&gt;,&amp;nbsp;&lt;code&gt;sunau&lt;/code&gt;,&amp;nbsp;&lt;code&gt;telnetlib&lt;/code&gt;,&amp;nbsp;&lt;code&gt;uu&lt;/code&gt;,&amp;nbsp;&lt;code&gt;xdrlib&lt;/code&gt;,&amp;nbsp;&lt;code&gt;lib2to3&lt;/code&gt;.&lt;/li&gt;&lt;li&gt;&lt;a
+        href=&quot;https://docs.python.org/3.13/whatsnew/3.13.html#removed-modules-and-apis&quot;&gt;Many
+        other removals&lt;/a&gt;&amp;nbsp;of deprecated classes, functions and methods
+        in various standard library modules.&lt;/li&gt;&lt;li&gt;C API&amp;nbsp;&lt;a
+        href=&quot;https://docs.python.org/3.13/whatsnew/3.13.html#removed-c-apis&quot;&gt;removals&lt;/a&gt;&amp;nbsp;and&amp;nbsp;&lt;a
+        href=&quot;https://docs.python.org/3.13/whatsnew/3.13.html#deprecated-c-apis&quot;&gt;deprecations&lt;/a&gt;.
+        (Some removals present in alpha 1 were reverted in alpha 2, as the removals
+        were deemed too disruptive at this time.)&lt;/li&gt;&lt;li&gt;&lt;a href=&quot;https://docs.python.org/3.13/whatsnew/3.13.html#new-deprecations&quot;&gt;New
+        deprecations&lt;/a&gt;, most of which are scheduled for removal from Python
+        3.15 or 3.16.&lt;/li&gt;&lt;/ul&gt;&lt;p&gt;&lt;small&gt;(Hey,&amp;nbsp;&lt;strong&gt;fellow
+        core developer,&lt;/strong&gt;&amp;nbsp;if a feature you find important is
+        missing from this list,&amp;nbsp;&lt;a href=&quot;mailto:thomas@python.org&quot;&gt;let
+        Thomas know&lt;/a&gt;.)&lt;/small&gt;&lt;/p&gt;&lt;p&gt;For more details on
+        the changes to Python 3.13, see&amp;nbsp;&lt;a href=&quot;https://docs.python.org/3.13/whatsnew/3.13.html&quot;&gt;What\u2019s
+        new in Python 3.13&lt;/a&gt;. The next release of Python 3.13 will be the
+        official 3.13.0 release, currently scheduled for Monday, 2024-10-07.&lt;/p&gt;&lt;h1&gt;&lt;a
+        class=&quot;anchor&quot; href=&quot;https://discuss.python.org/t/python-3-13-0-release-candidate-1-released/59703#p-181511-more-resources-8&quot;
+        name=&quot;p-181511-more-resources-8&quot;&gt;&lt;/a&gt;&amp;nbsp;&lt;/h1&gt;&lt;h1&gt;More
+        resources&lt;/h1&gt;&lt;ul&gt;&lt;li&gt;&lt;a href=&quot;https://docs.python.org/3.13/&quot;&gt;Online
+        Documentation&lt;/a&gt;&lt;/li&gt;&lt;li&gt;&lt;a href=&quot;https://peps.python.org/pep-0719/&quot;&gt;PEP
+        719&lt;/a&gt;, 3.13 Release Schedule&lt;/li&gt;&lt;li&gt;Report bugs at&amp;nbsp;&lt;a
+        class=&quot;inline-onebox&quot; href=&quot;https://github.com/python/cpython/issues&quot;&gt;Issues
+        \xB7 python/cpython \xB7 GitHub&lt;/a&gt;.&lt;/li&gt;&lt;li&gt;&lt;a href=&quot;https://www.python.org/psf/donations/python-dev/&quot;&gt;Help
+        fund Python directly&lt;/a&gt;&amp;nbsp;(or&amp;nbsp;&lt;a href=&quot;https://github.com/sponsors/python&quot;&gt;via
+        GitHub Sponsors&lt;/a&gt;), and support&amp;nbsp;&lt;a href=&quot;https://www.python.org/psf/donations/&quot;&gt;the
+        Python community&lt;/a&gt;.&lt;/li&gt;&lt;/ul&gt;&lt;h1&gt;&lt;a class=&quot;anchor&quot;
+        href=&quot;https://discuss.python.org/t/python-3-13-0-release-candidate-1-released/59703#p-181511-enjoy-the-new-releases-9&quot;
+        name=&quot;p-181511-enjoy-the-new-releases-9&quot;&gt;&lt;/a&gt;&amp;nbsp;&lt;/h1&gt;&lt;h1&gt;Enjoy
+        the new releases&lt;/h1&gt;&lt;p&gt;Thanks to all of the many volunteers who
+        help make Python Development and these releases possible! Please consider
+        supporting our efforts by volunteering yourself or through organization contributions
+        to the Python Software Foundation.&lt;/p&gt;&lt;p&gt;Your release team,&lt;/p&gt;&lt;p&gt;Thomas
+        Wouters&lt;br /&gt;\u0141ukasz Langa&lt;br /&gt;Ned Deily&lt;br /&gt;Steve
+        Dower&lt;/p&gt;</content><link rel='edit' type='application/atom+xml' href='https://www.blogger.com/feeds/3941553907430899163/posts/default/6169827174856335099'/><link
+        rel='self' type='application/atom+xml' href='https://www.blogger.com/feeds/3941553907430899163/posts/default/6169827174856335099'/><link
+        rel='alternate' type='text/html' href='https://pythoninsider.blogspot.com/2024/10/python-3130-release-candidate-3-released.html'
+        title='Python 3.13.0 release candidate 3 released'/><author><name>Thomas Wouters</name><uri>http://www.blogger.com/profile/10346112333332923135</uri><email>noreply@blogger.com</email><gd:image
+        rel='http://schemas.google.com/g/2005#thumbnail' width='16' height='16' src='https://img1.blogblog.com/img/b16-rounded.gif'/></author></entry><entry><id>tag:blogger.com,1999:blog-3941553907430899163.post-4161392573311517936</id><published>2024-09-07T10:24:00.004-04:00</published><updated>2024-09-07T10:24:24.543-04:00</updated><title
+        type='text'>Python 3.13.0RC2, 3.12.6, 3.11.10, 3.10.15, 3.9.20, and 3.8.20
+        are now available!</title><content type='html'>&lt;p&gt;Hi there!&lt;br /&gt;\nA
+        big joint release today. Mostly security fixes but we also have the final
+        release candidate of 3.13 so let\u2019s start with that!&lt;/p&gt;\n&lt;h3&gt;Python
+        3.13.0RC2&lt;/h3&gt;\n&lt;p&gt;Final opportunity to test and find any show-stopper
+        bugs before we bless and release 3.13.0 final on October 1st.&lt;/p&gt;\n&lt;p&gt;Get
+        it here: &lt;a class=&quot;inline-onebox&quot; href=&quot;https://www.python.org/downloads/release/python-3130rc2/&quot;
+        tabindex=&quot;-1&quot;&gt;Python Release Python 3.13.0rc2 | Python.org&lt;/a&gt;&lt;/p&gt;\n&lt;h4&gt;Call
+        to action&lt;/h4&gt;\n&lt;p&gt;We strongly encourage maintainers of third-party
+        Python projects to \nprepare their projects for 3.13 compatibilities during
+        this phase, and \nwhere necessary publish Python 3.13 wheels on PyPI to be
+        ready for the \nfinal release of 3.13.0. Any binary wheels built against Python
+        \n3.13.0rc2 will work with future versions of Python 3.13. As always, \nreport
+        any issues to &lt;a href=&quot;https://github.com/python/cpython/issues&quot;
+        tabindex=&quot;-1&quot;&gt;the Python bug tracker&lt;/a&gt;.&lt;/p&gt;\n&lt;p&gt;Please
+        keep in mind that this is a preview release and while it\u2019s as close to
+        the final release as we can get it, its use is &lt;strong&gt;not&lt;/strong&gt;
+        recommended for production environments.&lt;/p&gt;\n&lt;h4&gt;Core developers:
+        time to work on documentation now&lt;/h4&gt;\n&lt;ul&gt;&lt;li&gt;Are all
+        your changes properly documented?&lt;/li&gt;&lt;li&gt;Are they mentioned in
+        &lt;a href=&quot;https://docs.python.org/3.13/whatsnew/3.13.html&quot; tabindex=&quot;-1&quot;&gt;What\u2019s
+        New&lt;/a&gt;?&lt;/li&gt;&lt;li&gt;Did you notice other changes you know of
+        to have insufficient documentation?&lt;/li&gt;&lt;/ul&gt;\n&lt;p&gt;As a reminder,
+        until the final release of 3.13.0, the 3.13 branch is set up so that the Release
+        Manager (&lt;a class=&quot;mention&quot; data-name=&quot;thomas&quot; href=&quot;https://discuss.python.org/u/thomas&quot;
+        tabindex=&quot;-1&quot;&gt;@thomas&lt;/a&gt;) has to merge the changes. Please
+        add him (&lt;code&gt;@Yhg1s&lt;/code&gt;\n on GitHub) to any changes you think
+        should go into 3.13.0. At this \npoint, unless something critical comes up,
+        it should really be &lt;strong&gt;documentation only&lt;/strong&gt;. Other
+        changes (including tests) will be pushed to 3.13.1.&lt;/p&gt;\n&lt;h4&gt;New
+        features in Python 3.13&lt;/h4&gt;\n&lt;ul&gt;&lt;li&gt;A &lt;a href=&quot;https://docs.python.org/3.13/whatsnew/3.13.html#a-better-interactive-interpreter&quot;
+        tabindex=&quot;-1&quot;&gt;new and improved interactive interpreter&lt;/a&gt;,
+        based on &lt;a href=&quot;https://pypy.org&quot; tabindex=&quot;-1&quot;&gt;PyPy&lt;/a&gt;\u2019s,
+        featuring multi-line editing and color support, as well as colorized &lt;a
+        href=&quot;https://docs.python.org/3.13/whatsnew/3.13.html#improved-error-messages&quot;
+        tabindex=&quot;-1&quot;&gt;exception tracebacks&lt;/a&gt;.&lt;/li&gt;&lt;li&gt;An
+        &lt;a href=&quot;https://docs.python.org/3.13/whatsnew/3.13.html#free-threaded-cpython&quot;
+        tabindex=&quot;-1&quot;&gt;&lt;em&gt;experimental&lt;/em&gt; free-threaded
+        build mode&lt;/a&gt;,\n which disables the Global Interpreter Lock, allowing
+        threads to run \nmore concurrently. The build mode is available as an experimental
+        \nfeature in the Windows and macOS installers as well.&lt;/li&gt;&lt;li&gt;A
+        &lt;a href=&quot;https://docs.python.org/3.13/whatsnew/3.13.html#experimental-jit-compiler&quot;
+        tabindex=&quot;-1&quot;&gt;preliminary, &lt;em&gt;experimental&lt;/em&gt;
+        JIT&lt;/a&gt;, providing the ground work for significant performance improvements.&lt;/li&gt;&lt;li&gt;The
+        &lt;code&gt;locals()&lt;/code&gt; builtin function (and its C equivalent)
+        now has &lt;a href=&quot;https://docs.python.org/3.13/whatsnew/3.13.html#defined-mutation-semantics-for-locals&quot;
+        tabindex=&quot;-1&quot;&gt;well-defined semantics when mutating the returned
+        mapping&lt;/a&gt;, which allows debuggers to operate more consistently.&lt;/li&gt;&lt;li&gt;The
+        (cyclic) garbage collector is now &lt;a href=&quot;https://docs.python.org/3.13/whatsnew/3.13.html#incremental-garbage-collection&quot;
+        tabindex=&quot;-1&quot;&gt;incremental&lt;/a&gt;, which should mean shorter
+        pauses for collection in programs with a lot of objects.&lt;/li&gt;&lt;li&gt;A
+        modified version of &lt;a href=&quot;https://github.com/microsoft/mimalloc&quot;
+        tabindex=&quot;-1&quot;&gt;mimalloc&lt;/a&gt; is now included, optional but
+        enabled by default if supported by the platform, and required for the free-threaded
+        build mode.&lt;/li&gt;&lt;li&gt;Docstrings now have &lt;a href=&quot;https://docs.python.org/3.13/whatsnew/3.13.html#other-language-changes&quot;
+        tabindex=&quot;-1&quot;&gt;their leading indentation stripped&lt;/a&gt;, reducing
+        memory use and the size of .pyc files. (Most tools handling docstrings already
+        strip leading indentation.)&lt;/li&gt;&lt;li&gt;The &lt;a href=&quot;https://docs.python.org/3.13/library/dbm.html&quot;
+        tabindex=&quot;-1&quot;&gt;dbm module&lt;/a&gt; has a new &lt;a href=&quot;https://docs.python.org/3.13/whatsnew/3.13.html#dbm&quot;
+        tabindex=&quot;-1&quot;&gt;dbm.sqlite3 backend&lt;/a&gt; that is used by default
+        when creating new files.&lt;/li&gt;&lt;li&gt;The minimum supported macOS version
+        was changed from 10.9 to &lt;strong&gt;10.13 (High Sierra)&lt;/strong&gt;.
+        Older macOS versions will not be supported going forward.&lt;/li&gt;&lt;li&gt;WASI
+        is now a &lt;a href=&quot;https://peps.python.org/pep-0011/#tier-2&quot; tabindex=&quot;-1&quot;&gt;Tier
+        2 supported platform&lt;/a&gt;. Emscripten is no longer an &lt;a href=&quot;https://peps.python.org/pep-0011/#no-longer-supported-platforms&quot;
+        tabindex=&quot;-1&quot;&gt;officially supported platform&lt;/a&gt; (but &lt;a
+        href=&quot;https://pyodide.org&quot; tabindex=&quot;-1&quot;&gt;Pyodide&lt;/a&gt;
+        continues to support Emscripten).&lt;/li&gt;&lt;li&gt;iOS is now a &lt;a href=&quot;https://peps.python.org/pep-0730/&quot;
+        tabindex=&quot;-1&quot;&gt;Tier 3 supported platform&lt;/a&gt;, with &lt;a
+        href=&quot;https://peps.python.org/pep-0738/&quot; tabindex=&quot;-1&quot;&gt;Android
+        on the way as well&lt;/a&gt;.&lt;/li&gt;&lt;/ul&gt;\n&lt;h3&gt;Python 3.12.6&lt;/h3&gt;\n&lt;p&gt;This
+        is an expedited release for 3.12 due to security content. The schedule returns
+        back to regular programming in October.&lt;/p&gt;\n&lt;p&gt;One notable change
+        for macOS users: as mentioned in the previous release of 3.12, this release
+        &lt;strong&gt;drops support for macOS versions 10.9 through 10.12&lt;/strong&gt;.\n
+        Versions of macOS older than 10.13 haven\u2019t been supported by Apple \nsince
+        2019, and maintaining support for them has become too difficult. \n(All versions
+        of Python 3.13 have already dropped support for them.)&lt;/p&gt;\n&lt;p&gt;Get
+        it here: &lt;a class=&quot;inline-onebox&quot; href=&quot;https://www.python.org/downloads/release/python-3126/&quot;
+        tabindex=&quot;-1&quot;&gt;Python Release Python 3.12.6 | Python.org&lt;/a&gt;&lt;/p&gt;\n&lt;p&gt;92
+        commits.&lt;/p&gt;\n&lt;h3&gt;Python 3.11.10&lt;/h3&gt;\n&lt;p&gt;Python 3.11
+        joins the elite club of security-only versions with no binary installers.&lt;/p&gt;\n&lt;p&gt;Get
+        it here: &lt;a class=&quot;inline-onebox&quot; href=&quot;https://www.python.org/downloads/release/python-31110/&quot;
+        tabindex=&quot;-1&quot;&gt;Python Release Python 3.11.10 | Python.org&lt;/a&gt;&lt;/p&gt;\n&lt;p&gt;28
+        commits.&lt;/p&gt;\n&lt;h3&gt;Python 3.10.15&lt;/h3&gt;\n&lt;p&gt;Get it here:
+        &lt;a class=&quot;inline-onebox&quot; href=&quot;https://www.python.org/downloads/release/python-31015/&quot;
+        tabindex=&quot;-1&quot;&gt;Python Release Python 3.10.15 | Python.org&lt;/a&gt;&lt;/p&gt;\n&lt;p&gt;24
+        commits.&lt;/p&gt;\n&lt;h3&gt;Python 3.9.20&lt;/h3&gt;\n&lt;p&gt;Get it here:
+        &lt;a class=&quot;inline-onebox&quot; href=&quot;https://www.python.org/downloads/release/python-3920/&quot;
+        tabindex=&quot;-1&quot;&gt;Python Release Python 3.9.20 | Python.org&lt;/a&gt;&lt;/p&gt;\n&lt;p&gt;22
+        commits.&lt;/p&gt;\n&lt;h3&gt;Python 3.8.20&lt;/h3&gt;\n&lt;p&gt;Python 3.8
+        is very close to End of Life (see &lt;a href=&quot;https://peps.python.org/pep-0569/&quot;
+        tabindex=&quot;-1&quot;&gt;the Release Schedule&lt;/a&gt;). Will this be the
+        last release of 3.8 ever? We\u2019ll see\u2026 but now I think I jinxed it.&lt;/p&gt;\n&lt;p&gt;Get
+        it here: &lt;a class=&quot;inline-onebox&quot; href=&quot;https://www.python.org/downloads/release/python-3820/&quot;
+        tabindex=&quot;-1&quot;&gt;Python Release Python 3.8.20 | Python.org&lt;/a&gt;&lt;/p&gt;\n&lt;p&gt;22
+        commits.&lt;/p&gt;\n&lt;h3&gt;Security content in today\u2019s releases&lt;/h3&gt;\n&lt;ul&gt;&lt;li&gt;&lt;a
+        href=&quot;https://github.com/python/cpython/issues/123678&quot; tabindex=&quot;-1&quot;&gt;gh-123678&lt;/a&gt;
+        and &lt;a href=&quot;https://github.com/python/cpython/issues/116741&quot;
+        tabindex=&quot;-1&quot;&gt;gh-116741&lt;/a&gt;: Upgrade bundled libexpat to
+        2.6.3 to fix &lt;a href=&quot;https://github.com/advisories/GHSA-ch5v-h69f-mxc8&quot;
+        tabindex=&quot;-1&quot;&gt;CVE-2024-28757&lt;/a&gt;, &lt;a href=&quot;https://github.com/advisories/GHSA-4hvh-m426-wv8w&quot;
+        tabindex=&quot;-1&quot;&gt;CVE-2024-45490&lt;/a&gt;, &lt;a href=&quot;https://github.com/advisories/GHSA-784x-7qm2-gp97&quot;
+        tabindex=&quot;-1&quot;&gt;CVE-2024-45491&lt;/a&gt; and &lt;a href=&quot;https://github.com/advisories/GHSA-5qxm-qvmj-8v79&quot;
+        tabindex=&quot;-1&quot;&gt;CVE-2024-45492&lt;/a&gt;.&lt;/li&gt;&lt;li&gt;&lt;a
+        href=&quot;https://github.com/python/cpython/issues/118486&quot; tabindex=&quot;-1&quot;&gt;gh-118486&lt;/a&gt;:
+        &lt;a href=&quot;https://docs.python.org/3/library/os.html#os.mkdir&quot;
+        tabindex=&quot;-1&quot;&gt;&lt;code&gt;os.mkdir()&lt;/code&gt;&lt;/a&gt; on
+        Windows now accepts &lt;em&gt;mode&lt;/em&gt; of &lt;code&gt;0o700&lt;/code&gt;
+        to restrict the new directory to the current user. This fixes CVE-2024-4030
+        affecting &lt;a href=&quot;https://docs.python.org/3/library/tempfile.html#tempfile.mkdtemp&quot;
+        tabindex=&quot;-1&quot;&gt;&lt;code&gt;tempfile.mkdtemp()&lt;/code&gt;&lt;/a&gt;
+        in scenarios where the base temporary directory is more permissive than the
+        default.&lt;/li&gt;&lt;li&gt;&lt;a href=&quot;https://github.com/python/cpython/issues/123067&quot;
+        tabindex=&quot;-1&quot;&gt;gh-123067&lt;/a&gt;: Fix quadratic complexity in
+        parsing &lt;code&gt;&quot;&lt;/code&gt;-quoted cookie values with backslashes
+        by &lt;a href=&quot;https://docs.python.org/3/library/http.cookies.html#module-http.cookies&quot;
+        tabindex=&quot;-1&quot;&gt;&lt;code&gt;http.cookies&lt;/code&gt;&lt;/a&gt;.
+        Fixes CVE-2024-7592.&lt;/li&gt;&lt;li&gt;&lt;a href=&quot;https://github.com/python/cpython/issues/113171&quot;
+        tabindex=&quot;-1&quot;&gt;gh-113171&lt;/a&gt;:\n Fixed various false positives
+        and false negatives in \nIPv4Address.is_private, IPv4Address.is_global, IPv6Address.is_private,
+        \nIPv6Address.is_global. Fixes CVE-2024-4032.&lt;/li&gt;&lt;li&gt;&lt;a href=&quot;https://github.com/python/cpython/issues/67693&quot;
+        tabindex=&quot;-1&quot;&gt;gh-67693&lt;/a&gt;: Fix &lt;a href=&quot;https://docs.python.org/3/library/urllib.parse.html#urllib.parse.urlunparse&quot;
+        tabindex=&quot;-1&quot;&gt;&lt;code&gt;urllib.parse.urlunparse()&lt;/code&gt;&lt;/a&gt;
+        and &lt;a href=&quot;https://docs.python.org/3/library/urllib.parse.html#urllib.parse.urlunsplit&quot;
+        tabindex=&quot;-1&quot;&gt;&lt;code&gt;urllib.parse.urlunsplit()&lt;/code&gt;&lt;/a&gt;
+        for URIs with path starting with multiple slashes and no authority. Fixes
+        CVE-2015-2104.&lt;/li&gt;&lt;li&gt;&lt;a href=&quot;https://github.com/python/cpython/issues/121957&quot;
+        tabindex=&quot;-1&quot;&gt;gh-121957&lt;/a&gt;: Fixed missing audit events
+        around interactive use of Python, now also properly firing for &lt;code&gt;python
+        -i&lt;/code&gt;, as well as for &lt;code&gt;python -m asyncio&lt;/code&gt;.
+        The event in question is &lt;code&gt;cpython.run_stdin&lt;/code&gt;.&lt;/li&gt;&lt;li&gt;&lt;a
+        href=&quot;https://github.com/python/cpython/issues/122133&quot; tabindex=&quot;-1&quot;&gt;gh-122133&lt;/a&gt;:
+        Authenticate the socket connection for the &lt;code&gt;socket.socketpair()&lt;/code&gt;
+        fallback on platforms where &lt;code&gt;AF_UNIX&lt;/code&gt; is not available
+        like Windows.&lt;/li&gt;&lt;li&gt;&lt;a href=&quot;https://github.com/python/cpython/issues/121285&quot;
+        tabindex=&quot;-1&quot;&gt;gh-121285&lt;/a&gt;: Remove backtracking from tarfile
+        header parsing for &lt;code&gt;hdrcharset&lt;/code&gt;, PAX, and GNU sparse
+        headers. That\u2019s CVE-2024-6232.&lt;/li&gt;&lt;li&gt;&lt;a href=&quot;https://github.com/python/cpython/issues/114572&quot;
+        tabindex=&quot;-1&quot;&gt;gh-114572&lt;/a&gt;: &lt;a href=&quot;https://docs.python.org/3/library/ssl.html#ssl.SSLContext.cert_store_stats&quot;
+        tabindex=&quot;-1&quot;&gt;&lt;code&gt;ssl.SSLContext.cert_store_stats()&lt;/code&gt;&lt;/a&gt;
+        and &lt;a href=&quot;https://docs.python.org/3/library/ssl.html#ssl.SSLContext.get_ca_certs&quot;
+        tabindex=&quot;-1&quot;&gt;&lt;code&gt;ssl.SSLContext.get_ca_certs()&lt;/code&gt;&lt;/a&gt;
+        now correctly lock access to the certificate store, when the &lt;a href=&quot;https://docs.python.org/3/library/ssl.html#ssl.SSLContext&quot;
+        tabindex=&quot;-1&quot;&gt;&lt;code&gt;ssl.SSLContext&lt;/code&gt;&lt;/a&gt;
+        is shared across multiple threads.&lt;/li&gt;&lt;li&gt;&lt;a href=&quot;https://github.com/python/cpython/issues/102988&quot;
+        tabindex=&quot;-1&quot;&gt;gh-102988&lt;/a&gt;: &lt;a href=&quot;https://docs.python.org/3/library/email.utils.html#email.utils.getaddresses&quot;
+        tabindex=&quot;-1&quot;&gt;&lt;code&gt;email.utils.getaddresses()&lt;/code&gt;&lt;/a&gt;
+        and &lt;a href=&quot;https://docs.python.org/3/library/email.utils.html#email.utils.parseaddr&quot;
+        tabindex=&quot;-1&quot;&gt;&lt;code&gt;email.utils.parseaddr()&lt;/code&gt;&lt;/a&gt;
+        now return &lt;code&gt;(&#39;&#39;, &#39;&#39;)&lt;/code&gt;\n 2-tuples in
+        more situations where invalid email addresses are \nencountered instead of
+        potentially inaccurate values. Add optional &lt;em&gt;strict&lt;/em&gt; parameter
+        to these two functions: use &lt;code&gt;strict=False&lt;/code&gt; to get the
+        old behavior, accept malformed inputs. &lt;code&gt;getattr(email.utils, &#39;supports_strict_parsing&#39;,
+        False)&lt;/code&gt; can be use to check if the &lt;em&gt;strict&lt;/em&gt;
+        paramater is available. This improves the CVE-2023-27043 fix.&lt;/li&gt;&lt;li&gt;&lt;a
+        href=&quot;https://github.com/python/cpython/issues/123270&quot; tabindex=&quot;-1&quot;&gt;gh-123270&lt;/a&gt;:
+        Sanitize names in &lt;a href=&quot;https://docs.python.org/3/library/zipfile.html#zipfile.Path&quot;
+        tabindex=&quot;-1&quot;&gt;&lt;code&gt;zipfile.Path&lt;/code&gt;&lt;/a&gt;
+        to avoid infinite loops (&lt;a href=&quot;https://github.com/python/cpython/issues/122905&quot;
+        tabindex=&quot;-1&quot;&gt;gh-122905&lt;/a&gt;) without breaking contents
+        using legitimate characters. That\u2019s CVE-2024-8088.&lt;/li&gt;&lt;li&gt;&lt;a
+        href=&quot;https://github.com/python/cpython/issues/121650&quot; tabindex=&quot;-1&quot;&gt;gh-121650&lt;/a&gt;:
+        &lt;a href=&quot;https://docs.python.org/3/library/email.html#module-email&quot;
+        tabindex=&quot;-1&quot;&gt;&lt;code&gt;email&lt;/code&gt;&lt;/a&gt; headers
+        with embedded newlines are now quoted on output. The &lt;a href=&quot;https://docs.python.org/3/library/email.generator.html#module-email.generator&quot;
+        tabindex=&quot;-1&quot;&gt;&lt;code&gt;generator&lt;/code&gt;&lt;/a&gt; will
+        now refuse to serialize (write) headers that are unsafely folded or delimited;
+        see &lt;a href=&quot;https://docs.python.org/3/library/email.policy.html#email.policy.Policy.verify_generated_headers&quot;
+        tabindex=&quot;-1&quot;&gt;&lt;code&gt;verify_generated_headers&lt;/code&gt;&lt;/a&gt;.
+        That\u2019s CVE-2024-6923.&lt;/li&gt;&lt;li&gt;&lt;a href=&quot;https://github.com/python/cpython/issues/119690&quot;
+        tabindex=&quot;-1&quot;&gt;gh-119690&lt;/a&gt;: Fixes data type confusion
+        in audit events raised by &lt;code&gt;_winapi.CreateFile&lt;/code&gt; and
+        &lt;code&gt;_winapi.CreateNamedPipe&lt;/code&gt;.&lt;/li&gt;&lt;li&gt;&lt;a
+        href=&quot;https://github.com/python/cpython/issues/116773&quot; tabindex=&quot;-1&quot;&gt;gh-116773&lt;/a&gt;:
+        Fix instances of &lt;code&gt;&amp;lt;_overlapped.Overlapped object at 0xXXX&amp;gt;
+        still has pending operation at deallocation, the process may crash&lt;/code&gt;.&lt;/li&gt;&lt;li&gt;&lt;a
+        href=&quot;https://github.com/python/cpython/issues/112275&quot; tabindex=&quot;-1&quot;&gt;gh-112275&lt;/a&gt;:
+        A deadlock involving &lt;code&gt;pystate.c&lt;/code&gt;\u2019s &lt;code&gt;HEAD_LOCK&lt;/code&gt;
+        in &lt;code&gt;posixmodule.c&lt;/code&gt; at fork is now fixed.&lt;/li&gt;&lt;/ul&gt;\n&lt;h3&gt;Stay
+        safe and upgrade!&lt;/h3&gt;\n&lt;p&gt;Upgrading is highly recommended to
+        all users of affected versions.&lt;/p&gt;\n&lt;h3&gt;Thank you for your support&lt;/h3&gt;\n&lt;p&gt;Thanks
+        to all of the many volunteers who help make Python Development\n and these
+        releases possible! Please consider supporting our efforts by \nvolunteering
+        yourself or through organization contributions to the \nPython Software Foundation.&lt;/p&gt;&lt;p&gt;\u2013&lt;br
+        /&gt;\n\u0141ukasz Langa &lt;a class=&quot;mention&quot; data-name=&quot;ambv&quot;
+        href=&quot;https://discuss.python.org/u/ambv&quot; tabindex=&quot;-1&quot;&gt;@ambv&lt;/a&gt;&lt;br
+        /&gt;\non behalf of your friendly release team,&lt;/p&gt;\n&lt;p&gt;Ned Deily
+        &lt;a class=&quot;mention&quot; data-name=&quot;nad&quot; href=&quot;https://discuss.python.org/u/nad&quot;
+        tabindex=&quot;-1&quot;&gt;@nad&lt;/a&gt;&lt;br /&gt;\nSteve Dower &lt;a class=&quot;mention&quot;
+        data-name=&quot;steve.dower&quot; href=&quot;https://discuss.python.org/u/steve.dower&quot;
+        tabindex=&quot;-1&quot;&gt;@steve.dower&lt;/a&gt;&lt;br /&gt;\nPablo Galindo
+        Salgado &lt;a class=&quot;mention&quot; data-name=&quot;pablogsal&quot; href=&quot;https://discuss.python.org/u/pablogsal&quot;
+        tabindex=&quot;-1&quot;&gt;@pablogsal&lt;/a&gt;&lt;br /&gt;\n\u0141ukasz Langa
+        &lt;a class=&quot;mention&quot; data-name=&quot;ambv&quot; href=&quot;https://discuss.python.org/u/ambv&quot;
+        tabindex=&quot;-1&quot;&gt;@ambv&lt;/a&gt;&lt;br /&gt;\nThomas Wouters &lt;a
+        class=&quot;mention&quot; data-name=&quot;thomas&quot; href=&quot;https://discuss.python.org/u/thomas&quot;
+        tabindex=&quot;-1&quot;&gt;@thomas&lt;/a&gt;&lt;/p&gt;&lt;p&gt;&amp;nbsp;&lt;/p&gt;&lt;p&gt;&amp;nbsp;&lt;/p&gt;</content><link
+        rel='edit' type='application/atom+xml' href='https://www.blogger.com/feeds/3941553907430899163/posts/default/4161392573311517936'/><link
+        rel='self' type='application/atom+xml' href='https://www.blogger.com/feeds/3941553907430899163/posts/default/4161392573311517936'/><link
+        rel='alternate' type='text/html' href='https://pythoninsider.blogspot.com/2024/09/python-3130rc2-3126-31110-31015-3920.html'
+        title='Python 3.13.0RC2, 3.12.6, 3.11.10, 3.10.15, 3.9.20, and 3.8.20 are
+        now available!'/><author><name>\u0141ukasz Langa</name><uri>http://www.blogger.com/profile/01161413896843370614</uri><email>noreply@blogger.com</email><gd:image
+        rel='http://schemas.google.com/g/2005#thumbnail' width='32' height='32' src='//blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEi0eNJsbYbs-q-tZAExGK4rL3OKqKyufuMWsVc6UZFFpneSdr9AqAnf6XLnJsjHPYfVVZPzRop8XRSJ-V1sibK3GOBRwAjZd6aLwxVgenfucrA2JH9P-0cZRJiVj8YyJHE/s220/llanga1600x1600.jpg'/></author></entry><entry><id>tag:blogger.com,1999:blog-3941553907430899163.post-6730601300082688318</id><published>2024-08-07T09:17:00.001-04:00</published><updated>2024-08-07T09:17:33.273-04:00</updated><title
+        type='text'>Python 3.12.5 released</title><content type='html'>&lt;p&gt;&amp;nbsp;&lt;/p&gt;&lt;p&gt;I&#39;m
+        pleased to announce the release of Python 3.12.5:&lt;br /&gt;&lt;br /&gt;&lt;a
+        href=&quot;https://www.python.org/downloads/release/python-3125/&quot;&gt;https://www.python.org/downloads/release/python-3125/&lt;/a&gt;&lt;br
+        /&gt;&lt;/p&gt;&lt;h1&gt;&amp;nbsp;&lt;/h1&gt;&lt;h1&gt;This is the fifth
+        maintenance release of Python 3.12&lt;/h1&gt;\n&lt;p&gt;Python 3.12 is the
+        &lt;span style=&quot;font-family: inherit;&quot;&gt;newest &lt;/span&gt;major
+        release of the Python programming \nlanguage, and it contains many new features
+        and optimizations. 3.12.5 is\n the latest maintenance release, containing
+        more than 250 bugfixes, \nbuild improvements and documentation changes since
+        3.12.4.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot;font-family: inherit;&quot;&gt;This
+        version of Python 3.12 also comes with pip 24.2 by default. &lt;strong&gt;However,\n
+        due to an incompatibility with older macOS versions, macOS 10.9 through\n
+        10.12 will downgrade their version of pip to 24.1.2 during the \ninstallation
+        process&lt;/strong&gt; (in the Install Certificates step). See the installer
+        ReadMe and &lt;a href=&quot;https://github.com/pypa/pip/issues/12901&quot;&gt;the
+        pip issue on the matter&lt;/a&gt;\n for more information. Versions of macOS
+        older than 10.13 haven\u2019t been \nsupported by Apple since 2019, and maintaining
+        support for them is \nbecoming increasingly difficult. While this release
+        of 3.12 still \nsupports them, &lt;strong&gt;it is likely that we will be
+        forced to drop support for macOS 10.12 and older in a future 3.12 release&lt;/strong&gt;.
+        (Python 3.13 has already dropped support for them.)&lt;/span&gt;&lt;/p&gt;&lt;p&gt;&amp;nbsp;&lt;/p&gt;\n&lt;h1&gt;&lt;a
+        class=&quot;anchor&quot; href=&quot;https://discuss.python.org/t/python-3-12-4-now-available/55128#major-new-features-of-the-312-series-compared-to-311-2&quot;
+        name=&quot;major-new-features-of-the-312-series-compared-to-311-2&quot;&gt;&lt;/a&gt;&amp;nbsp;&lt;/h1&gt;&lt;h1&gt;Major
+        new features of the 3.12 series, compared to 3.11&lt;/h1&gt;\n&lt;h2&gt;&lt;a
+        class=&quot;anchor&quot; href=&quot;https://discuss.python.org/t/python-3-12-4-now-available/55128#new-features-3&quot;
+        name=&quot;new-features-3&quot;&gt;&lt;/a&gt;&amp;nbsp;&lt;/h2&gt;&lt;h2&gt;New
+        features&lt;/h2&gt;\n&lt;ul&gt;&lt;li&gt;&lt;a href=&quot;https://docs.python.org/3.12/whatsnew/3.12.html#pep-701-syntactic-formalization-of-f-strings&quot;&gt;More
+        flexible f-string parsing&lt;/a&gt;, allowing many things previously disallowed
+        (&lt;a href=&quot;https://peps.python.org/pep-0701/&quot;&gt;PEP 701&lt;/a&gt;).&lt;/li&gt;&lt;li&gt;&lt;a
+        href=&quot;https://docs.python.org/3.12/whatsnew/3.12.html#pep-688-making-the-buffer-protocol-accessible-in-python&quot;&gt;Support
+        for the buffer protocol&lt;/a&gt; in Python code (&lt;a href=&quot;https://peps.python.org/pep-0688/&quot;&gt;PEP
+        688&lt;/a&gt;).&lt;/li&gt;&lt;li&gt;&lt;a href=&quot;https://docs.python.org/3.12/whatsnew/3.12.html#pep-669-low-impact-monitoring-for-cpython&quot;&gt;A
+        new debugging/profiling API&lt;/a&gt; (&lt;a href=&quot;https://peps.python.org/pep-0669/&quot;&gt;PEP
+        669&lt;/a&gt;).&lt;/li&gt;&lt;li&gt;&lt;a href=&quot;https://docs.python.org/3.12/whatsnew/3.12.html#pep-684-a-per-interpreter-gil&quot;&gt;Support
+        for isolated subinterpreters&lt;/a&gt; with separate Global Interpreter Locks
+        (&lt;a href=&quot;https://peps.python.org/pep-0684&quot;&gt;PEP 684&lt;/a&gt;).&lt;/li&gt;&lt;li&gt;&lt;a
+        href=&quot;https://docs.python.org/3.12/whatsnew/3.12.html#improved-error-messages&quot;&gt;Even
+        more improved error messages&lt;/a&gt;. More exceptions potentially caused
+        by typos now make suggestions to the user.&lt;/li&gt;&lt;li&gt;&lt;a href=&quot;https://docs.python.org/3.12/howto/perf_profiling.html&quot;&gt;Support
+        for the Linux &lt;code&gt;perf&lt;/code&gt; profiler&lt;/a&gt; to report Python
+        function names in traces.&lt;/li&gt;&lt;li&gt;&lt;a href=&quot;https://docs.python.org/3.12/whatsnew/3.12.html#optimizations&quot;&gt;Many
+        large and small performance improvements&lt;/a&gt; (like &lt;a href=&quot;https://peps.python.org/pep-0709/&quot;&gt;PEP
+        709&lt;/a&gt; and support for the BOLT binary optimizer), delivering an estimated
+        5% overall performance improvement.&lt;/li&gt;&lt;/ul&gt;\n&lt;h2&gt;&lt;a
+        class=&quot;anchor&quot; href=&quot;https://discuss.python.org/t/python-3-12-4-now-available/55128#type-annotations-4&quot;
+        name=&quot;type-annotations-4&quot;&gt;&lt;/a&gt;Type annotations&lt;/h2&gt;\n&lt;ul&gt;&lt;li&gt;&lt;a
+        href=&quot;https://docs.python.org/3.12/whatsnew/3.12.html#pep-695-type-parameter-syntax&quot;&gt;New
+        type annotation syntax&lt;/a&gt; for generic classes (&lt;a href=&quot;https://peps.python.org/pep-0695/&quot;&gt;PEP
+        695&lt;/a&gt;).&lt;/li&gt;&lt;li&gt;&lt;a href=&quot;https://docs.python.org/3.12/whatsnew/3.12.html#pep-698-override-decorator-for-static-typing&quot;&gt;New
+        override decorator&lt;/a&gt; for methods (&lt;a href=&quot;https://peps.python.org/pep-0698&quot;&gt;PEP
+        698&lt;/a&gt;).&lt;/li&gt;&lt;/ul&gt;\n&lt;h2&gt;&lt;a class=&quot;anchor&quot;
+        href=&quot;https://discuss.python.org/t/python-3-12-4-now-available/55128#deprecations-5&quot;
+        name=&quot;deprecations-5&quot;&gt;&lt;/a&gt;Deprecations&lt;/h2&gt;\n&lt;ul&gt;&lt;li&gt;The
+        deprecated &lt;code&gt;wstr&lt;/code&gt; and &lt;code&gt;wstr_length&lt;/code&gt;
+        members of the C implementation of unicode objects were removed, per &lt;a
+        href=&quot;https://peps.python.org/pep-0623/&quot;&gt;PEP 623&lt;/a&gt;.&lt;/li&gt;&lt;li&gt;In
+        the &lt;code&gt;unittest&lt;/code&gt; module, a number of long deprecated
+        methods and classes were removed. (They had been deprecated since Python 3.1
+        or 3.2).&lt;/li&gt;&lt;li&gt;The deprecated &lt;code&gt;smtpd&lt;/code&gt;
+        and &lt;code&gt;distutils&lt;/code&gt; modules have been removed (see &lt;a
+        href=&quot;https://peps.python.org/pep-0594/&quot;&gt;PEP 594&lt;/a&gt; and
+        &lt;a href=&quot;https://peps.python.org/pep-0632/&quot;&gt;PEP 632&lt;/a&gt;.
+        The &lt;code&gt;setuptools&lt;/code&gt; package continues to provide the &lt;code&gt;distutils&lt;/code&gt;
+        module.&lt;/li&gt;&lt;li&gt;&lt;a href=&quot;https://docs.python.org/3.12/whatsnew/3.12.html#removed&quot;&gt;A
+        number of other old, broken and deprecated functions, classes and methods&lt;/a&gt;
+        have been removed.&lt;/li&gt;&lt;li&gt;Invalid backslash escape sequences
+        in strings now warn with &lt;code&gt;SyntaxWarning&lt;/code&gt; instead of
+        &lt;code&gt;DeprecationWarning&lt;/code&gt;, making them more visible. (They
+        will become syntax errors in the future.)&lt;/li&gt;&lt;li&gt;The internal
+        representation of integers has changed in preparation \nfor performance enhancements.
+        (This should not affect most users as it \nis an internal detail, but it may
+        cause problems for Cython-generated \ncode.)&lt;/li&gt;&lt;/ul&gt;\n&lt;p&gt;For
+        more details on the changes to Python 3.12, see &lt;a href=&quot;https://docs.python.org/3.12/whatsnew/3.12.html&quot;&gt;What\u2019s
+        new in Python 3.12&lt;/a&gt;.&lt;/p&gt;\n&lt;h1&gt;&lt;a class=&quot;anchor&quot;
+        href=&quot;https://discuss.python.org/t/python-3-12-4-now-available/55128#more-resources-6&quot;
+        name=&quot;more-resources-6&quot;&gt;&lt;/a&gt;&amp;nbsp;&lt;/h1&gt;&lt;h1&gt;More
+        resources&lt;/h1&gt;\n&lt;ul&gt;&lt;li&gt;&lt;a href=&quot;https://docs.python.org/3.12/&quot;&gt;Online
+        Documentation&lt;/a&gt;.&lt;/li&gt;&lt;li&gt;&lt;a href=&quot;https://www.python.org/dev/peps/pep-0693/&quot;&gt;PEP
+        693&lt;/a&gt;, the Python 3.12 Release Schedule.&lt;/li&gt;&lt;li&gt;Report
+        bugs via &lt;a href=&quot;https://github.com/python/cpython/issues&quot;&gt;GitHub
+        Issues&lt;/a&gt;.&lt;/li&gt;&lt;li&gt;&lt;a href=&quot;https://www.python.org/psf/donations/python-dev/&quot;&gt;Help
+        fund Python directly&lt;/a&gt; or &lt;a href=&quot;https://github.com/sponsors/python&quot;&gt;via
+        GitHub Sponsors&lt;/a&gt;, and support &lt;a href=&quot;https://www.python.org/psf/donations/&quot;&gt;the
+        Python community&lt;/a&gt;.&lt;/li&gt;&lt;/ul&gt;\n&lt;h1&gt;&lt;a class=&quot;anchor&quot;
+        href=&quot;https://discuss.python.org/t/python-3-12-4-now-available/55128#enjoy-the-new-releases-7&quot;
+        name=&quot;enjoy-the-new-releases-7&quot;&gt;&lt;/a&gt;&amp;nbsp;&lt;/h1&gt;&lt;h1&gt;Enjoy
+        the new releases&lt;/h1&gt;\n&lt;p&gt;Thanks to all of the many volunteers
+        who help make Python Development\n and these releases possible! Please consider
+        supporting our efforts by \nvolunteering yourself or through organization
+        contributions to the \nPython Software Foundation.&lt;/p&gt;\n&lt;p&gt;&lt;br
+        /&gt;&lt;/p&gt;\n&lt;p&gt;Your release team,&lt;br /&gt;\nThomas Wouters &lt;br
+        /&gt;\n\u0141ukasz Langa &lt;br /&gt;\nNed Deily &lt;br /&gt;\nSteve Dower
+        &lt;br /&gt;&lt;/p&gt;</content><link rel='edit' type='application/atom+xml'
+        href='https://www.blogger.com/feeds/3941553907430899163/posts/default/6730601300082688318'/><link
+        rel='self' type='application/atom+xml' href='https://www.blogger.com/feeds/3941553907430899163/posts/default/6730601300082688318'/><link
+        rel='alternate' type='text/html' href='https://pythoninsider.blogspot.com/2024/08/python-3125-released.html'
+        title='Python 3.12.5 released'/><author><name>Thomas Wouters</name><uri>http://www.blogger.com/profile/10346112333332923135</uri><email>noreply@blogger.com</email><gd:image
+        rel='http://schemas.google.com/g/2005#thumbnail' width='16' height='16' src='https://img1.blogblog.com/img/b16-rounded.gif'/></author></entry><entry><id>tag:blogger.com,1999:blog-3941553907430899163.post-2154606060497606843</id><published>2024-08-01T05:30:00.001-04:00</published><updated>2024-08-01T05:30:48.185-04:00</updated><title
+        type='text'>Python 3.13.0 release candidate 1 released</title><content type='html'>&lt;p&gt;&amp;nbsp;I&#39;m
+        pleased to announce the release of Python 3.13 &lt;b&gt;release candidate
+        1&lt;/b&gt;.&lt;br /&gt;&lt;br /&gt;&lt;a href=&quot;https://www.python.org/downloads/release/python-3130rc1/&quot;&gt;https://www.python.org/downloads/release/python-3130rc1/&lt;/a&gt;&lt;/p&gt;&lt;p&gt;&amp;nbsp;&lt;/p&gt;&lt;h1&gt;This
+        is the first release candidate of Python 3.13.0&lt;/h1&gt;\n&lt;p&gt;This
+        release, &lt;strong&gt;3.13.0rc1&lt;/strong&gt;, is the penultimate release
+        \npreview. Entering the release candidate phase, only reviewed code \nchanges
+        which are clear bug fixes are allowed between this release \ncandidate and
+        the final release. The second candidate (and the last \nplanned release preview)
+        is scheduled for Tuesday, 2024-09-03, while the\n official release of 3.13.0
+        is scheduled for Tuesday, 2024-10-01.&lt;/p&gt;\n&lt;p&gt;There will be &lt;strong&gt;no
+        ABI changes&lt;/strong&gt; from this point forward in the 3.13 series, and
+        the goal is that there will be as few code changes as possible.&lt;/p&gt;\n&lt;h3
+        style=&quot;text-align: left;&quot;&gt;&lt;a class=&quot;anchor&quot; href=&quot;https://discuss.python.org/t/python-3-13-0-release-candidate-1-released/59703#p-181511-call-to-action-2&quot;
+        name=&quot;p-181511-call-to-action-2&quot;&gt;&lt;/a&gt;Call to action&lt;/h3&gt;\n&lt;p&gt;We
+        strongly encourage maintainers of third-party Python projects to \nprepare
+        their projects for 3.13 compatibilities during this phase, and \nwhere necessary
+        publish Python 3.13 wheels on PyPI to be ready for the \nfinal release of
+        3.13.0. Any binary wheels built against Python \n3.13.0rc1 &lt;strong&gt;will
+        work&lt;/strong&gt; with future versions of Python 3.13. As always, report
+        any issues to &lt;a href=&quot;https://github.com/python/cpython/issues&quot;&gt;the
+        Python bug tracker&lt;/a&gt;.&lt;/p&gt;\n&lt;p&gt;Please keep in mind that
+        this is a preview release and while it\u2019s as close to the final release
+        as we can get it, its use is &lt;strong&gt;not&lt;/strong&gt; recommended
+        for production environments.&lt;/p&gt;\n&lt;h3&gt;&lt;a class=&quot;anchor&quot;
+        href=&quot;https://discuss.python.org/t/python-3-13-0-release-candidate-1-released/59703#p-181511-core-developers-time-to-work-on-documentation-now-3&quot;
+        name=&quot;p-181511-core-developers-time-to-work-on-documentation-now-3&quot;&gt;&lt;/a&gt;Core
+        developers: time to work on documentation now&lt;/h3&gt;\n&lt;ul&gt;&lt;li&gt;Are
+        all your changes properly documented?&lt;/li&gt;&lt;li&gt;Are they mentioned
+        in &lt;a href=&quot;https://docs.python.org/3.13/whatsnew/3.13.html&quot;&gt;What\u2019s
+        New&lt;/a&gt;?&lt;/li&gt;&lt;li&gt;Did you notice other changes you know of
+        to have insufficient documentation?&lt;/li&gt;&lt;/ul&gt;\n&lt;h1&gt;&lt;a
+        class=&quot;anchor&quot; href=&quot;https://discuss.python.org/t/python-3-13-0-release-candidate-1-released/59703#p-181511-major-new-features-of-the-313-series-compared-to-312-4&quot;
+        name=&quot;p-181511-major-new-features-of-the-313-series-compared-to-312-4&quot;&gt;&lt;/a&gt;&amp;nbsp;&lt;/h1&gt;&lt;h1&gt;Major
+        new features of the 3.13 series, compared to 3.12&lt;/h1&gt;\n&lt;p&gt;Some
+        of the new major new features and changes in Python 3.13 are:&lt;/p&gt;\n&lt;h2&gt;&lt;a
+        class=&quot;anchor&quot; href=&quot;https://discuss.python.org/t/python-3-13-0-release-candidate-1-released/59703#p-181511-new-features-5&quot;
+        name=&quot;p-181511-new-features-5&quot;&gt;&lt;/a&gt;New features&lt;/h2&gt;\n&lt;ul&gt;&lt;li&gt;A
+        &lt;a href=&quot;https://docs.python.org/3.13/whatsnew/3.13.html#a-better-interactive-interpreter&quot;&gt;new
+        and improved interactive interpreter&lt;/a&gt;, based on &lt;a href=&quot;https://pypy.org&quot;&gt;PyPy&lt;/a&gt;\u2019s,
+        featuring multi-line editing and color support, as well as colorized &lt;a
+        href=&quot;https://docs.python.org/3.13/whatsnew/3.13.html#improved-error-messages&quot;&gt;exception
+        tracebacks&lt;/a&gt;.&lt;/li&gt;&lt;li&gt;An &lt;a href=&quot;https://docs.python.org/3.13/whatsnew/3.13.html#free-threaded-cpython&quot;&gt;&lt;em&gt;experimental&lt;/em&gt;
+        free-threaded build mode&lt;/a&gt;,\n which disables the Global Interpreter
+        Lock, allowing threads to run \nmore concurrently. The build mode is available
+        as an experimental \nfeature in the Windows and macOS installers as well.&lt;/li&gt;&lt;li&gt;A
+        &lt;a href=&quot;https://docs.python.org/3.13/whatsnew/3.13.html#experimental-jit-compiler&quot;&gt;preliminary,
+        &lt;em&gt;experimental&lt;/em&gt; JIT&lt;/a&gt;, providing the ground work
+        for significant performance improvements.&lt;/li&gt;&lt;li&gt;The &lt;code&gt;locals()&lt;/code&gt;
+        builtin function (and its C equivalent) now has &lt;a href=&quot;https://docs.python.org/3.13/whatsnew/3.13.html#defined-mutation-semantics-for-locals&quot;&gt;well-defined
+        semantics when mutating the returned mapping&lt;/a&gt;, which allows debuggers
+        to operate more consistently.&lt;/li&gt;&lt;li&gt;The (cyclic) garbage collector
+        is now &lt;a href=&quot;https://docs.python.org/3.13/whatsnew/3.13.html#incremental-garbage-collection&quot;&gt;incremental&lt;/a&gt;,
+        which should mean shorter pauses for collection in programs with a lot of
+        objects.&lt;/li&gt;&lt;li&gt;A modified version of &lt;a href=&quot;https://github.com/microsoft/mimalloc&quot;&gt;mimalloc&lt;/a&gt;
+        is now included, optional but enabled by default if supported by the platform,
+        and required for the free-threaded build mode.&lt;/li&gt;&lt;li&gt;Docstrings
+        now have &lt;a href=&quot;https://docs.python.org/3.13/whatsnew/3.13.html#other-language-changes&quot;&gt;their
+        leading indentation stripped&lt;/a&gt;, reducing memory use and the size of
+        .pyc files. (Most tools handling docstrings already strip leading indentation.)&lt;/li&gt;&lt;li&gt;The
+        &lt;a href=&quot;https://docs.python.org/3.13/library/dbm.html&quot;&gt;dbm
+        module&lt;/a&gt; has a new &lt;a href=&quot;https://docs.python.org/3.13/whatsnew/3.13.html#dbm&quot;&gt;dbm.sqlite3
+        backend&lt;/a&gt; that is used by default when creating new files.&lt;/li&gt;&lt;li&gt;The
+        minimum supported macOS version was changed from 10.9 to &lt;strong&gt;10.13
+        (High Sierra)&lt;/strong&gt;. Older macOS versions will not be supported going
+        forward.&lt;/li&gt;&lt;li&gt;WASI is now a &lt;a href=&quot;https://peps.python.org/pep-0011/#tier-2&quot;&gt;Tier
+        2 supported platform&lt;/a&gt;. Emscripten is no longer an &lt;a href=&quot;https://peps.python.org/pep-0011/#no-longer-supported-platforms&quot;&gt;officially
+        supported platform&lt;/a&gt; (but &lt;a href=&quot;https://pyodide.org&quot;&gt;Pyodide&lt;/a&gt;
+        continues to support Emscripten).&lt;/li&gt;&lt;li&gt;iOS is now a &lt;a href=&quot;https://peps.python.org/pep-0730/&quot;&gt;Tier
+        3 supported platform&lt;/a&gt;, with &lt;a href=&quot;https://peps.python.org/pep-0738/&quot;&gt;Android
+        on the way as well&lt;/a&gt;.&lt;/li&gt;&lt;/ul&gt;\n&lt;h2&gt;&lt;a class=&quot;anchor&quot;
+        href=&quot;https://discuss.python.org/t/python-3-13-0-release-candidate-1-released/59703#p-181511-typing-6&quot;
+        name=&quot;p-181511-typing-6&quot;&gt;&lt;/a&gt;Typing&lt;/h2&gt;\n&lt;ul&gt;&lt;li&gt;Support
+        for &lt;a href=&quot;https://peps.python.org/pep-0696/&quot;&gt;type defaults
+        in type parameters&lt;/a&gt;.&lt;/li&gt;&lt;li&gt;A &lt;a href=&quot;https://peps.python.org/pep-0742/&quot;&gt;new
+        type narrowing annotation&lt;/a&gt;, &lt;code&gt;typing.TypeIs&lt;/code&gt;.&lt;/li&gt;&lt;li&gt;A
+        new annotation for &lt;a href=&quot;https://peps.python.org/pep-0705/&quot;&gt;read-only
+        items in TypeDicts&lt;/a&gt;.&lt;/li&gt;&lt;li&gt;A new annotation for &lt;a
+        href=&quot;https://peps.python.org/pep-0702&quot;&gt;marking deprecations
+        in the type system&lt;/a&gt;.&lt;/li&gt;&lt;/ul&gt;\n&lt;h2&gt;&lt;a class=&quot;anchor&quot;
+        href=&quot;https://discuss.python.org/t/python-3-13-0-release-candidate-1-released/59703#p-181511-removals-and-new-deprecations-7&quot;
+        name=&quot;p-181511-removals-and-new-deprecations-7&quot;&gt;&lt;/a&gt;Removals
+        and new deprecations&lt;/h2&gt;\n&lt;ul&gt;&lt;li&gt;&lt;a href=&quot;https://peps.python.org/pep-0594/&quot;&gt;PEP
+        594 (Removing dead batteries from the standard library)&lt;/a&gt; scheduled
+        removals of many deprecated modules: &lt;code&gt;aifc&lt;/code&gt;, &lt;code&gt;audioop&lt;/code&gt;,
+        &lt;code&gt;chunk&lt;/code&gt;, &lt;code&gt;cgi&lt;/code&gt;, &lt;code&gt;cgitb&lt;/code&gt;,
+        &lt;code&gt;crypt&lt;/code&gt;, &lt;code&gt;imghdr&lt;/code&gt;, &lt;code&gt;mailcap&lt;/code&gt;,
+        &lt;code&gt;msilib&lt;/code&gt;, &lt;code&gt;nis&lt;/code&gt;, &lt;code&gt;nntplib&lt;/code&gt;,
+        &lt;code&gt;ossaudiodev&lt;/code&gt;, &lt;code&gt;pipes&lt;/code&gt;, &lt;code&gt;sndhdr&lt;/code&gt;,
+        &lt;code&gt;spwd&lt;/code&gt;, &lt;code&gt;sunau&lt;/code&gt;, &lt;code&gt;telnetlib&lt;/code&gt;,
+        &lt;code&gt;uu&lt;/code&gt;, &lt;code&gt;xdrlib&lt;/code&gt;, &lt;code&gt;lib2to3&lt;/code&gt;.&lt;/li&gt;&lt;li&gt;&lt;a
+        href=&quot;https://docs.python.org/3.13/whatsnew/3.13.html#removed&quot;&gt;Many
+        other removals&lt;/a&gt; of deprecated classes, functions and methods in various
+        standard library modules.&lt;/li&gt;&lt;li&gt;C API &lt;a href=&quot;https://docs.python.org/3.13/whatsnew/3.13.html#id10&quot;&gt;removals&lt;/a&gt;
+        and &lt;a href=&quot;https://docs.python.org/3.13/whatsnew/3.13.html#id9&quot;&gt;deprecations&lt;/a&gt;.
+        (Some removals present in alpha 1 were reverted in alpha 2, as the removals
+        were deemed too disruptive at this time.)&lt;/li&gt;&lt;li&gt;&lt;a href=&quot;https://docs.python.org/3.13/whatsnew/3.13.html#deprecated&quot;&gt;New
+        deprecations&lt;/a&gt;, most of which are scheduled for removal from Python
+        3.15 or 3.16.&lt;/li&gt;&lt;/ul&gt;\n&lt;p&gt;&lt;small&gt;(Hey, &lt;strong&gt;fellow
+        core developer,&lt;/strong&gt; if a feature you find important is missing
+        from this list, &lt;a href=&quot;mailto:thomas@python.org&quot;&gt;let Thomas
+        know&lt;/a&gt;.)&lt;/small&gt;&lt;/p&gt;\n&lt;p&gt;For more details on the
+        changes to Python 3.13, see &lt;a href=&quot;https://docs.python.org/3.13/whatsnew/3.13.html&quot;&gt;What\u2019s
+        new in Python 3.13&lt;/a&gt;. The next pre-release of Python 3.13 will be
+        3.13.0rc2, &lt;strong&gt;the final release candidate&lt;/strong&gt;, currently
+        scheduled for 2024-09-03.&lt;/p&gt;\n&lt;h1&gt;&lt;a class=&quot;anchor&quot;
+        href=&quot;https://discuss.python.org/t/python-3-13-0-release-candidate-1-released/59703#p-181511-more-resources-8&quot;
+        name=&quot;p-181511-more-resources-8&quot;&gt;&lt;/a&gt;&amp;nbsp;&lt;/h1&gt;&lt;h1&gt;More
+        resources&lt;/h1&gt;\n&lt;ul&gt;&lt;li&gt;&lt;a href=&quot;https://docs.python.org/3.13/&quot;&gt;Online
+        Documentation&lt;/a&gt;&lt;/li&gt;&lt;li&gt;&lt;a href=&quot;https://peps.python.org/pep-0719/&quot;&gt;PEP
+        719&lt;/a&gt;, 3.13 Release Schedule&lt;/li&gt;&lt;li&gt;Report bugs at &lt;a
+        class=&quot;inline-onebox&quot; href=&quot;https://github.com/python/cpython/issues&quot;&gt;Issues
+        \xB7 python/cpython \xB7 GitHub&lt;/a&gt;.&lt;/li&gt;&lt;li&gt;&lt;a href=&quot;https://www.python.org/psf/donations/python-dev/&quot;&gt;Help
+        fund Python directly&lt;/a&gt; (or &lt;a href=&quot;https://github.com/sponsors/python&quot;&gt;via
+        GitHub Sponsors&lt;/a&gt;), and support &lt;a href=&quot;https://www.python.org/psf/donations/&quot;&gt;the
+        Python community&lt;/a&gt;.&lt;/li&gt;&lt;/ul&gt;\n&lt;h1&gt;&lt;a class=&quot;anchor&quot;
+        href=&quot;https://discuss.python.org/t/python-3-13-0-release-candidate-1-released/59703#p-181511-enjoy-the-new-releases-9&quot;
+        name=&quot;p-181511-enjoy-the-new-releases-9&quot;&gt;&lt;/a&gt;&amp;nbsp;&lt;/h1&gt;&lt;h1&gt;Enjoy
+        the new releases&lt;/h1&gt;\n&lt;p&gt;Thanks to all of the many volunteers
+        who help make Python Development\n and these releases possible! Please consider
+        supporting our efforts by \nvolunteering yourself or through organization
+        contributions to the \nPython Software Foundation.&lt;/p&gt;\n&lt;p&gt;Whatevs,&lt;/p&gt;\n&lt;p&gt;Your
+        release team,&lt;br /&gt;\nThomas Wouters &lt;br /&gt;\n\u0141ukasz Langa
+        &lt;br /&gt;\nNed Deily &lt;br /&gt;\nSteve Dower &lt;br /&gt;&lt;/p&gt;</content><link
+        rel='edit' type='application/atom+xml' href='https://www.blogger.com/feeds/3941553907430899163/posts/default/2154606060497606843'/><link
+        rel='self' type='application/atom+xml' href='https://www.blogger.com/feeds/3941553907430899163/posts/default/2154606060497606843'/><link
+        rel='alternate' type='text/html' href='https://pythoninsider.blogspot.com/2024/08/python-3130-release-candidate-1-released.html'
+        title='Python 3.13.0 release candidate 1 released'/><author><name>Thomas Wouters</name><uri>http://www.blogger.com/profile/10346112333332923135</uri><email>noreply@blogger.com</email><gd:image
+        rel='http://schemas.google.com/g/2005#thumbnail' width='16' height='16' src='https://img1.blogblog.com/img/b16-rounded.gif'/></author></entry><entry><id>tag:blogger.com,1999:blog-3941553907430899163.post-1010897847880281507</id><published>2024-07-18T10:16:00.003-04:00</published><updated>2024-07-18T10:16:44.900-04:00</updated><title
+        type='text'>Python 3.13.0 beta 4 released</title><content type='html'>&lt;p&gt;I&#39;m
+        pleased to announce the release of Python 3.13 beta 4.&lt;br /&gt;&lt;br /&gt;&lt;a
+        href=&quot;https://www.python.org/downloads/release/python-3130b4/&quot;&gt;https://www.python.org/downloads/release/python-3130b4/&lt;/a&gt;&lt;/p&gt;\n\n&lt;h1
+        style=&quot;text-align: left;&quot;&gt;&lt;span style=&quot;font-family: inherit;&quot;&gt;&amp;nbsp;&lt;/span&gt;&lt;/h1&gt;&lt;h1
+        style=&quot;text-align: left;&quot;&gt;&lt;span style=&quot;font-family: inherit;&quot;&gt;This
+        is a beta preview of Python 3.13&lt;/span&gt;&lt;/h1&gt;\n&lt;p&gt;Python
+        3.13 is still in development.  This release, 3.13.0b4, is the &lt;strong&gt;final&lt;/strong&gt;
+        beta release preview of 3.13.&lt;/p&gt;\n&lt;p&gt;Beta release previews are
+        intended to give the wider community the \nopportunity to test new features
+        and bug fixes and to prepare their \nprojects to support the new feature release.&lt;/p&gt;\n&lt;p&gt;We
+        &lt;strong&gt;strongly encourage&lt;/strong&gt; maintainers of third-party
+        Python projects to &lt;strong&gt;test with 3.13&lt;/strong&gt; during the
+        beta phase and report issues found to &lt;a href=&quot;https://github.com/python/cpython/issues&quot;&gt;the
+        Python bug tracker&lt;/a&gt;\n as soon as possible.  While the release is
+        planned to be feature \ncomplete entering the beta phase, it is possible that
+        features may be \nmodified or, in rare cases, deleted up until the start of
+        the release \ncandidate phase (Tuesday 2024-07-30).  Our goal is to have &lt;strong&gt;no
+        ABI changes&lt;/strong&gt;\n after this final beta release, and as few code
+        changes as possible \nafter 3.13.0rc1, the first release candidate.  To achieve
+        that, it will \nbe &lt;strong&gt;extremely important&lt;/strong&gt; to get
+        as much exposure for 3.13 as possible during the beta phase.&lt;/p&gt;\n&lt;p&gt;Please
+        keep in mind that this is a preview release and its use is &lt;strong&gt;not&lt;/strong&gt;
+        recommended for production environments.&lt;/p&gt;\n&lt;h1&gt;&lt;a class=&quot;anchor&quot;
+        href=&quot;https://discuss.python.org/t/python-3-13-0b4-now-available/58565#major-new-features-of-the-313-series-compared-to-312-1&quot;
+        name=&quot;major-new-features-of-the-313-series-compared-to-312-1&quot;&gt;&lt;/a&gt;&amp;nbsp;&lt;/h1&gt;&lt;h1&gt;Major
+        new features of the 3.13 series, compared to 3.12&lt;/h1&gt;\n&lt;p&gt;Some
+        of the new major new features and changes in Python 3.13 are:&lt;/p&gt;\n&lt;h2&gt;&lt;a
+        class=&quot;anchor&quot; href=&quot;https://discuss.python.org/t/python-3-13-0b4-now-available/58565#new-features-2&quot;
+        name=&quot;new-features-2&quot;&gt;&lt;/a&gt;New features&lt;/h2&gt;\n&lt;ul&gt;&lt;li&gt;A
+        &lt;a href=&quot;https://docs.python.org/3.13/whatsnew/3.13.html#a-better-interactive-interpreter&quot;&gt;new
+        and improved interactive interpreter&lt;/a&gt;, based on &lt;a href=&quot;https://pypy.org&quot;&gt;PyPy&lt;/a&gt;\u2019s,
+        featuring multi-line editing and color support, as well as colorized &lt;a
+        href=&quot;https://docs.python.org/3.13/whatsnew/3.13.html#improved-error-messages&quot;&gt;exception
+        tracebacks&lt;/a&gt;.&lt;/li&gt;&lt;li&gt;An &lt;a href=&quot;https://docs.python.org/3.13/whatsnew/3.13.html#free-threaded-cpython&quot;&gt;&lt;em&gt;experimental&lt;/em&gt;
+        free-threaded build mode&lt;/a&gt;,\n which disables the Global Interpreter
+        Lock, allowing threads to run \nmore concurrently. The build mode is available
+        as an experimental \nfeature in the Windows and macOS installers as well.&lt;/li&gt;&lt;li&gt;A
+        &lt;a href=&quot;https://docs.python.org/3.13/whatsnew/3.13.html#experimental-jit-compiler&quot;&gt;preliminary,
+        &lt;em&gt;experimental&lt;/em&gt; JIT&lt;/a&gt;, providing the ground work
+        for significant performance improvements.&lt;/li&gt;&lt;li&gt;The &lt;code&gt;locals()&lt;/code&gt;
+        builtin function (and its C equivalent) now has &lt;a href=&quot;https://docs.python.org/3.13/whatsnew/3.13.html#defined-mutation-semantics-for-locals&quot;&gt;well-defined
+        semantics when mutating the returned mapping&lt;/a&gt;, which allows debuggers
+        to operate more consistently.&lt;/li&gt;&lt;li&gt;The (cyclic) garbage collector
+        is now &lt;a href=&quot;https://docs.python.org/3.13/whatsnew/3.13.html#incremental-garbage-collection&quot;&gt;incremental&lt;/a&gt;,
+        which should mean shorter pauses for collection in programs with a lot of
+        objects.&lt;/li&gt;&lt;li&gt;A modified version of &lt;a href=&quot;https://github.com/microsoft/mimalloc&quot;&gt;mimalloc&lt;/a&gt;
+        is now included, optional but enabled by default if supported by the platform,
+        and required for the free-threaded build mode.&lt;/li&gt;&lt;li&gt;Docstrings
+        now have &lt;a href=&quot;https://docs.python.org/3.13/whatsnew/3.13.html#other-language-changes&quot;&gt;their
+        leading indentation stripped&lt;/a&gt;, reducing memory use and the size of
+        .pyc files. (Most tools handling docstrings already strip leading indentation.)&lt;/li&gt;&lt;li&gt;The
+        &lt;a href=&quot;https://docs.python.org/3.13/library/dbm.html&quot;&gt;dbm
+        module&lt;/a&gt; has a new &lt;a href=&quot;https://docs.python.org/3.13/whatsnew/3.13.html#dbm&quot;&gt;dbm.sqlite3
+        backend&lt;/a&gt; that is used by default when creating new files.&lt;/li&gt;&lt;li&gt;The
+        minimum supported macOS version was changed from 10.9 to &lt;strong&gt;10.13
+        (High Sierra)&lt;/strong&gt;. Older macOS versions will not be supported going
+        forward.&lt;/li&gt;&lt;li&gt;WASI is now a &lt;a href=&quot;https://peps.python.org/pep-0011/#tier-2&quot;&gt;Tier
+        2 supported platform&lt;/a&gt;. Emscripten is no longer an &lt;a href=&quot;https://peps.python.org/pep-0011/#no-longer-supported-platforms&quot;&gt;officially
+        supported platform&lt;/a&gt; (but &lt;a href=&quot;https://pyodide.org&quot;&gt;Pyodide&lt;/a&gt;
+        continues to support Emscripten).&lt;/li&gt;&lt;/ul&gt;\n&lt;h2&gt;&lt;a class=&quot;anchor&quot;
+        href=&quot;https://discuss.python.org/t/python-3-13-0b4-now-available/58565#typing-3&quot;
+        name=&quot;typing-3&quot;&gt;&lt;/a&gt;Typing&lt;/h2&gt;\n&lt;ul&gt;&lt;li&gt;Support
+        for &lt;a href=&quot;https://peps.python.org/pep-0696/&quot;&gt;type defaults
+        in type parameters&lt;/a&gt;.&lt;/li&gt;&lt;li&gt;A &lt;a href=&quot;https://peps.python.org/pep-0742/&quot;&gt;new
+        type narrowing annotation&lt;/a&gt;, &lt;code&gt;typing.TypeIs&lt;/code&gt;.&lt;/li&gt;&lt;li&gt;A
+        new annotation for &lt;a href=&quot;https://peps.python.org/pep-0705/&quot;&gt;read-only
+        items in TypeDicts&lt;/a&gt;.&lt;/li&gt;&lt;li&gt;A new annotation for &lt;a
+        href=&quot;https://peps.python.org/pep-0702&quot;&gt;marking deprecations
+        in the type system&lt;/a&gt;.&lt;/li&gt;&lt;/ul&gt;\n&lt;h2&gt;&lt;a class=&quot;anchor&quot;
+        href=&quot;https://discuss.python.org/t/python-3-13-0b4-now-available/58565#removals-and-new-deprecations-4&quot;
+        name=&quot;removals-and-new-deprecations-4&quot;&gt;&lt;/a&gt;Removals and
+        new deprecations&lt;/h2&gt;\n&lt;ul&gt;&lt;li&gt;&lt;a href=&quot;https://peps.python.org/pep-0594/&quot;&gt;PEP
+        594 (Removing dead batteries from the standard library)&lt;/a&gt; scheduled
+        removals of many deprecated modules: &lt;code&gt;aifc&lt;/code&gt;, &lt;code&gt;audioop&lt;/code&gt;,
+        &lt;code&gt;chunk&lt;/code&gt;, &lt;code&gt;cgi&lt;/code&gt;, &lt;code&gt;cgitb&lt;/code&gt;,
+        &lt;code&gt;crypt&lt;/code&gt;, &lt;code&gt;imghdr&lt;/code&gt;, &lt;code&gt;mailcap&lt;/code&gt;,
+        &lt;code&gt;msilib&lt;/code&gt;, &lt;code&gt;nis&lt;/code&gt;, &lt;code&gt;nntplib&lt;/code&gt;,
+        &lt;code&gt;ossaudiodev&lt;/code&gt;, &lt;code&gt;pipes&lt;/code&gt;, &lt;code&gt;sndhdr&lt;/code&gt;,
+        &lt;code&gt;spwd&lt;/code&gt;, &lt;code&gt;sunau&lt;/code&gt;, &lt;code&gt;telnetlib&lt;/code&gt;,
+        &lt;code&gt;uu&lt;/code&gt;, &lt;code&gt;xdrlib&lt;/code&gt;, &lt;code&gt;lib2to3&lt;/code&gt;.&lt;/li&gt;&lt;li&gt;&lt;a
+        href=&quot;https://docs.python.org/3.13/whatsnew/3.13.html#removed&quot;&gt;Many
+        other removals&lt;/a&gt; of deprecated classes, functions and methods in various
+        standard library modules.&lt;/li&gt;&lt;li&gt;C API &lt;a href=&quot;https://docs.python.org/3.13/whatsnew/3.13.html#id10&quot;&gt;removals&lt;/a&gt;
+        and &lt;a href=&quot;https://docs.python.org/3.13/whatsnew/3.13.html#id9&quot;&gt;deprecations&lt;/a&gt;.
+        \ (Some removals present in alpha 1 were reverted in alpha 2, as the removals
+        were deemed too disruptive at this time.)&lt;/li&gt;&lt;li&gt;&lt;a href=&quot;https://docs.python.org/3.13/whatsnew/3.13.html#deprecated&quot;&gt;New
+        deprecations&lt;/a&gt;, most of which are scheduled for removal from Python
+        3.15 or 3.16.&lt;/li&gt;&lt;/ul&gt;\n&lt;p&gt;&lt;small&gt;(Hey, &lt;strong&gt;fellow
+        core developer,&lt;/strong&gt; if a feature you find important is missing
+        from this list, &lt;a href=&quot;mailto:thomas@python.org&quot;&gt;let Thomas
+        know&lt;/a&gt;.)&lt;/small&gt;&lt;/p&gt;\n&lt;p&gt;For more details on the
+        changes to Python 3.13, see &lt;a href=&quot;https://docs.python.org/3.13/whatsnew/3.13.html&quot;&gt;What\u2019s
+        new in Python 3.13&lt;/a&gt;. The next pre-release of Python 3.13 will be
+        3.13.0rc1, &lt;strong&gt;the first release candidate&lt;/strong&gt;, currently
+        scheduled for 2024-07-30.&lt;/p&gt;\n&lt;h1&gt;&lt;a class=&quot;anchor&quot;
+        href=&quot;https://discuss.python.org/t/python-3-13-0b4-now-available/58565#more-resources-5&quot;
+        name=&quot;more-resources-5&quot;&gt;&lt;/a&gt;&amp;nbsp;&lt;/h1&gt;&lt;h1&gt;More
+        resources&lt;/h1&gt;\n&lt;ul&gt;&lt;li&gt;&lt;a href=&quot;https://docs.python.org/3.13/&quot;&gt;Online
+        Documentation&lt;/a&gt;&lt;/li&gt;&lt;li&gt;&lt;a href=&quot;https://peps.python.org/pep-0719/&quot;&gt;PEP
+        719&lt;/a&gt;, 3.13 Release Schedule&lt;/li&gt;&lt;li&gt;Report bugs at &lt;a
+        href=&quot;https://github.com/python/cpython/issues&quot;&gt;https://github.com/python/cpython/issues&lt;/a&gt;.&lt;/li&gt;&lt;li&gt;&lt;a
+        href=&quot;https://www.python.org/psf/donations/python-dev/&quot;&gt;Help
+        fund Python directly&lt;/a&gt; (or &lt;a href=&quot;https://github.com/sponsors/python&quot;&gt;via
+        GitHub Sponsors&lt;/a&gt;), and support &lt;a href=&quot;https://www.python.org/psf/donations/&quot;&gt;the
+        Python community&lt;/a&gt;.&lt;/li&gt;&lt;/ul&gt;\n&lt;h1&gt;&lt;a class=&quot;anchor&quot;
+        href=&quot;https://discuss.python.org/t/python-3-13-0b4-now-available/58565#enjoy-the-new-releases-6&quot;
+        name=&quot;enjoy-the-new-releases-6&quot;&gt;&lt;/a&gt;&amp;nbsp;&lt;/h1&gt;&lt;h1&gt;Enjoy
+        the new releases&lt;/h1&gt;\n&lt;p&gt;Thanks to all of the many volunteers
+        who help make Python Development\n and these releases possible! Please consider
+        supporting our efforts by \nvolunteering yourself or through organization
+        contributions to the \nPython Software Foundation.&lt;/p&gt;&lt;p&gt;&amp;nbsp;&lt;/p&gt;&lt;p&gt;Your
+        release team,&lt;br /&gt;Thomas Wouters&lt;br /&gt;\u0141ukasz Langa&lt;br
+        /&gt;Ned Deily&lt;br /&gt;Steve Dower&amp;nbsp; &lt;br /&gt;&lt;/p&gt;</content><link
+        rel='edit' type='application/atom+xml' href='https://www.blogger.com/feeds/3941553907430899163/posts/default/1010897847880281507'/><link
+        rel='self' type='application/atom+xml' href='https://www.blogger.com/feeds/3941553907430899163/posts/default/1010897847880281507'/><link
+        rel='alternate' type='text/html' href='https://pythoninsider.blogspot.com/2024/07/python-3130-beta-4-released.html'
+        title='Python 3.13.0 beta 4 released'/><author><name>Thomas Wouters</name><uri>http://www.blogger.com/profile/10346112333332923135</uri><email>noreply@blogger.com</email><gd:image
+        rel='http://schemas.google.com/g/2005#thumbnail' width='16' height='16' src='https://img1.blogblog.com/img/b16-rounded.gif'/></author></entry><entry><id>tag:blogger.com,1999:blog-3941553907430899163.post-7085913750996158792</id><published>2024-06-27T15:57:00.001-04:00</published><updated>2024-06-27T15:57:26.030-04:00</updated><title
+        type='text'>Python 3.13.0 beta 3 released</title><content type='html'>&lt;p&gt;&amp;nbsp;&lt;/p&gt;&lt;p&gt;I&#39;m
+        pleased to announce the release of Python 3.13 beta 3.&lt;br /&gt;&lt;br /&gt;&lt;a
+        href=&quot;https://www.python.org/downloads/release/python-3130b3/&quot;&gt;https://www.python.org/downloads/release/python-3130b3/&lt;/a&gt;&lt;/p&gt;&lt;p&gt;&amp;nbsp;&lt;/p&gt;&lt;h1
+        style=&quot;text-align: left;&quot;&gt;This is a beta preview of Python 3.13&lt;/h1&gt;\n&lt;p&gt;Python
+        3.13 is still in development.  This release, 3.13.0b3, is the third of four
+        beta release previews of 3.13.&lt;/p&gt;&lt;p&gt;&lt;/p&gt;\n&lt;p&gt;Beta
+        release previews are intended to give the wider community the \nopportunity
+        to test new features and bug fixes and to prepare their \nprojects to support
+        the new feature release.&lt;/p&gt;\n&lt;p&gt;We &lt;b&gt;strongly encourage&lt;/b&gt;
+        maintainers of third-party Python projects to &lt;b&gt;test with 3.13&lt;/b&gt;
+        during the beta phase and report issues found to &lt;a href=&quot;https://github.com/python/cpython/issues&quot;&gt;the
+        Python bug tracker &lt;/a&gt;\n as soon as possible. While the release is
+        planned to be feature \ncomplete entering the beta phase, it is possible that
+        features may be \nmodified or, in rare cases, deleted up until the start of
+        the release \ncandidate phase (Tuesday 2024-07-30). Our goal is to have no
+        ABI changes\n after beta 4 and as few code changes as possible after 3.13.0rc1,
+        the \nfirst release candidate. To achieve that, it will be &lt;b&gt;extremely
+        important&lt;/b&gt; to get as much exposure for 3.13 as possible during the
+        beta phase.&lt;/p&gt;&lt;p&gt;&amp;nbsp;&lt;/p&gt;&lt;p&gt;Please keep in
+        mind that this is a preview release and its use is &lt;b&gt;not&lt;/b&gt;
+        recommended for production environments.&lt;/p&gt;\n&lt;h1&gt;&lt;a class=&quot;anchor&quot;
+        href=&quot;https://discuss.python.org/t/3-13-0b2-now-available/55056#major-new-features-of-the-313-series-compared-to-312-1&quot;
+        name=&quot;major-new-features-of-the-313-series-compared-to-312-1&quot;&gt;&lt;/a&gt;&amp;nbsp;&lt;/h1&gt;&lt;h1&gt;Major
+        new features of the 3.13 series, compared to 3.12&lt;/h1&gt;\n&lt;p&gt;Some
+        of the new major new features and changes in Python 3.13 are:&lt;/p&gt;\n&lt;h2&gt;&lt;a
+        class=&quot;anchor&quot; href=&quot;https://discuss.python.org/t/3-13-0b2-now-available/55056#new-features-2&quot;
+        name=&quot;new-features-2&quot;&gt;&lt;/a&gt;New features&lt;/h2&gt;\n&lt;ul&gt;&lt;li&gt;A
+        &lt;a href=&quot;https://docs.python.org/3.13/whatsnew/3.13.html#a-better-interactive-interpreter&quot;&gt;new
+        and improved interactive interpreter &lt;/a&gt;, based on &lt;a href=&quot;https://pypy.org&quot;&gt;PyPy&lt;/a&gt;\u2019s,
+        featuring multi-line editing and color support, as well as colorized &lt;a
+        href=&quot;https://docs.python.org/3.13/whatsnew/3.13.html#improved-error-messages&quot;&gt;exception
+        tracebacks &lt;/a&gt;.&lt;/li&gt;&lt;li&gt;An &lt;a href=&quot;https://docs.python.org/3.13/whatsnew/3.13.html#free-threaded-cpython&quot;&gt;&lt;i&gt;experimental&lt;/i&gt;
+        free-threaded build mode &lt;/a&gt;, which disables the Global Interpreter
+        Lock, allowing threads to run more concurrently. The build mode is available
+        as an experimental feature in the Windows and macOS installers as well.&lt;/li&gt;&lt;li&gt;A
+        &lt;a href=&quot;https://docs.python.org/3.13/whatsnew/3.13.html#experimental-jit-compiler&quot;&gt;preliminary,
+        &lt;i&gt;experimental&lt;/i&gt; JIT &lt;/a&gt;, providing the ground work
+        for significant performance improvements.&lt;/li&gt;&lt;li&gt;The (cyclic)
+        garbage collector is now &lt;a href=&quot;https://docs.python.org/3.13/whatsnew/3.13.html#incremental-garbage-collection&quot;&gt;incremental
+        &lt;/a&gt;, which should mean shorter pauses for collection in programs with
+        a lot of objects.&lt;/li&gt;&lt;li&gt;A modified version of &lt;a href=&quot;https://github.com/microsoft/mimalloc&quot;&gt;mimalloc
+        &lt;/a&gt; is now included, optional but enabled by default if supported by
+        the platform, and required for the free-threaded build mode.&lt;/li&gt;&lt;li&gt;Docstrings
+        now have &lt;a href=&quot;https://docs.python.org/3.13/whatsnew/3.13.html#other-language-changes&quot;&gt;their
+        leading indentation stripped&lt;/a&gt;, reducing memory use and the size of
+        .pyc files. (Most tools handling docstrings already strip leading indentation.)&lt;/li&gt;&lt;li&gt;The
+        &lt;a href=&quot;https://docs.python.org/3.13/library/dbm.html&quot;&gt;dbm
+        module &lt;/a&gt; has a new &lt;a href=&quot;https://docs.python.org/3.13/whatsnew/3.13.html#dbm&quot;&gt;dbm.sqlite3
+        backend &lt;/a&gt; that is used by default when creating new files.&lt;/li&gt;&lt;li&gt;The
+        minimum supported macOS version was changed from 10.9 to &lt;strong&gt;10.13
+        (High Sierra)&lt;/strong&gt;. Older macOS versions will not be supported going
+        forward. &lt;br /&gt;&lt;/li&gt;&lt;/ul&gt;\n&lt;h2&gt;&lt;a class=&quot;anchor&quot;
+        href=&quot;https://discuss.python.org/t/3-13-0b2-now-available/55056#typing-3&quot;
+        name=&quot;typing-3&quot;&gt;&lt;/a&gt;Typing&lt;/h2&gt;\n&lt;ul&gt;&lt;li&gt;Support
+        for &lt;a href=&quot;https://peps.python.org/pep-0696/&quot;&gt;type defaults
+        in type parameters&lt;/a&gt;.&lt;/li&gt;&lt;li&gt;A &lt;a href=&quot;https://peps.python.org/pep-0742/&quot;&gt;new
+        type narrowing annotation &lt;/a&gt;, &lt;code&gt;typing.TypeIs&lt;/code&gt;.&lt;/li&gt;&lt;li&gt;A
+        new annotation for &lt;a href=&quot;https://peps.python.org/pep-0705/&quot;&gt;read-only
+        items in TypeDicts &lt;/a&gt;.&lt;/li&gt;&lt;/ul&gt;\n&lt;h2&gt;&lt;a class=&quot;anchor&quot;
+        href=&quot;https://discuss.python.org/t/3-13-0b2-now-available/55056#removals-and-new-deprecations-4&quot;
+        name=&quot;removals-and-new-deprecations-4&quot;&gt;&lt;/a&gt;Removals and
+        new deprecations&lt;/h2&gt;\n&lt;ul&gt;&lt;li&gt;&lt;a href=&quot;https://peps.python.org/pep-0594/&quot;&gt;PEP
+        594 (Removing dead batteries from the standard library)&lt;/a&gt; scheduled
+        removals of many deprecated modules: &lt;code&gt;aifc&lt;/code&gt;, &lt;code&gt;audioop&lt;/code&gt;,
+        &lt;code&gt;chunk&lt;/code&gt;, &lt;code&gt;cgi&lt;/code&gt;, &lt;code&gt;cgitb&lt;/code&gt;,
+        &lt;code&gt;crypt&lt;/code&gt;, &lt;code&gt;imghdr&lt;/code&gt;, &lt;code&gt;mailcap&lt;/code&gt;,
+        &lt;code&gt;msilib&lt;/code&gt;, &lt;code&gt;nis&lt;/code&gt;, &lt;code&gt;nntplib&lt;/code&gt;,
+        &lt;code&gt;ossaudiodev&lt;/code&gt;, &lt;code&gt;pipes&lt;/code&gt;, &lt;code&gt;sndhdr&lt;/code&gt;,
+        &lt;code&gt;spwd&lt;/code&gt;, &lt;code&gt;sunau&lt;/code&gt;, &lt;code&gt;telnetlib&lt;/code&gt;,
+        &lt;code&gt;uu&lt;/code&gt;, &lt;code&gt;xdrlib&lt;/code&gt;, &lt;code&gt;lib2to3&lt;/code&gt;.&lt;/li&gt;&lt;li&gt;&lt;a
+        href=&quot;https://docs.python.org/3.13/whatsnew/3.13.html#removed&quot;&gt;Many
+        other removals &lt;/a&gt; of deprecated classes, functions and methods in
+        various standard library modules.&lt;/li&gt;&lt;li&gt;C API &lt;a href=&quot;https://docs.python.org/3.13/whatsnew/3.13.html#id10&quot;&gt;removals&lt;/a&gt;
+        and &lt;a href=&quot;https://docs.python.org/3.13/whatsnew/3.13.html#id9&quot;&gt;deprecations&lt;/a&gt;.
+        (Some removals present in alpha 1 were reverted in alpha 2, as the removals
+        were deemed too disruptive at this time.)&lt;/li&gt;&lt;li&gt;&lt;a href=&quot;https://docs.python.org/3.13/whatsnew/3.13.html#deprecated&quot;&gt;New
+        deprecations&lt;/a&gt;, most of which are scheduled for removal from Python
+        3.15 or 3.16.&lt;/li&gt;&lt;/ul&gt;\n&lt;p&gt;&lt;small&gt;(Hey, &lt;b&gt;fellow
+        core developer,&lt;/b&gt; if a feature you find important is missing from
+        this list, &lt;a href=&quot;mailto:thomas@python.org&quot;&gt;let Thomas know&lt;/a&gt;.)&lt;/small&gt;&lt;/p&gt;\n&lt;p&gt;For
+        more details on the changes to Python 3.13, see &lt;a href=&quot;https://docs.python.org/3.13/whatsnew/3.13.html&quot;&gt;What\u2019s
+        new in Python 3.13 &lt;/a&gt;. The next pre-release of Python 3.13 will be
+        3.13.0b4, currently scheduled for 2024-07-16.&lt;/p&gt;\n&lt;h1&gt;&lt;a class=&quot;anchor&quot;
+        href=&quot;https://discuss.python.org/t/3-13-0b2-now-available/55056#more-resources-5&quot;
+        name=&quot;more-resources-5&quot;&gt;&lt;/a&gt;&amp;nbsp;&lt;/h1&gt;&lt;h1&gt;More
+        resources&lt;/h1&gt;\n&lt;ul&gt;&lt;li&gt;&lt;a href=&quot;https://docs.python.org/3.13/&quot;&gt;Online
+        Documentation&lt;/a&gt;&lt;/li&gt;&lt;li&gt;&lt;a href=&quot;https://peps.python.org/pep-0719/&quot;&gt;PEP
+        719 &lt;/a&gt;, 3.13 Release Schedule&lt;/li&gt;&lt;li&gt;Report bugs at &lt;a
+        class=&quot;inline-onebox&quot; href=&quot;https://github.com/python/cpython/issues&quot;&gt;Issues
+        \xB7 python/cpython \xB7 GitHub &lt;/a&gt;.&lt;/li&gt;&lt;li&gt;&lt;a href=&quot;https://www.python.org/psf/donations/python-dev/&quot;&gt;Help
+        fund Python directly&lt;/a&gt; (or &lt;a href=&quot;https://github.com/sponsors/python&quot;&gt;via
+        GitHub Sponsors&lt;/a&gt;), and support &lt;a href=&quot;https://www.python.org/psf/donations/&quot;&gt;the
+        Python community&lt;/a&gt;.&lt;/li&gt;&lt;/ul&gt;&lt;h1&gt;&amp;nbsp;&lt;/h1&gt;&lt;h1&gt;Enjoy
+        the new releases&lt;/h1&gt;\n&lt;p&gt;Thanks to all of the many volunteers
+        who help make Python Development\n and these releases possible! Please consider
+        supporting our efforts by \nvolunteering yourself or through organization
+        contributions to the \nPython Software Foundation.&lt;/p&gt;\n\n&lt;p&gt;Your
+        release team,&lt;br /&gt;\nThomas Wouters &lt;br /&gt;\n\u0141ukasz Langa
+        &lt;br /&gt;\nNed Deily &lt;br /&gt;\nSteve Dower&amp;nbsp;&lt;/p&gt;&lt;p&gt;&amp;nbsp;&lt;/p&gt;</content><link
+        rel='edit' type='application/atom+xml' href='https://www.blogger.com/feeds/3941553907430899163/posts/default/7085913750996158792'/><link
+        rel='self' type='application/atom+xml' href='https://www.blogger.com/feeds/3941553907430899163/posts/default/7085913750996158792'/><link
+        rel='alternate' type='text/html' href='https://pythoninsider.blogspot.com/2024/06/python-3130-beta-3-released.html'
+        title='Python 3.13.0 beta 3 released'/><author><name>Thomas Wouters</name><uri>http://www.blogger.com/profile/10346112333332923135</uri><email>noreply@blogger.com</email><gd:image
+        rel='http://schemas.google.com/g/2005#thumbnail' width='16' height='16' src='https://img1.blogblog.com/img/b16-rounded.gif'/></author></entry><entry><id>tag:blogger.com,1999:blog-3941553907430899163.post-3732744794989577164</id><published>2024-06-06T21:50:00.002-04:00</published><updated>2024-06-06T21:50:37.946-04:00</updated><title
+        type='text'>Python 3.12.4 released</title><content type='html'>&lt;p&gt;I&#39;m
+        pleased to announce the release of Python 3.12.4:&lt;br /&gt;&lt;br /&gt;https://www.python.org/downloads/release/python-3124/&lt;/p&gt;&lt;h1&gt;&amp;nbsp;&lt;/h1&gt;&lt;h1&gt;This
+        is the third maintenance release of Python 3.12&lt;/h1&gt;\n&lt;p&gt;Python
+        3.12 is the newest major release of the Python programming \nlanguage, and
+        it contains many new features and optimizations. 3.12.4 is\n the latest maintenance
+        release, containing more than 250 bugfixes, \nbuild improvements and documentation
+        changes since 3.12.3.&lt;/p&gt;\n&lt;h1&gt;&lt;a class=&quot;anchor&quot;
+        href=&quot;https://discuss.python.org/t/python-3-12-4-now-available/55128#major-new-features-of-the-312-series-compared-to-311-2&quot;
+        name=&quot;major-new-features-of-the-312-series-compared-to-311-2&quot;&gt;&lt;/a&gt;&amp;nbsp;&lt;/h1&gt;&lt;h1&gt;Major
+        new features of the 3.12 series, compared to 3.11&lt;/h1&gt;\n&lt;h2&gt;&lt;a
+        class=&quot;anchor&quot; href=&quot;https://discuss.python.org/t/python-3-12-4-now-available/55128#new-features-3&quot;
+        name=&quot;new-features-3&quot;&gt;&lt;/a&gt;&amp;nbsp;&lt;/h2&gt;&lt;h2&gt;New
+        features&lt;/h2&gt;\n&lt;ul&gt;&lt;li&gt;&lt;a href=&quot;https://docs.python.org/3.12/whatsnew/3.12.html#pep-701-syntactic-formalization-of-f-strings&quot;&gt;More
+        flexible f-string parsing&lt;/a&gt;, allowing many things previously disallowed
+        (&lt;a href=&quot;https://peps.python.org/pep-0701/&quot;&gt;PEP 701&lt;/a&gt;).&lt;/li&gt;&lt;li&gt;&lt;a
+        href=&quot;https://docs.python.org/3.12/whatsnew/3.12.html#pep-688-making-the-buffer-protocol-accessible-in-python&quot;&gt;Support
+        for the buffer protocol&lt;/a&gt; in Python code (&lt;a href=&quot;https://peps.python.org/pep-0688/&quot;&gt;PEP
+        688&lt;/a&gt;).&lt;/li&gt;&lt;li&gt;&lt;a href=&quot;https://docs.python.org/3.12/whatsnew/3.12.html#pep-669-low-impact-monitoring-for-cpython&quot;&gt;A
+        new debugging/profiling API&lt;/a&gt; (&lt;a href=&quot;https://peps.python.org/pep-0669/&quot;&gt;PEP
+        669&lt;/a&gt;).&lt;/li&gt;&lt;li&gt;&lt;a href=&quot;https://docs.python.org/3.12/whatsnew/3.12.html#pep-684-a-per-interpreter-gil&quot;&gt;Support
+        for isolated subinterpreters&lt;/a&gt; with separate Global Interpreter Locks
+        (&lt;a href=&quot;https://peps.python.org/pep-0684&quot;&gt;PEP 684&lt;/a&gt;).&lt;/li&gt;&lt;li&gt;&lt;a
+        href=&quot;https://docs.python.org/3.12/whatsnew/3.12.html#improved-error-messages&quot;&gt;Even
+        more improved error messages&lt;/a&gt;. More exceptions potentially caused
+        by typos now make suggestions to the user.&lt;/li&gt;&lt;li&gt;&lt;a href=&quot;https://docs.python.org/3.12/howto/perf_profiling.html&quot;&gt;Support
+        for the Linux &lt;code&gt;perf&lt;/code&gt; profiler&lt;/a&gt; to report Python
+        function names in traces.&lt;/li&gt;&lt;li&gt;&lt;a href=&quot;https://docs.python.org/3.12/whatsnew/3.12.html#optimizations&quot;&gt;Many
+        large and small performance improvements&lt;/a&gt; (like &lt;a href=&quot;https://peps.python.org/pep-0709/&quot;&gt;PEP
+        709&lt;/a&gt; and support for the BOLT binary optimizer), delivering an estimated
+        5% overall performance improvement.&lt;/li&gt;&lt;/ul&gt;\n&lt;h2&gt;&lt;a
+        class=&quot;anchor&quot; href=&quot;https://discuss.python.org/t/python-3-12-4-now-available/55128#type-annotations-4&quot;
+        name=&quot;type-annotations-4&quot;&gt;&lt;/a&gt;Type annotations&lt;/h2&gt;\n&lt;ul&gt;&lt;li&gt;&lt;a
+        href=&quot;https://docs.python.org/3.12/whatsnew/3.12.html#pep-695-type-parameter-syntax&quot;&gt;New
+        type annotation syntax&lt;/a&gt; for generic classes (&lt;a href=&quot;https://peps.python.org/pep-0695/&quot;&gt;PEP
+        695&lt;/a&gt;).&lt;/li&gt;&lt;li&gt;&lt;a href=&quot;https://docs.python.org/3.12/whatsnew/3.12.html#pep-698-override-decorator-for-static-typing&quot;&gt;New
+        override decorator&lt;/a&gt; for methods (&lt;a href=&quot;https://peps.python.org/pep-0698&quot;&gt;PEP
+        698&lt;/a&gt;).&lt;/li&gt;&lt;/ul&gt;\n&lt;h2&gt;&lt;a class=&quot;anchor&quot;
+        href=&quot;https://discuss.python.org/t/python-3-12-4-now-available/55128#deprecations-5&quot;
+        name=&quot;deprecations-5&quot;&gt;&lt;/a&gt;Deprecations&lt;/h2&gt;\n&lt;ul&gt;&lt;li&gt;The
+        deprecated &lt;code&gt;wstr&lt;/code&gt; and &lt;code&gt;wstr_length&lt;/code&gt;
+        members of the C implementation of unicode objects were removed, per &lt;a
+        href=&quot;https://peps.python.org/pep-0623/&quot;&gt;PEP 623&lt;/a&gt;.&lt;/li&gt;&lt;li&gt;In
+        the &lt;code&gt;unittest&lt;/code&gt; module, a number of long deprecated
+        methods and classes were removed. (They had been deprecated since Python 3.1
+        or 3.2).&lt;/li&gt;&lt;li&gt;The deprecated &lt;code&gt;smtpd&lt;/code&gt;
+        and &lt;code&gt;distutils&lt;/code&gt; modules have been removed (see &lt;a
+        href=&quot;https://peps.python.org/pep-0594/&quot;&gt;PEP 594&lt;/a&gt; and
+        &lt;a href=&quot;https://peps.python.org/pep-0632/&quot;&gt;PEP 632&lt;/a&gt;.
+        The &lt;code&gt;setuptools&lt;/code&gt; package continues to provide the &lt;code&gt;distutils&lt;/code&gt;
+        module.&lt;/li&gt;&lt;li&gt;&lt;a href=&quot;https://docs.python.org/3.12/whatsnew/3.12.html#removed&quot;&gt;A
+        number of other old, broken and deprecated functions, classes and methods&lt;/a&gt;
+        have been removed.&lt;/li&gt;&lt;li&gt;Invalid backslash escape sequences
+        in strings now warn with &lt;code&gt;SyntaxWarning&lt;/code&gt; instead of
+        &lt;code&gt;DeprecationWarning&lt;/code&gt;, making them more visible. (They
+        will become syntax errors in the future.)&lt;/li&gt;&lt;li&gt;The internal
+        representation of integers has changed in preparation \nfor performance enhancements.
+        (This should not affect most users as it \nis an internal detail, but it may
+        cause problems for Cython-generated \ncode.)&lt;/li&gt;&lt;/ul&gt;\n&lt;p&gt;For
+        more details on the changes to Python 3.12, see &lt;a href=&quot;https://docs.python.org/3.12/whatsnew/3.12.html&quot;&gt;What\u2019s
+        new in Python 3.12&lt;/a&gt;.&lt;/p&gt;\n&lt;h1&gt;&lt;a class=&quot;anchor&quot;
+        href=&quot;https://discuss.python.org/t/python-3-12-4-now-available/55128#more-resources-6&quot;
+        name=&quot;more-resources-6&quot;&gt;&lt;/a&gt;&amp;nbsp;&lt;/h1&gt;&lt;h1&gt;More
+        resources&lt;/h1&gt;\n&lt;ul&gt;&lt;li&gt;&lt;a href=&quot;https://docs.python.org/3.12/&quot;&gt;Online
+        Documentation&lt;/a&gt;.&lt;/li&gt;&lt;li&gt;&lt;a href=&quot;https://www.python.org/dev/peps/pep-0693/&quot;&gt;PEP
+        693&lt;/a&gt;, the Python 3.12 Release Schedule.&lt;/li&gt;&lt;li&gt;Report
+        bugs via &lt;a href=&quot;https://github.com/python/cpython/issues&quot;&gt;GitHub
+        Issues&lt;/a&gt;.&lt;/li&gt;&lt;li&gt;&lt;a href=&quot;https://www.python.org/psf/donations/python-dev/&quot;&gt;Help
+        fund Python directly&lt;/a&gt; or &lt;a href=&quot;https://github.com/sponsors/python&quot;&gt;via
+        GitHub Sponsors&lt;/a&gt;, and support &lt;a href=&quot;https://www.python.org/psf/donations/&quot;&gt;the
+        Python community&lt;/a&gt;.&lt;/li&gt;&lt;/ul&gt;\n&lt;h1&gt;&lt;a class=&quot;anchor&quot;
+        href=&quot;https://discuss.python.org/t/python-3-12-4-now-available/55128#enjoy-the-new-releases-7&quot;
+        name=&quot;enjoy-the-new-releases-7&quot;&gt;&lt;/a&gt;&amp;nbsp;&lt;/h1&gt;&lt;h1&gt;Enjoy
+        the new releases&lt;/h1&gt;\n&lt;p&gt;Thanks to all of the many volunteers
+        who help make Python Development\n and these releases possible! Please consider
+        supporting our efforts by \nvolunteering yourself or through organization
+        contributions to the \nPython Software Foundation.&lt;/p&gt;\n&lt;p&gt;&lt;br
+        /&gt;&lt;/p&gt;\n&lt;p&gt;Your release team,&lt;br /&gt;\nThomas Wouters &lt;br
+        /&gt;\n\u0141ukasz Langa &lt;br /&gt;\nNed Deily &lt;br /&gt;\nSteve Dower&amp;nbsp;&lt;/p&gt;</content><link
+        rel='edit' type='application/atom+xml' href='https://www.blogger.com/feeds/3941553907430899163/posts/default/3732744794989577164'/><link
+        rel='self' type='application/atom+xml' href='https://www.blogger.com/feeds/3941553907430899163/posts/default/3732744794989577164'/><link
+        rel='alternate' type='text/html' href='https://pythoninsider.blogspot.com/2024/06/python-3124-released.html'
+        title='Python 3.12.4 released'/><author><name>Thomas Wouters</name><uri>http://www.blogger.com/profile/10346112333332923135</uri><email>noreply@blogger.com</email><gd:image
+        rel='http://schemas.google.com/g/2005#thumbnail' width='16' height='16' src='https://img1.blogblog.com/img/b16-rounded.gif'/></author></entry></feed>"
     headers:
       accept-ranges:
       - bytes
+      age:
+      - '0'
       cache-control:
-      - private, max-age=0
+      - public, must-revalidate, proxy-revalidate, max-age=1
       content-encoding:
       - gzip
+      content-length:
+      - '35082'
+      content-security-policy-report-only:
+      - script-src 'none';form-action 'none';frame-src 'none'; report-uri https://csp.withgoogle.com/csp/httpsserver2/blogger-renderd
       content-type:
-      - text/html; charset=UTF-8
+      - application/atom+xml; charset=UTF-8
+      cross-origin-opener-policy-report-only:
+      - same-origin; report-to=coop_reporting
+      cross-origin-resource-policy:
+      - cross-origin
       date:
-      - Tue, 29 Jul 2025 09:02:43 GMT
+      - Tue, 29 Jul 2025 09:33:39 GMT
       etag:
-      - W/"4e50f1f1e6aea1309a53eb57cf2eead310a79291d2758e5ee1289fb1be60f537"
+      - W/"582799ad9ab9d7cac4b476ba8a5d3146f4c5066352789d8561180f9f5c7f997f"
       expires:
-      - Tue, 29 Jul 2025 09:02:43 GMT
+      - Tue, 29 Jul 2025 06:42:47 GMT
       last-modified:
       - Tue, 22 Jul 2025 20:13:02 GMT
+      report-to:
+      - '{"group":"blogger-renderd","max_age":2592000,"endpoints":[{"url":"https://csp.withgoogle.com/csp/report-to/httpsserver2/blogger-renderd"}]}'
       server:
       - envoy
-      transfer-encoding:
-      - chunked
+      vary:
+      - Accept-Encoding
       via:
       - 1.1 varnish, 1.1 varnish
       x-cache:
-      - MISS, MISS
+      - HIT, MISS
       x-cache-hits:
       - 0, 0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '170'
+      - '197'
+      x-frame-options:
+      - SAMEORIGIN
       x-served-by:
-      - cache-lga21964-LGA, cache-dfw-kdfw8210070-DFW
+      - cache-lga21991-LGA, cache-dfw-kdfw8210132-DFW
       x-timer:
-      - S1753779763.932201,VS0,VE124
+      - S1753781619.966094,VS0,VE152
       x-xss-protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - python-requests/2.31.0
-    method: GET
-    uri: https://proxy:8080/
-  response:
-    body:
-      string: "<!DOCTYPE html>\n<html class='v2' dir='ltr' xmlns='http://www.w3.org/1999/xhtml'
-        xmlns:b='http://www.google.com/2005/gml/b' xmlns:data='http://www.google.com/2005/gml/data'
-        xmlns:expr='http://www.google.com/2005/gml/expr'>\n<head>\n<link href='https://www.blogger.com/static/v1/widgets/573632073-css_bundle_v2.css'
-        rel='stylesheet' type='text/css'/>\n<script data-domain='pythoninsider.blogspot.com'
-        defer='defer' src='https://analytics.python.org/js/script.outbound-links.js'></script>\n<link
-        href='https://blog.python.org/favicon.ico' rel='icon' type='image/x-icon'/>\n<meta
-        content='blogger' name='generator'/>\n<link href='https://blog.python.org/feeds/posts/default'
-        rel='alternate' title='Python Insider - Atom' type='application/atom+xml'/>\n<link
-        href='https://blog.python.org/feeds/posts/default?alt=rss' rel='alternate'
-        title='Python Insider - RSS' type='application/rss+xml'/>\n<link href='https://www.blogger.com/feeds/3941553907430899163/posts/default'
-        rel='service.post' title='Python Insider - Atom' type='application/atom+xml'/>\n<!--[if
-        IE]><script type=\"text/javascript\" src=\"https://www.blogger.com/static/v1/jsbin/2591933621-ieretrofit.js\"></script>
-        <![endif]-->\n<meta content='https://blog.python.org/' name='og:url:domain'/>\n<!--[if
-        IE]> <script> (function() { var html5 = (\"abbr,article,aside,audio,canvas,datalist,details,\"
-        + \"figure,footer,header,hgroup,mark,menu,meter,nav,output,\" + \"progress,section,time,video\").split(',');
-        for (var i = 0; i < html5.length; i++) { document.createElement(html5[i]);
-        } try { document.execCommand('BackgroundImageCache', false, true); } catch(e)
-        {} })(); </script> <![endif]-->\n<title>Python Insider</title>\n<meta name='author'
-        value='The Python Community'/>\n<style id='page-skin-1' type='text/css'><!--\n\n--></style>\n<style
-        id='template-skin-1' type='text/css'><!--\n\n--></style>\n<!--[if lt IE 9]>
-        <script src=\"http://html5shiv.googlecode.com/svn/trunk/html5.js\"></script>
-        <![endif]-->\n<style type='text/css'>\nbody {\n  font-family: Arial,Tahoma,Helvetica,FreeSans,sans-serif;\n
-        \ font-size: 12px;\n  color: #111;\n  background:#3272ac;\n\n  background-image:
-        -webkit-gradient(\n    linear,\n    left bottom,\n    left top,\n    color-stop(0.21,
-        rgb(50,114,172)),\n    color-stop(0.84, rgb(250,229,164))\n);\nbackground-image:
-        -moz-linear-gradient(\n    center bottom,\n    #3272ac 21%,\n    #fae5a4 84%\n);\n\nbackground-repeat:no-repeat;\n}\n\nh2
-        {font-size: 1em; }\nh3 { font-size: 1.2em}\n\n#wholeC {\n  background-color:#fff;\n
-        \ width: 90%;\n  margin: 0 auto 2em auto;\n}\n\n#cmain {\n  float:left;\n
-        \ width: 68%;\n  padding:0;\n  margin: 2em 0 2em 2%;\n}\n#cside {\n  float:right;\n
-        \ width: 23%;\n  margin-right: 2%;\n  margin-top: 2em;\n  margin-bottom: 3em;\n
-        \ padding-bottom: 3em;\n  font-size: 0.95em;\n}\n#cside a {\nfont-size: 0.95em\n}\n#cside
-        h2 {\ntext-transform:uppercase;\ncolor: #715707\n}\n\na { color: #142f46 }\na:hover
-        { color: #557 }\na:visited { color: #334 }\n\nh2.date-header { font-size:
-        13px; }\nh3.post-title { font-size: 16px; margin-bottom: 1em; }\n\ndiv.date-outer
-        {\n/* blog post container */\nmargin: 0 0 2em 0;\npadding: 0;\nfont-size:13px;\nline-height:133%;\n}\n\nheader#chead
-        {\ndisplay: block;\nmargin: 0 auto 1em auto;\npadding: 0;\nwidth: 70%;\nheight:145px;\noverflow:
-        hidden;\ncolor: #222;\nbackground: #fff;\nborder-bottom: 1px solid #ddd; \n\n}\n#Header1
-        {\nfont-size:16px;\n}\n#Header1 .description {\nposition:relative;\ntop: -35px;\nleft:
-        116px;\n}\n\n.wshad {\n    padding: 2em 8px;\n    border: 1px solid #99A;\n
-        \   -moz-box-shadow: 0 5px 10px #222;\n    -webkit-box-shadow: 0 5px 10px
-        #222;\n    box-shadow: 0 5px 10px #222;\n}\n\n.post-footer {\nborder-top:1px
-        outset #ddd;border-right:1px inset #ddd;\nbackground-color: #f5f5f5;\npadding:
-        10px 5px;\nposition:relative;\nleft:-1.2em;\nopacity: 0.75;\nfont-size:0.9em;\n}\n\n</style>\n<script
-        src='https://code.jquery.com/jquery-3.2.1.slim.min.js'></script>\n<script>\n$(document).ready(function()
-        {\n  $(\"a\").each(function() {\n    var i = $(this).attr(\"href\");\n    if
-        (!i) {\n      return;\n    }\n    var n = i.replace(\"https://pythoninsider.blogspot.com\",
-        \"https://blog.python.org\");\n    $(this).attr(\"href\", function() {\n      return
-        n\n    })\n  })\n});\n</script>\n<link href='https://www.blogger.com/dyn-css/authorization.css?targetBlogID=3941553907430899163&amp;zx=eb47a3b4-8679-40a3-a3c9-0305e654ac4c'
-        media='none' onload='if(media!=&#39;all&#39;)media=&#39;all&#39;' rel='stylesheet'/><noscript><link
-        href='https://www.blogger.com/dyn-css/authorization.css?targetBlogID=3941553907430899163&amp;zx=eb47a3b4-8679-40a3-a3c9-0305e654ac4c'
-        rel='stylesheet'/></noscript>\n<meta name='google-adsense-platform-account'
-        content='ca-host-pub-1556223355139109'/>\n<meta name='google-adsense-platform-domain'
-        content='blogspot.com'/>\n\n</head>\n<body>\n<div class='navbar section' id='navbar'><div
-        class='widget Navbar' data-version='1' id='Navbar1'><script type=\"text/javascript\">\n
-        \   function setAttributeOnload(object, attribute, val) {\n      if(window.addEventListener)
-        {\n        window.addEventListener('load',\n          function(){ object[attribute]
-        = val; }, false);\n      } else {\n        window.attachEvent('onload', function(){
-        object[attribute] = val; });\n      }\n    }\n  </script>\n<div id=\"navbar-iframe-container\"></div>\n<script
-        type=\"text/javascript\" src=\"https://apis.google.com/js/platform.js\"></script>\n<script
-        type=\"text/javascript\">\n      gapi.load(\"gapi.iframes:gapi.iframes.style.bubble\",
-        function() {\n        if (gapi.iframes && gapi.iframes.getContext) {\n          gapi.iframes.getContext().openChild({\n
-        \             url: 'https://www.blogger.com/navbar/3941553907430899163?origin\\x3dhttps://pythoninsider.blogspot.com',\n
-        \             where: document.getElementById(\"navbar-iframe-container\"),\n
-        \             id: \"navbar-iframe\"\n          });\n        }\n      });\n
-        \   </script><script type=\"text/javascript\">\n(function() {\nvar script
-        = document.createElement('script');\nscript.type = 'text/javascript';\nscript.src
-        = '//pagead2.googlesyndication.com/pagead/js/google_top_exp.js';\nvar head
-        = document.getElementsByTagName('head')[0];\nif (head) {\nhead.appendChild(script);\n}})();\n</script>\n</div></div>\n<div
-        id='wholeC'>\n<header id='chead'>\n<div class='header section' id='header'><div
-        class='widget Header' data-version='1' id='Header1'>\n<div id='header-inner'>\n<a
-        href='https://pythoninsider.blogspot.com/' style='display: block'>\n<img alt='Python
-        Insider' height='139px; ' id='Header1_headerimg' src='https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEiaYv-cjwDu6xU0AXLrBK0BEw19ERUxBEsbApijz0uyz_ouDUsdt-RS8Ims7R2PCwvlQAFhxxA15m7zgeB582M-Wsz9bSTpLk7WkzBdwwrMVRJPE-OstLYwR3TFITAh77gF2XEEnIzJAGRK/s1600/python-insider-header.png'
-        style='display: block' width='600px; '/>\n</a>\n<div class='descriptionwrapper'>\n<p
-        class='description'><span>Python core development news and information.</span></p>\n</div>\n</div>\n</div></div>\n</header>\n<div
-        id='cmain'>\n<section id='ccontent'>\n<div class='main section' id='main'><div
-        class='widget Blog' data-version='1' id='Blog1'>\n<div class='blog-posts hfeed'>\n\n
-        \         <div class=\"date-outer\">\n        \n<h2 class='date-header'><span>Tuesday,
-        July 22, 2025</span></h2>\n\n          <div class=\"date-posts\">\n        \n<div
-        class='post-outer'>\n<div class='post hentry'>\n<a name='8412948848050014787'></a>\n<h3
-        class='post-title entry-title'>\n<a href='https://pythoninsider.blogspot.com/2025/07/python-314-release-candidate-1-is-go.html'>Python
-        3.14 release candidate 1 is go!</a>\n</h3>\n<div class='post-header'>\n<div
-        class='post-header-line-1'></div>\n</div>\n<div class='post-body entry-content'>\n<p><a
-        href=\"https://www.youtube.com/watch?v=ydyXFUmv6S4\">It&#8217;s</a> the\nfirst
-        3.14 release candidate!</p>\n<p><a class=\"uri\" href=\"https://www.python.org/downloads/release/python-3140rc1/\">https://www.python.org/downloads/release/python-3140rc1/</a></p>\n<p><strong>This
-        is the first release candidate of Python\n3.14</strong></p>\n<p>This release,
-        <strong>3.14.0rc1</strong>, is the penultimate release\npreview. Entering
-        the release candidate phase, only reviewed code\nchanges which are clear bug
-        fixes are allowed between this release\ncandidate and the final release. The
-        second candidate (and the last\nplanned release preview) is scheduled for
-        Tuesday, 2025-08-26, while the\nofficial release of 3.14.0 is scheduled for
-        Tuesday, 2025-10-07.</p>\n<p>There will be <strong><em>no ABI changes</em></strong>
-        from this\npoint forward in the 3.14 series, and the goal is that there will
-        be as\nfew code changes as possible.</p>\n<h1 id=\"call-to-action\">Call to
-        action</h1>\n<p>We <strong><em>strongly encourage</em></strong> maintainers
-        of\nthird-party Python projects to prepare their projects for 3.14 during\nthis
-        phase, and where necessary publish Python 3.14 wheels on PyPI to be\nready
-        for the final release of 3.14.0, and to help other projects do\ntheir own
-        testing. Any binary wheels built against Python 3.14.0rc1\n<strong><em>will
-        work</em></strong> with future versions of Python 3.14.\nAs always, report
-        any issues to <a href=\"https://github.com/python/cpython/issues\">the Python
-        bug\ntracker</a>.</p>\n<p>Please keep in mind that this is a preview release
-        and while it&#8217;s as\nclose to the final release as we can get it, its
-        use is\n<strong><em>not</em></strong> recommended for production\nenvironments.</p>\n<h2
-        id=\"core-developers-time-to-work-on-documentation-now\">Core\ndevelopers:
-        time to work on documentation now</h2>\n<ul>\n<li>Are all your changes properly
-        documented?</li>\n<li>Are they mentioned in <a href=\"https://docs.python.org/3.14/whatsnew/3.14.html\">What&#8217;s\nNew</a>?</li>\n<li>Did
-        you notice other changes you know of to have insufficient\ndocumentation?</li>\n</ul>\n<h1
-        id=\"major-new-features-of-the-3.14-series-compared-to-3.13\">Major\nnew features
-        of the 3.14 series, compared to 3.13</h1>\n<p>Some of the major new features
-        and changes in Python 3.14 are:</p>\n<h2 id=\"new-features\">New features</h2>\n<ul>\n<li><a
-        href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pep779\">PEP\n779</a>:
-        Free-threaded Python is officially supported</li>\n<li><a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pep649\">PEP\n649</a>:
-        The evaluation of type annotations is now deferred, improving\nthe semantics
-        of using annotations.</li>\n<li><a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pep750\">PEP\n750</a>:
-        Template string literals (t-strings) for custom string\nprocessing, using
-        the familiar syntax of f-strings.</li>\n<li><a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pep734\">PEP\n734</a>:
-        Multiple interpreters in the stdlib.</li>\n<li><a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pep784\">PEP\n784</a>:
-        A new module <code>compression.zstd</code> providing support\nfor the Zstandard
-        compression algorithm.</li>\n<li><a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pep758\">PEP\n758</a>:
-        <code>except</code> and <code>except*</code> expressions may\nnow omit the
-        brackets.</li>\n<li><a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pyrepl-highlighting\">Syntax\nhighlighting
-        in PyREPL</a>, and support for color in <a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-color-unittest\">unittest</a>,\n<a
-        href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-color-argparse\">argparse</a>,\n<a
-        href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-color-json\">json</a>\nand
-        <a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-color-calendar\">calendar</a>\nCLIs.</li>\n<li><a
-        href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pep768\">PEP\n768</a>:
-        A zero-overhead external debugger interface for CPython.</li>\n<li><a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#uuid\">UUID\nversions
-        6-8</a> are now supported by the <code>uuid</code> module, and\ngeneration
-        of versions 3-5 are up to 40% faster.</li>\n<li><a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pep765\">PEP\n765</a>:
-        Disallow\n<code>return</code>/<code>break</code>/<code>continue</code> that
-        exit a\n<code>finally</code> block.</li>\n<li><a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pep741\">PEP\n741</a>:
-        An improved C API for configuring Python.</li>\n<li>A <a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-tail-call\">new\ntype
-        of interpreter</a>. For certain newer compilers, this interpreter\nprovides
-        significantly better performance. Opt-in for now, requires\nbuilding from
-        source.</li>\n<li><a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#improved-error-messages\">Improved\nerror
-        messages.</a></li>\n<li><a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#hmac\">Builtin\nimplementation
-        of HMAC</a> with formally verified code from the HACL*\nproject.</li>\n<li>A
-        <a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#asyncio-introspection-capabilities\">new\ncommand-line
-        interface</a> to inspect running Python processes using\nasynchronous tasks.</li>\n<li>The
-        pdb module now supports <a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#remote-attaching-to-a-running-python-process-with-pdb\">remote\nattaching
-        to a running Python process</a>.</li>\n</ul>\n<p><small>(Hey, <strong>fellow
-        core developer,</strong> if a feature you\nfind important is missing from
-        this list, let Hugo know.)</small></p>\n<p>For more details on the changes
-        to Python 3.14, see <a href=\"https://docs.python.org/3.14/whatsnew/3.14.html\">What&#8217;s
-        new in\nPython 3.14</a>. The next pre-release of Python 3.14 will be the final\nrelease
-        candidate, 3.14.0rc2, scheduled for 2025-08-26.</p>\n<h2 id=\"build-changes\">Build
-        changes</h2>\n<ul>\n<li><a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pep761\">PEP\n761</a>:
-        Python 3.14 and onwards no longer provides PGP signatures for\nrelease artifacts.
-        Instead, Sigstore is recommended for verifiers.</li>\n<li>Official macOS and
-        Windows release binaries include an <a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-jit-compiler\"><em>experimental</em>\nJIT
-        compiler</a>.</li>\n</ul>\n<h2 id=\"incompatible-changes-removals-and-new-deprecations\">Incompatible\nchanges,
-        removals and new deprecations</h2>\n<ul>\n<li><a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#incompatible-changes\">Incompatible\nchanges</a></li>\n<li>Python
-        <a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#removed\">removals</a>\nand
-        <a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#deprecated\">deprecations</a></li>\n<li>C
-        API <a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#c-api-removed\">removals</a>\nand
-        <a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#c-api-deprecated\">deprecations</a></li>\n<li>Overview
-        of all <a href=\"https://docs.python.org/3.14/deprecations/index.html\">pending\ndeprecations</a></li>\n</ul>\n<h1
-        id=\"python-install-manager\">Python install manager</h1>\n<p>The installer
-        we offer for Windows is being replaced by our new\ninstall manager, which
-        can be installed from <a href=\"https://apps.microsoft.com/detail/9NQ7512CXL7T\">the
-        Windows\nStore</a> or from its <a href=\"https://www.python.org/downloads/latest/pymanager/\">download\npage</a>.
-        See <a href=\"https://docs.python.org/3.14/using/windows.html\">our\ndocumentation</a>
-        for more information. The JSON file available for\ndownload below contains
-        the list of all the installable packages\navailable as part of this release,
-        including file URLs and hashes, but\nis not required to install the latest
-        release. The traditional installer\nwill remain available throughout the 3.14
-        and 3.15 releases.</p>\n<h1 id=\"more-resources\">More resources</h1>\n<ul>\n<li><a
-        href=\"https://docs.python.org/3.14/\">Online\ndocumentation</a></li>\n<li><a
-        href=\"https://peps.python.org/pep-0745/\">PEP 745</a>, 3.14\nRelease Schedule</li>\n<li>Report
-        bugs at <a href=\"https://github.com/python/cpython/issues\">github.com/python/cpython/issues</a></li>\n<li><a
-        href=\"https://www.python.org/psf/donations/\">Help fund Python and\nits community</a></li>\n</ul>\n<h1
-        id=\"and-now-for-something-completely-different\">And now for\nsomething completely
-        different</h1>\n<p>Today, 22nd July, is Pi Approximation Day, because 22/7
-        is a common\napproximation of <em>\u03C0</em> and closer to <em>\u03C0</em>
-        than 3.14.</p>\n<p>22/7 is a Diophantine approximation, named after Diophantus
-        of\nAlexandria (3rd century CE), which is a way of estimating a real number\nas
-        a ratio of two integers. 22/7 has been known since antiquity;\nArchimedes
-        (3rd century BCE) wrote the first known proof that 22/7\noverestimates <em>\u03C0</em>
-        by comparing 96-sided polygons to the circle it\ncircumscribes.</p>\n<p>Another
-        approximation is 355/113. In Chinese mathematics, 22/7 and\n355/113 are respectively
-        known as Yuel\xFC (\u7EA6\u7387; yu\u0113l\u01DC; &#8220;approximate\nratio&#8221;)
-        and Mil\xFC (\u5BC6\u7387; m\xECl\u01DC; &#8220;close ratio&#8221;).</p>\n<p>Happy
-        <a href=\"https://piapproximationday.com/\">Pi Approximation\nDay</a>!</p>\n<h1
-        id=\"enjoy-the-new-release\">Enjoy the new release</h1>\n<p>Thanks to all
-        of the many volunteers who help make Python Development\nand these releases
-        possible! Please consider supporting our efforts by\nvolunteering yourself
-        or through organisation contributions to the <a href=\"https://www.python.org/psf-landing/\">Python
-        Software\nFoundation</a>.</p>\n<p>Regards from a Helsinki heatwave after an
-        excellent <a href=\"https://ep2025.europython.eu/\">EuroPython</a>,</p>\n<p>Your
-        release team, <br>Hugo van Kemenade \n  <br>Ned Deily\n  <br>Steve Dower\n
-        \ <br>\u0141ukasz Langa\n</p>\n<div style='clear: both;'></div>\n</div>\n<div
-        class='post-footer'>\n<div class='post-footer-line post-footer-line-1'><span
-        class='post-author vcard'>\nPosted by\n<span class='fn'>Hugo</span>\n</span>\n<span
-        class='post-timestamp'>\nat\n<a class='timestamp-link' href='https://pythoninsider.blogspot.com/2025/07/python-314-release-candidate-1-is-go.html'
-        rel='bookmark' title='permanent link'><abbr class='published' title='2025-07-22T15:47:00-04:00'>3:47&#8239;PM</abbr></a>\n</span>\n<span
-        class='post-comment-link'>\n</span>\n<span class='post-icons'>\n</span>\n<div
-        class='post-share-buttons'>\n<a class='goog-inline-block share-button sb-email'
-        href='https://www.blogger.com/share-post.g?blogID=3941553907430899163&postID=8412948848050014787&target=email'
-        target='_blank' title='Email This'><span class='share-button-link-text'>Email
-        This</span></a><a class='goog-inline-block share-button sb-blog' href='https://www.blogger.com/share-post.g?blogID=3941553907430899163&postID=8412948848050014787&target=blog'
-        onclick='window.open(this.href, \"_blank\", \"height=270,width=475\"); return
-        false;' target='_blank' title='BlogThis!'><span class='share-button-link-text'>BlogThis!</span></a><a
-        class='goog-inline-block share-button sb-twitter' href='https://www.blogger.com/share-post.g?blogID=3941553907430899163&postID=8412948848050014787&target=twitter'
-        target='_blank' title='Share to X'><span class='share-button-link-text'>Share
-        to X</span></a><a class='goog-inline-block share-button sb-facebook' href='https://www.blogger.com/share-post.g?blogID=3941553907430899163&postID=8412948848050014787&target=facebook'
-        onclick='window.open(this.href, \"_blank\", \"height=430,width=640\"); return
-        false;' target='_blank' title='Share to Facebook'><span class='share-button-link-text'>Share
-        to Facebook</span></a><a class='goog-inline-block share-button sb-pinterest'
-        href='https://www.blogger.com/share-post.g?blogID=3941553907430899163&postID=8412948848050014787&target=pinterest'
-        target='_blank' title='Share to Pinterest'><span class='share-button-link-text'>Share
-        to Pinterest</span></a>\n</div>\n</div>\n<div class='post-footer-line post-footer-line-2'><span
-        class='post-labels'>\nLabels:\n<a href='https://pythoninsider.blogspot.com/search/label/releases'
-        rel='tag'>releases</a>\n</span>\n</div>\n<div class='post-footer-line post-footer-line-3'><span
-        class='post-location'>\n</span>\n</div>\n</div>\n</div>\n</div>\n\n          </div></div>\n
-        \       \n\n          <div class=\"date-outer\">\n        \n<h2 class='date-header'><span>Tuesday,
-        July 8, 2025</span></h2>\n\n          <div class=\"date-posts\">\n        \n<div
-        class='post-outer'>\n<div class='post hentry'>\n<a name='2902244612701978117'></a>\n<h3
-        class='post-title entry-title'>\n<a href='https://pythoninsider.blogspot.com/2025/07/python-3140-beta-4-is-here.html'>Python
-        3.14.0 beta 4 is here!</a>\n</h3>\n<div class='post-header'>\n<div class='post-header-line-1'></div>\n</div>\n<div
-        class='post-body entry-content'>\n<p><a href=\"https://www.youtube.com/watch?v=cCim90WO1-4\">It&#8217;s</a>
-        the\nfinal 3.14 beta!</p>\n<p><a class=\"uri\" href=\"https://www.python.org/downloads/release/python-3140b4/\">https://www.python.org/downloads/release/python-3140b4/</a></p>\n<p><strong>This
-        is a beta preview of Python 3.14</strong></p>\n<p>Python 3.14 is still in
-        development. This release, 3.14.0b4, is the\nlast of four planned beta releases.</p>\n<p>Beta
-        release previews are intended to give the wider community the\nopportunity
-        to test new features and bug fixes and to prepare their\nprojects to support
-        the new feature release.</p>\n<p>We <strong><em>strongly encourage</em></strong>
-        maintainers of\nthird-party Python projects to <strong><em>test with 3.14</em></strong>\nduring
-        the beta phase and report issues found to <a href=\"https://github.com/python/cpython/issues\">the
-        Python bug\ntracker</a> as soon as possible. While the release is planned
-        to be\nfeature-complete entering the beta phase, it is possible that features\nmay
-        be modified or, in rare cases, deleted up until the start of the\nrelease
-        candidate phase (Tuesday 2025-07-22). Our goal is to have\n<strong><em>no
-        ABI changes</em></strong> after beta 4 and as few code\nchanges as possible
-        after the first release candidate. To achieve that,\nit will be <strong><em>extremely
-        important</em></strong> to get as much\nexposure for 3.14 as possible during
-        the beta phase.</p>\n<p>This includes creating pre-release wheels for 3.14,
-        as it helps other\nprojects to do their own testing. However, we recommend
-        that your\nregular production releases wait until 3.14.0rc1, to avoid the
-        risk of\nABI breaks.</p>\n<p>Please keep in mind that this is a preview release
-        and its use is\n<strong><em>not</em></strong> recommended for production\nenvironments.</p>\n<h1
-        id=\"major-new-features-of-the-3.14-series-compared-to-3.13\">Major\nnew features
-        of the 3.14 series, compared to 3.13</h1>\n<p>Some of the major new features
-        and changes in Python 3.14 are:</p>\n<h2 id=\"new-features\">New features</h2>\n<p><em>Note
-        that PEPs <a href=\"https://discuss.python.org/t/pep-734-multiple-interpreters-in-the-stdlib/41147/36\">734</a>\nand
-        <a href=\"https://discuss.python.org/t/pep-779-criteria-for-supported-status-for-free-threaded-python/84319/123\">779</a>\nare
-        exceptionally new in beta 3!</em></p>\n<ul>\n<li><a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pep779\">PEP\n779</a>:
-        Free-threaded Python is officially supported</li>\n<li><a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pep649\">PEP\n649</a>:
-        The evaluation of type annotations is now deferred, improving\nthe semantics
-        of using annotations.</li>\n<li><a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pep750\">PEP\n750</a>:
-        Template string literals (t-strings) for custom string\nprocessing, using
-        the familiar syntax of f-strings.</li>\n<li><a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pep734\">PEP\n734</a>:
-        Multiple interpreters in the stdlib.</li>\n<li><a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pep784\">PEP\n784</a>:
-        A new module <code>compression.zstd</code> providing support\nfor the Zstandard
-        compression algorithm.</li>\n<li><a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pep758\">PEP\n758</a>:
-        <code>except</code> and <code>except*</code> expressions may\nnow omit the
-        brackets.</li>\n<li><a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pyrepl-highlighting\">Syntax\nhighlighting
-        in PyREPL</a>, and support for color in <a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-color-unittest\">unittest</a>,\n<a
-        href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-color-argparse\">argparse</a>,\n<a
-        href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-color-json\">json</a>\nand
-        <a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-color-calendar\">calendar</a>\nCLIs.</li>\n<li><a
-        href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pep768\">PEP\n768</a>:
-        A zero-overhead external debugger interface for CPython.</li>\n<li><a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#uuid\">UUID\nversions
-        6-8</a> are now supported by the <code>uuid</code> module, and\ngeneration
-        of versions 3-5 and 8 are up to 40% faster.</li>\n<li><a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pep765\">PEP\n765</a>:
-        Disallow\n<code>return</code>/<code>break</code>/<code>continue</code> that
-        exit a\n<code>finally</code> block.</li>\n<li><a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pep741\">PEP\n741</a>:
-        An improved C API for configuring Python.</li>\n<li>A <a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-tail-call\">new\ntype
-        of interpreter</a>. For certain newer compilers, this interpreter\nprovides
-        significantly better performance. Opt-in for now, requires\nbuilding from
-        source.</li>\n<li><a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#improved-error-messages\">Improved\nerror
-        messages.</a></li>\n<li><a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#hmac\">Builtin\nimplementation
-        of HMAC</a> with formally verified code from the HACL*\nproject.</li>\n<li>A
-        <a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#asyncio-introspection-capabilities\">new\ncommand-line
-        interface</a> to inspect running Python processes using\nasynchronous tasks.</li>\n<li>The
-        pdb module now supports <a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#remote-attaching-to-a-running-python-process-with-pdb\">remote\nattaching
-        to a running Python process</a>.</li>\n</ul>\n<p><small>(Hey, <strong>fellow
-        core developer,</strong> if a feature you\nfind important is missing from
-        this list, let Hugo know.)</small></p>\n<p>For more details on the changes
-        to Python 3.14, see <a href=\"https://docs.python.org/3.14/whatsnew/3.14.html\">What&#8217;s
-        new in\nPython 3.14</a>. The next pre-release of Python 3.14 will be the first\nrelease
-        candidate, 3.14.0rc1, scheduled for 2025-07-22.</p>\n<h2 id=\"build-changes\">Build
-        changes</h2>\n<ul>\n<li><a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pep761\">PEP\n761</a>:
-        Python 3.14 and onwards no longer provides PGP signatures for\nrelease artifacts.
-        Instead, Sigstore is recommended for verifiers.</li>\n<li>Official macOS and
-        Windows release binaries include an <a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-jit-compiler\"><em>experimental</em>\nJIT
-        compiler</a>.</li>\n</ul>\n<h2 id=\"incompatible-changes-removals-and-new-deprecations\">Incompatible\nchanges,
-        removals and new deprecations</h2>\n<ul>\n<li><a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#incompatible-changes\">Incompatible\nchanges</a></li>\n<li>Python
-        <a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#removed\">removals</a>\nand
-        <a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#deprecated\">deprecations</a></li>\n<li>C
-        API <a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#c-api-removed\">removals</a>\nand
-        <a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#c-api-deprecated\">deprecations</a></li>\n<li>Overview
-        of all <a href=\"https://docs.python.org/3.14/deprecations/index.html\">pending\ndeprecations</a></li>\n</ul>\n<h1
-        id=\"python-install-manager\">Python install manager</h1>\n<p>The installer
-        we offer for Windows is being replaced by our new\ninstall manager, which
-        can be installed from <a href=\"https://apps.microsoft.com/detail/9NQ7512CXL7T\">the
-        Windows\nStore</a> or from its <a href=\"https://www.python.org/downloads/latest/pymanager/\">download\npage</a>.
-        See <a href=\"https://docs.python.org/3.14/using/windows.html\">our\ndocumentation</a>
-        for more information. The JSON file available for\ndownload below contains
-        the list of all the installable packages\navailable as part of this release,
-        including file URLs and hashes, but\nis not required to install the latest
-        release. The traditional installer\nwill remain available throughout the 3.14
-        and 3.15 releases.</p>\n<h1 id=\"more-resources\">More resources</h1>\n<ul>\n<li><a
-        href=\"https://docs.python.org/3.14/\">Online\ndocumentation</a></li>\n<li><a
-        href=\"https://peps.python.org/pep-0745/\">PEP 745</a>, 3.14\nRelease Schedule</li>\n<li>Report
-        bugs at <a href=\"https://github.com/python/cpython/issues\">github.com/python/cpython/issues</a></li>\n<li><a
-        href=\"https://www.python.org/psf/donations/\">Help fund Python and\nits community</a></li>\n</ul>\n<h1
-        id=\"and-now-for-something-completely-different\">And now for\nsomething completely
-        different</h1>\n<p>All this talk of <em>\u03C0</em> and yet some say <em>\u03C0</em>
-        is wrong. <a href=\"https://www.tauday.com/\">Tau Day</a> (June 28th, 6/28
-        in the US)\ncelebrates <em>\u03C4</em> as the &#8220;true circle constant&#8221;,
-        as the ratio of a\ncircle&#8217;s circumference to its radius, <em>C/r</em>
-        = 6.283185&#8230; The <a href=\"https://www.tauday.com/tau-manifesto\">Tau
-        Manifesto</a> declares\n<em>\u03C0</em> &#8220;a confusing and unnatural choice
-        for the circle constant&#8221;,\nin part because &#8220;<em>2\u03C0</em> occurs
-        with astonishing frequency\nthroughout mathematics&#8221;.</p>\n<p>If you
-        wish to embrace <em>\u03C4</em> the good news is <a href=\"https://peps.python.org/pep-0628/\">PEP
-        628</a> added <a href=\"https://docs.python.org/3/library/math.html#math.tau\"><code>math.tau</code></a>\nto
-        Python 3.6 in 2016:</p>\n<blockquote>\n<p>When working with radians, it is
-        trivial to convert any given\nfraction of a circle to a value in radians in
-        terms of <code>tau</code>.\nA quarter circle is <code>tau/4</code>, a half
-        circle is\n<code>tau/2</code>, seven 25ths is <code>7*tau/25</code>, etc.
-        In\ncontrast with the equivalent expressions in terms of <code>pi</code>\n(<code>pi/2</code>,
-        <code>pi</code>, <code>14*pi/25</code>), the\nunnecessary and needlessly confusing
-        multiplication by two is gone.</p>\n</blockquote>\n<h1 id=\"enjoy-the-new-release\">Enjoy
-        the new release</h1>\n<p>Thanks to all of the many volunteers who help make
-        Python Development\nand these releases possible! Please consider supporting
-        our efforts by\nvolunteering yourself or through organisation contributions
-        to the <a href=\"https://www.python.org/psf-landing/\">Python Software\nFoundation</a>.</p>\n<p>Regards
-        from a cloudy Helsinki, looking forward to Prague and <a href=\"https://ep2025.europython.eu/\">EuroPython</a>
-        next week,</p>\n<p>Your release team, <br>Hugo van Kemenade <br>Ned Deily
-        <br>Steve\nDower <br>\u0141ukasz Langa</p>\n<div style='clear: both;'></div>\n</div>\n<div
-        class='post-footer'>\n<div class='post-footer-line post-footer-line-1'><span
-        class='post-author vcard'>\nPosted by\n<span class='fn'>Hugo</span>\n</span>\n<span
-        class='post-timestamp'>\nat\n<a class='timestamp-link' href='https://pythoninsider.blogspot.com/2025/07/python-3140-beta-4-is-here.html'
-        rel='bookmark' title='permanent link'><abbr class='published' title='2025-07-08T11:04:00-04:00'>11:04&#8239;AM</abbr></a>\n</span>\n<span
-        class='post-comment-link'>\n</span>\n<span class='post-icons'>\n</span>\n<div
-        class='post-share-buttons'>\n<a class='goog-inline-block share-button sb-email'
-        href='https://www.blogger.com/share-post.g?blogID=3941553907430899163&postID=2902244612701978117&target=email'
-        target='_blank' title='Email This'><span class='share-button-link-text'>Email
-        This</span></a><a class='goog-inline-block share-button sb-blog' href='https://www.blogger.com/share-post.g?blogID=3941553907430899163&postID=2902244612701978117&target=blog'
-        onclick='window.open(this.href, \"_blank\", \"height=270,width=475\"); return
-        false;' target='_blank' title='BlogThis!'><span class='share-button-link-text'>BlogThis!</span></a><a
-        class='goog-inline-block share-button sb-twitter' href='https://www.blogger.com/share-post.g?blogID=3941553907430899163&postID=2902244612701978117&target=twitter'
-        target='_blank' title='Share to X'><span class='share-button-link-text'>Share
-        to X</span></a><a class='goog-inline-block share-button sb-facebook' href='https://www.blogger.com/share-post.g?blogID=3941553907430899163&postID=2902244612701978117&target=facebook'
-        onclick='window.open(this.href, \"_blank\", \"height=430,width=640\"); return
-        false;' target='_blank' title='Share to Facebook'><span class='share-button-link-text'>Share
-        to Facebook</span></a><a class='goog-inline-block share-button sb-pinterest'
-        href='https://www.blogger.com/share-post.g?blogID=3941553907430899163&postID=2902244612701978117&target=pinterest'
-        target='_blank' title='Share to Pinterest'><span class='share-button-link-text'>Share
-        to Pinterest</span></a>\n</div>\n</div>\n<div class='post-footer-line post-footer-line-2'><span
-        class='post-labels'>\nLabels:\n<a href='https://pythoninsider.blogspot.com/search/label/releases'
-        rel='tag'>releases</a>\n</span>\n</div>\n<div class='post-footer-line post-footer-line-3'><span
-        class='post-location'>\n</span>\n</div>\n</div>\n</div>\n</div>\n\n          </div></div>\n
-        \       \n\n          <div class=\"date-outer\">\n        \n<h2 class='date-header'><span>Tuesday,
-        June 17, 2025</span></h2>\n\n          <div class=\"date-posts\">\n        \n<div
-        class='post-outer'>\n<div class='post hentry'>\n<a name='6430176619474922622'></a>\n<h3
-        class='post-title entry-title'>\n<a href='https://pythoninsider.blogspot.com/2025/06/python-3140-beta-3-is-here.html'>Python
-        3.14.0 beta 3 is here!</a>\n</h3>\n<div class='post-header'>\n<div class='post-header-line-1'></div>\n</div>\n<div
-        class='post-body entry-content'>\n<p>It&#8217;s 3.14 beta 3!</p>\n<p><a class=\"uri\"
-        href=\"https://www.python.org/downloads/release/python-3140b3/\">https://www.python.org/downloads/release/python-3140b3/</a></p>\n<p><strong>This
-        is a beta preview of Python 3.14</strong></p>\n<p>Python 3.14 is still in
-        development. This release, 3.14.0b3, is the\nthird of four planned beta releases.</p>\n<p>Beta
-        release previews are intended to give the wider community the\nopportunity
-        to test new features and bug fixes and to prepare their\nprojects to support
-        the new feature release.</p>\n<p>We <strong><em>strongly encourage</em></strong>
-        maintainers of\nthird-party Python projects to <strong><em>test with 3.14</em></strong>\nduring
-        the beta phase and report issues found to <a href=\"https://github.com/python/cpython/issues\">the
-        Python bug\ntracker</a> as soon as possible. While the release is planned
-        to be\nfeature-complete entering the beta phase, it is possible that features\nmay
-        be modified or, in rare cases, deleted up until the start of the\nrelease
-        candidate phase (Tuesday 2025-07-22). Our goal is to have\n<strong><em>no
-        ABI changes</em></strong> after beta 4 and as few code\nchanges as possible
-        after the first release candidate. To achieve that,\nit will be <strong><em>extremely
-        important</em></strong> to get as much\nexposure for 3.14 as possible during
-        the beta phase.</p>\n<p>This includes creating pre-release wheels for 3.14,
-        as it helps other\nprojects to do their own testing. However, we recommend
-        that your\nregular production releases wait until 3.14.0rc1, to avoid the
-        risk of\nABI breaks.</p>\n<p>Please keep in mind that this is a preview release
-        and its use is\n<strong><em>not</em></strong> recommended for production\nenvironments.</p>\n<h1
-        id=\"major-new-features-of-the-3.14-series-compared-to-3.13\">Major\nnew features
-        of the 3.14 series, compared to 3.13</h1>\n<p>Some of the major new features
-        and changes in Python 3.14 are:</p>\n<h2 id=\"new-features\">New features</h2>\n<p><em>Note
-        that PEPs <a href=\"https://discuss.python.org/t/pep-734-multiple-interpreters-in-the-stdlib/41147/36\">734</a>\nand
-        <a href=\"https://discuss.python.org/t/pep-779-criteria-for-supported-status-for-free-threaded-python/84319/123\">779</a>\nare
-        exceptionally new in beta 3!</em></p>\n<ul>\n<li><a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pep779\">PEP\n779</a>:
-        Free-threaded Python is officially supported</li>\n<li><a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pep649\">PEP\n649</a>:
-        The evaluation of type annotations is now deferred, improving\nthe semantics
-        of using annotations.</li>\n<li><a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pep750\">PEP\n750</a>:
-        Template string literals (t-strings) for custom string\nprocessing, using
-        the familiar syntax of f-strings.</li>\n<li><a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pep734\">PEP\n734</a>:
-        Multiple interpreters in the stdlib.</li>\n<li><a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pep784\">PEP\n784</a>:
-        A new module <code>compression.zstd</code> providing support\nfor the Zstandard
-        compression algorithm.</li>\n<li><a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pep758\">PEP\n758</a>:
-        <code>except</code> and <code>except*</code> expressions may\nnow omit the
-        brackets.</li>\n<li><a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pyrepl-highlighting\">Syntax\nhighlighting
-        in PyREPL</a>, and support for color in <a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-color-unittest\">unittest</a>,\n<a
-        href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-color-argparse\">argparse</a>,\n<a
-        href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-color-json\">json</a>\nand
-        <a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-color-calendar\">calendar</a>\nCLIs.</li>\n<li><a
-        href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pep768\">PEP\n768</a>:
-        A zero-overhead external debugger interface for CPython.</li>\n<li><a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#uuid\">UUID\nversions
-        6-8</a> are now supported by the <code>uuid</code> module, and\ngeneration
-        of versions 3-5 and 8 are up to 40% faster.</li>\n<li><a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pep765\">PEP\n765</a>:
-        Disallow\n<code>return</code>/<code>break</code>/<code>continue</code> that
-        exit a\n<code>finally</code> block.</li>\n<li><a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pep741\">PEP\n741</a>:
-        An improved C API for configuring Python.</li>\n<li>A <a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-tail-call\">new\ntype
-        of interpreter</a>. For certain newer compilers, this interpreter\nprovides
-        significantly better performance. Opt-in for now, requires\nbuilding from
-        source.</li>\n<li><a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#improved-error-messages\">Improved\nerror
-        messages.</a></li>\n<li><a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#hmac\">Builtin\nimplementation
-        of HMAC</a> with formally verified code from the HACL*\nproject.</li>\n<li>A
-        <a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#asyncio-introspection-capabilities\">new\ncommand-line
-        interface</a> to inspect running Python processes using\nasynchronous tasks.</li>\n<li>The
-        pdb module now supports <a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#remote-attaching-to-a-running-python-process-with-pdb\">remote\nattaching
-        to a running Python process</a>.</li>\n</ul>\n<p><small>(Hey, <strong>fellow
-        core developer,</strong> if a feature you\nfind important is missing from
-        this list, let Hugo know.)</small></p>\n<p>For more details on the changes
-        to Python 3.14, see <a href=\"https://docs.python.org/3.14/whatsnew/3.14.html\">What&#8217;s
-        new in\nPython 3.14</a>. The next pre-release of Python 3.14 will be the final\nbeta,
-        3.14.0b4, scheduled for 2025-07-08.</p>\n<h2 id=\"build-changes\">Build changes</h2>\n<ul>\n<li><a
-        href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pep761\">PEP\n761</a>:
-        Python 3.14 and onwards no longer provides PGP signatures for\nrelease artifacts.
-        Instead, Sigstore is recommended for verifiers.</li>\n<li>Official macOS and
-        Windows release binaries include an <a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-jit-compiler\"><em>experimental</em>\nJIT
-        compiler</a>.</li>\n</ul>\n<h2 id=\"incompatible-changes-removals-and-new-deprecations\">Incompatible\nchanges,
-        removals and new deprecations</h2>\n<ul>\n<li><a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#incompatible-changes\">Incompatible\nchanges</a></li>\n<li>Python
-        <a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#removed\">removals</a>\nand
-        <a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#deprecated\">deprecations</a></li>\n<li>C
-        API <a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#c-api-removed\">removals</a>\nand
-        <a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#c-api-deprecated\">deprecations</a></li>\n<li>Overview
-        of all <a href=\"https://docs.python.org/3.14/deprecations/index.html\">pending\ndeprecations</a></li>\n</ul>\n<h1
-        id=\"python-install-manager\">Python install manager</h1>\n<p>The installer
-        we offer for Windows is being replaced by our new\ninstall manager, which
-        can be installed from <a href=\"https://apps.microsoft.com/detail/9NQ7512CXL7T\">the
-        Windows\nStore</a> or <a href=\"https://www.python.org/ftp/python/pymanager/\">our\nFTP
-        page</a>. See <a href=\"https://docs.python.org/3.14/using/windows.html\">our\ndocumentation</a>
-        for more information. The JSON file available for\ndownload below contains
-        the list of all the installable packages\navailable as part of this release,
-        including file URLs and hashes, but\nis not required to install the latest
-        release. The traditional installer\nwill remain available throughout the 3.14
-        and 3.15 releases.</p>\n<h1 id=\"more-resources\">More resources</h1>\n<ul>\n<li><a
-        href=\"https://docs.python.org/3.14/\">Online\ndocumentation</a></li>\n<li><a
-        href=\"https://peps.python.org/pep-0745/\">PEP 745</a>, 3.14\nRelease Schedule</li>\n<li>Report
-        bugs at <a href=\"https://github.com/python/cpython/issues\">github.com/python/cpython/issues</a></li>\n<li><a
-        href=\"https://www.python.org/psf/donations/\">Help fund Python and\nits community</a></li>\n</ul>\n<h1
-        id=\"and-now-for-something-completely-different\">And now for\nsomething completely
-        different</h1>\n<p>If you&#8217;re heading out to sea, remember the <a href=\"https://xkcd.com/3023/\">Maritime
-        Approximation</a>:</p>\n<blockquote>\n<p><em>\u03C0</em> mph = <em>e</em>
-        knots</p>\n</blockquote>\n<h1 id=\"enjoy-the-new-release\">Enjoy the new release</h1>\n<p>Thanks
-        to all of the many volunteers who help make Python Development\nand these
-        releases possible! Please consider supporting our efforts by\nvolunteering
-        yourself or through organisation contributions to the <a href=\"https://www.python.org/psf-landing/\">Python
-        Software\nFoundation</a>.</p>\n<p>Regards from sunny Helsinki with 19 hours
-        of daylight,</p>\n<p>Your release team, \n  <br>Hugo van Kemenade\n  <br>Ned
-        Deily\n  <br>Steve Dower\n  <br>\u0141ukasz Langa\n</p>\n<div style='clear:
-        both;'></div>\n</div>\n<div class='post-footer'>\n<div class='post-footer-line
-        post-footer-line-1'><span class='post-author vcard'>\nPosted by\n<span class='fn'>Hugo</span>\n</span>\n<span
-        class='post-timestamp'>\nat\n<a class='timestamp-link' href='https://pythoninsider.blogspot.com/2025/06/python-3140-beta-3-is-here.html'
-        rel='bookmark' title='permanent link'><abbr class='published' title='2025-06-17T14:43:00-04:00'>2:43&#8239;PM</abbr></a>\n</span>\n<span
-        class='post-comment-link'>\n</span>\n<span class='post-icons'>\n</span>\n<div
-        class='post-share-buttons'>\n<a class='goog-inline-block share-button sb-email'
-        href='https://www.blogger.com/share-post.g?blogID=3941553907430899163&postID=6430176619474922622&target=email'
-        target='_blank' title='Email This'><span class='share-button-link-text'>Email
-        This</span></a><a class='goog-inline-block share-button sb-blog' href='https://www.blogger.com/share-post.g?blogID=3941553907430899163&postID=6430176619474922622&target=blog'
-        onclick='window.open(this.href, \"_blank\", \"height=270,width=475\"); return
-        false;' target='_blank' title='BlogThis!'><span class='share-button-link-text'>BlogThis!</span></a><a
-        class='goog-inline-block share-button sb-twitter' href='https://www.blogger.com/share-post.g?blogID=3941553907430899163&postID=6430176619474922622&target=twitter'
-        target='_blank' title='Share to X'><span class='share-button-link-text'>Share
-        to X</span></a><a class='goog-inline-block share-button sb-facebook' href='https://www.blogger.com/share-post.g?blogID=3941553907430899163&postID=6430176619474922622&target=facebook'
-        onclick='window.open(this.href, \"_blank\", \"height=430,width=640\"); return
-        false;' target='_blank' title='Share to Facebook'><span class='share-button-link-text'>Share
-        to Facebook</span></a><a class='goog-inline-block share-button sb-pinterest'
-        href='https://www.blogger.com/share-post.g?blogID=3941553907430899163&postID=6430176619474922622&target=pinterest'
-        target='_blank' title='Share to Pinterest'><span class='share-button-link-text'>Share
-        to Pinterest</span></a>\n</div>\n</div>\n<div class='post-footer-line post-footer-line-2'><span
-        class='post-labels'>\nLabels:\n<a href='https://pythoninsider.blogspot.com/search/label/releases'
-        rel='tag'>releases</a>\n</span>\n</div>\n<div class='post-footer-line post-footer-line-3'><span
-        class='post-location'>\n</span>\n</div>\n</div>\n</div>\n</div>\n\n          </div></div>\n
-        \       \n\n          <div class=\"date-outer\">\n        \n<h2 class='date-header'><span>Wednesday,
-        June 11, 2025</span></h2>\n\n          <div class=\"date-posts\">\n        \n<div
-        class='post-outer'>\n<div class='post hentry'>\n<a name='6912588868872774611'></a>\n<h3
-        class='post-title entry-title'>\n<a href='https://pythoninsider.blogspot.com/2025/06/python-3135-is-now-available.html'>Python
-        3.13.5 is now available!</a>\n</h3>\n<div class='post-header'>\n<div class='post-header-line-1'></div>\n</div>\n<div
-        class='post-body entry-content'>\n<p>When I was younger we would call this
-        a brown paper bag release, but \nactually, we shouldn&#8217;t hide from our
-        mistakes. We&#8217;re only human. So, \nplease enjoy:</p>\n<h1 style=\"text-align:
-        left;\"><a class=\"anchor\" href=\"https://discuss.python.org/t/python-3-13-5-is-now-available-yes-really/95211#p-254481-python-3135-1\"
-        name=\"p-254481-python-3135-1\"></a>Python 3.13.5</h1><div style=\"text-align:
-        left;\">&nbsp;</div><div style=\"text-align: left;\"><a href=\"https://www.python.org/downloads/release/python-3135/\">&nbsp;https://www.python.org/downloads/release/python-3135/</a></div><h3
-        style=\"text-align: left;\"><a class=\"anchor\" href=\"https://discuss.python.org/t/python-3-13-5-is-now-available-yes-really/95211#p-254481-this-is-the-fifth-maintenance-release-of-python-313-2\"
-        name=\"p-254481-this-is-the-fifth-maintenance-release-of-python-313-2\"></a>&nbsp;</h3><h3
-        style=\"text-align: left;\">This is the fifth maintenance release of Python
-        3.13</h3>\n<p>Python 3.13 is the newest major release of the Python programming
-        \nlanguage, and it contains many new features and optimizations compared \nto
-        Python 3.12. 3.13.5 is the fifth maintenance release of 3.13.</p>\n<p>3.13.5
-        is an expedited release to fix a couple of significant issues with the 3.13.4
-        release:</p>\n<ul><li><a href=\"https://github.com/python/cpython/issues/135151\">gh-135151</a>:
-        Building extension modules on Windows for the regular (non-free-threaded)
-        build failed.</li><li><a aria-label=\"gh-135171 link clicked 1 time\" data-clicks=\"1\"
-        href=\"https://github.com/python/cpython/issues/135171\">gh-135171</a>: Generator
-        expressions stopped raising <code>TypeError</code> (when iterating over non-iterable
-        objects) at creation time, delaying it to first use.</li><li><a href=\"https://github.com/python/cpython/issues/135326\">gh-135326</a>:
-        Passing int-like objects (like <code>numpy.int64</code>) to <code>random.getrandbits()</code>
-        failed, when it worked before.</li></ul>\n<p>Several other bug fixes (which
-        would otherwise have waited until the \nnext release) are also included. Special
-        thanks to everyone who worked \nhard the last couple of days to fix these
-        issues as quickly as possible.</p>\n<p><a href=\"https://docs.python.org/release/3.13.5/whatsnew/changelog.html#python-3-13-5\">Full
-        Changelog</a></p>\n<h3 style=\"text-align: left;\"><a class=\"anchor\" href=\"https://discuss.python.org/t/python-3-13-5-is-now-available-yes-really/95211#p-254481-more-resources-3\"
-        name=\"p-254481-more-resources-3\"></a>More resources</h3>\n<ul><li><a href=\"https://docs.python.org/3.13/\">Online
-        Documentation</a></li><li><a aria-label=\"PEP 719 link clicked 1 time\" data-clicks=\"1\"
-        href=\"https://peps.python.org/pep-0719/\">PEP 719</a>, 3.13 Release Schedule
-        (not that you&#8217;ll find this release on there yet.)</li><li>Report bugs
-        via <a href=\"https://github.com/python/cpython/issues\">GitHub</a>.</li><li><a
-        href=\"https://www.python.org/psf/donations/python-dev/\">Help fund Python
-        directly</a> (or <a href=\"https://github.com/sponsors/python\">via GitHub
-        Sponsors</a>), and support <a href=\"https://www.python.org/psf/donations/\">the
-        Python community</a>.</li></ul>\n<h3 style=\"text-align: left;\"><a class=\"anchor\"
-        href=\"https://discuss.python.org/t/python-3-13-5-is-now-available-yes-really/95211#p-254481-stay-safe-and-upgrade-4\"
-        name=\"p-254481-stay-safe-and-upgrade-4\"></a>&nbsp;</h3><h3 style=\"text-align:
-        left;\">Stay safe and upgrade!</h3>\n<p>As always, upgrading is highly recommended
-        to all users of 3.13.</p>\n<h3 style=\"text-align: left;\"><a class=\"anchor\"
-        href=\"https://discuss.python.org/t/python-3-13-5-is-now-available-yes-really/95211#p-254481-enjoy-the-new-releases-5\"
-        name=\"p-254481-enjoy-the-new-releases-5\"></a>&nbsp;</h3><h3 style=\"text-align:
-        left;\">Enjoy the new releases</h3>\n<p>Thanks to all of the many volunteers
-        who help make Python Development\n and these releases possible! Please consider
-        supporting our efforts by \nvolunteering yourself or through organization
-        contributions to the \nPython Software Foundation.</p>\n<p>Regards from hey,
-        it&#8217;s us again, your release team,<br />\nThomas Wouters <br />\nNed
-        Deily <br />\nSteve Dower <br />\n\u0141ukasz Langa <br /></p>\n<div style='clear:
-        both;'></div>\n</div>\n<div class='post-footer'>\n<div class='post-footer-line
-        post-footer-line-1'><span class='post-author vcard'>\nPosted by\n<span class='fn'>Thomas
-        Wouters</span>\n</span>\n<span class='post-timestamp'>\nat\n<a class='timestamp-link'
-        href='https://pythoninsider.blogspot.com/2025/06/python-3135-is-now-available.html'
-        rel='bookmark' title='permanent link'><abbr class='published' title='2025-06-11T18:03:00-04:00'>6:03&#8239;PM</abbr></a>\n</span>\n<span
-        class='post-comment-link'>\n</span>\n<span class='post-icons'>\n</span>\n<div
-        class='post-share-buttons'>\n<a class='goog-inline-block share-button sb-email'
-        href='https://www.blogger.com/share-post.g?blogID=3941553907430899163&postID=6912588868872774611&target=email'
-        target='_blank' title='Email This'><span class='share-button-link-text'>Email
-        This</span></a><a class='goog-inline-block share-button sb-blog' href='https://www.blogger.com/share-post.g?blogID=3941553907430899163&postID=6912588868872774611&target=blog'
-        onclick='window.open(this.href, \"_blank\", \"height=270,width=475\"); return
-        false;' target='_blank' title='BlogThis!'><span class='share-button-link-text'>BlogThis!</span></a><a
-        class='goog-inline-block share-button sb-twitter' href='https://www.blogger.com/share-post.g?blogID=3941553907430899163&postID=6912588868872774611&target=twitter'
-        target='_blank' title='Share to X'><span class='share-button-link-text'>Share
-        to X</span></a><a class='goog-inline-block share-button sb-facebook' href='https://www.blogger.com/share-post.g?blogID=3941553907430899163&postID=6912588868872774611&target=facebook'
-        onclick='window.open(this.href, \"_blank\", \"height=430,width=640\"); return
-        false;' target='_blank' title='Share to Facebook'><span class='share-button-link-text'>Share
-        to Facebook</span></a><a class='goog-inline-block share-button sb-pinterest'
-        href='https://www.blogger.com/share-post.g?blogID=3941553907430899163&postID=6912588868872774611&target=pinterest'
-        target='_blank' title='Share to Pinterest'><span class='share-button-link-text'>Share
-        to Pinterest</span></a>\n</div>\n</div>\n<div class='post-footer-line post-footer-line-2'><span
-        class='post-labels'>\n</span>\n</div>\n<div class='post-footer-line post-footer-line-3'><span
-        class='post-location'>\n</span>\n</div>\n</div>\n</div>\n</div>\n\n          </div></div>\n
-        \       \n\n          <div class=\"date-outer\">\n        \n<h2 class='date-header'><span>Tuesday,
-        June 3, 2025</span></h2>\n\n          <div class=\"date-posts\">\n        \n<div
-        class='post-outer'>\n<div class='post hentry'>\n<a name='8911393060938687340'></a>\n<h3
-        class='post-title entry-title'>\n<a href='https://pythoninsider.blogspot.com/2025/06/python-3134-31211-31113-31018-and-3923.html'>Python
-        3.13.4, 3.12.11, 3.11.13, 3.10.18 and 3.9.23 are now available</a>\n</h3>\n<div
-        class='post-header'>\n<div class='post-header-line-1'></div>\n</div>\n<div
-        class='post-body entry-content'>\n<p>&nbsp;</p><h1 style=\"text-align: left;\">Python
-        Release Party</h1>\n<p>It was only meant to be release day for 3.13.4 today,
-        but poor number\n 13 looked so lonely&#8230; And hey, we had a couple of tarfile
-        CVEs that we \nhad to fix. So most of the Release Managers and all the \nDevelopers-in-Residence
-        (including Security Developer-in-Residence Seth Michael Larson) came together
-        to make it a full release party.</p>\n<h1 style=\"text-align: left;\">Security
-        content in these releases</h1>\n<ul><li><a href=\"https://github.com/python/cpython/issues/135034\">gh-135034</a>:
-        Fixes multiple issues that allowed <code>tarfile</code> extraction filters
-        (<code>filter=\"data\"</code> and <code>filter=\"tar\"</code>) to be bypassed
-        using crafted symlinks and hard links.Addresses <a href=\"https://www.cve.org/CVERecord?id=CVE-2024-12718\"><b>CVE
-        2024-12718</b></a>, <a href=\"https://www.cve.org/CVERecord?id=CVE-2025-4138\"><b>CVE
-        2025-4138</b></a>, <a href=\"https://www.cve.org/CVERecord?id=CVE-2025-4330\"><b>CVE
-        2025-4330</b></a>, and <a href=\"https://www.cve.org/CVERecord?id=CVE-2025-4517\"><b>CVE
-        2025-4517</b></a>.</li><li><a href=\"https://github.com/python/cpython/issues/133767\">gh-133767</a>:
-        Fix use-after-free in the &#8220;unicode-escape&#8221; decoder with a non-&#8220;strict&#8221;
-        error handler.</li><li><a href=\"https://github.com/python/cpython/issues/128840\">gh-128840</a>:
-        Short-circuit the processing of long IPv6 addresses early in <a href=\"https://docs.python.org/release/3.13.4/library/ipaddress.html#module-ipaddress\"><code>ipaddress</code></a>
-        to prevent excessive memory consumption and a minor denial-of-service.</li></ul>\n<p>In
-        addition to the security fixed mentioned above, a few additional changes to
-        the <code>ipaddress</code> were backported to make the security fixes feasible.
-        (See the full changelogs for each release for more details.)</p>\n<h1 style=\"text-align:
-        left;\">Python 3.13.4</h1>\n<p>In addition to the security fixes, the fourth
-        maintenance release of \nPython 3.13 contains more than 300 bugfixes, build
-        improvements and \ndocumentation changes.</p><p><a href=\"https://www.python.org/downloads/release/python-3134/\">https://www.python.org/downloads/release/python-3134/</a></p>\n\n<h1
-        style=\"text-align: left;\">Python 3.12.11</h1><p><a href=\"https://www.python.org/downloads/release/python-31211/\">https://www.python.org/downloads/release/python-31211/</a></p><h1
-        style=\"text-align: left;\">Python 3.11.13</h1><p>&nbsp;<a href=\"https://www.python.org/downloads/release/python-31113/\">https://www.python.org/downloads/release/python-31113/</a></p><h1
-        style=\"text-align: left;\">Python 3.10.18</h1>\n<aside class=\"onebox allowlistedgeneric\"
-        data-onebox-src=\"https://www.python.org/downloads/release/python-31018/\"><br
-        /></aside><aside class=\"onebox allowlistedgeneric\" data-onebox-src=\"https://www.python.org/downloads/release/python-31018/\"><a
-        href=\"https://www.python.org/downloads/release/python-31018/\">https://www.python.org/downloads/release/python-31018/</a></aside><aside
-        class=\"onebox allowlistedgeneric\" data-onebox-src=\"https://www.python.org/downloads/release/python-31018/\">&nbsp;</aside>\n\n<h1
-        style=\"text-align: left;\">Python 3.9.23</h1>\n<p>Additional security content
-        in this release (already fixed in older releases for the other versions):</p>\n<ul><li><a
-        href=\"https://github.com/python/cpython/issues/80222\">gh-80222</a>:\n Fix
-        bug in the folding of quoted strings when flattening an email \nmessage using
-        a modern email policy. Previously when a quoted string was\n folded so that
-        it spanned more than one line, the surrounding quotes \nand internal escapes
-        would be omitted. This could theoretically be used \nto spoof header lines
-        using a carefully constructed quoted string if the\n resulting rendered email
-        was transmitted or re-parsed.</li></ul>\n<aside class=\"onebox allowlistedgeneric\"
-        data-onebox-src=\"https://www.python.org/downloads/release/python-3923/\"><a
-        href=\"https://www.python.org/downloads/release/python-3923\">https://www.python.org/downloads/release/python-3923</a><div
-        class=\"onebox-metadata\">\n    \n    \n  </div>\n\n  \n<br /></aside>\n\n<h1
-        style=\"text-align: left;\">Stay safe and upgrade!</h1>\n<p>As always, upgrading
-        is highly recommended to all users of affected versions.</p>\n<h1 style=\"text-align:
-        left;\">Enjoy the new releases</h1>\n<p>Thanks to all of the many volunteers
-        who help make Python Development\n and these releases possible! Please consider
-        supporting our efforts by \nvolunteering yourself or through organization
-        contributions to the \nPython Software Foundation.</p>\n<p>Regards from your
-        very <s>tired</s> tireless release team,<br />\nThomas Wouters <br />\nPablo
-        Galindo Salgado <br />\n\u0141ukasz Langa <br />\nNed Deily <br />\nSteve
-        Dower <br /></p>\n<div style='clear: both;'></div>\n</div>\n<div class='post-footer'>\n<div
-        class='post-footer-line post-footer-line-1'><span class='post-author vcard'>\nPosted
-        by\n<span class='fn'>Thomas Wouters</span>\n</span>\n<span class='post-timestamp'>\nat\n<a
-        class='timestamp-link' href='https://pythoninsider.blogspot.com/2025/06/python-3134-31211-31113-31018-and-3923.html'
-        rel='bookmark' title='permanent link'><abbr class='published' title='2025-06-03T17:04:00-04:00'>5:04&#8239;PM</abbr></a>\n</span>\n<span
-        class='post-comment-link'>\n</span>\n<span class='post-icons'>\n</span>\n<div
-        class='post-share-buttons'>\n<a class='goog-inline-block share-button sb-email'
-        href='https://www.blogger.com/share-post.g?blogID=3941553907430899163&postID=8911393060938687340&target=email'
-        target='_blank' title='Email This'><span class='share-button-link-text'>Email
-        This</span></a><a class='goog-inline-block share-button sb-blog' href='https://www.blogger.com/share-post.g?blogID=3941553907430899163&postID=8911393060938687340&target=blog'
-        onclick='window.open(this.href, \"_blank\", \"height=270,width=475\"); return
-        false;' target='_blank' title='BlogThis!'><span class='share-button-link-text'>BlogThis!</span></a><a
-        class='goog-inline-block share-button sb-twitter' href='https://www.blogger.com/share-post.g?blogID=3941553907430899163&postID=8911393060938687340&target=twitter'
-        target='_blank' title='Share to X'><span class='share-button-link-text'>Share
-        to X</span></a><a class='goog-inline-block share-button sb-facebook' href='https://www.blogger.com/share-post.g?blogID=3941553907430899163&postID=8911393060938687340&target=facebook'
-        onclick='window.open(this.href, \"_blank\", \"height=430,width=640\"); return
-        false;' target='_blank' title='Share to Facebook'><span class='share-button-link-text'>Share
-        to Facebook</span></a><a class='goog-inline-block share-button sb-pinterest'
-        href='https://www.blogger.com/share-post.g?blogID=3941553907430899163&postID=8911393060938687340&target=pinterest'
-        target='_blank' title='Share to Pinterest'><span class='share-button-link-text'>Share
-        to Pinterest</span></a>\n</div>\n</div>\n<div class='post-footer-line post-footer-line-2'><span
-        class='post-labels'>\n</span>\n</div>\n<div class='post-footer-line post-footer-line-3'><span
-        class='post-location'>\n</span>\n</div>\n</div>\n</div>\n</div>\n\n          </div></div>\n
-        \       \n\n          <div class=\"date-outer\">\n        \n<h2 class='date-header'><span>Monday,
-        May 26, 2025</span></h2>\n\n          <div class=\"date-posts\">\n        \n<div
-        class='post-outer'>\n<div class='post hentry'>\n<a name='8971055125507701901'></a>\n<h3
-        class='post-title entry-title'>\n<a href='https://pythoninsider.blogspot.com/2025/05/python-3140-beta-2-is-here.html'>Python
-        3.14.0 beta 2 is here!</a>\n</h3>\n<div class='post-header'>\n<div class='post-header-line-1'></div>\n</div>\n<div
-        class='post-body entry-content'>\n<p>Here&#8217;s the second 3.14 beta.</p>\n<p><a
-        class=\"uri\" href=\"https://www.python.org/downloads/release/python-3140b2/\">https://www.python.org/downloads/release/python-3140b2/</a></p>\n<p><strong>This
-        is a beta preview of Python 3.14</strong></p>\n<p>Python 3.14 is still in
-        development. This release, 3.14.0b2, is the\nsecond of four planned beta releases.</p>\n<p>Beta
-        release previews are intended to give the wider community the\nopportunity
-        to test new features and bug fixes and to prepare their\nprojects to support
-        the new feature release.</p>\n<p>We <strong><em>strongly encourage</em></strong>
-        maintainers of\nthird-party Python projects to <strong><em>test with 3.14</em></strong>\nduring
-        the beta phase and report issues found to <a href=\"https://github.com/python/cpython/issues\">the
-        Python bug\ntracker</a> as soon as possible. While the release is planned
-        to be\nfeature-complete entering the beta phase, it is possible that features\nmay
-        be modified or, in rare cases, deleted up until the start of the\nrelease
-        candidate phase (Tuesday 2025-07-22). Our goal is to have\n<strong><em>no
-        ABI changes</em></strong> after beta 4 and as few code\nchanges as possible
-        after the first release candidate. To achieve that,\nit will be <strong><em>extremely
-        important</em></strong> to get as much\nexposure for 3.14 as possible during
-        the beta phase.</p>\n<p>This includes creating pre-release wheels for 3.14,
-        as it helps other\nprojects to do their own testing. However, we recommend
-        that your\nregular production releases wait until 3.14.0rc1, to avoid the
-        risk of\nABI breaks.</p>\n<p>Please keep in mind that this is a preview release
-        and its use is\n<strong><em>not</em></strong> recommended for production\nenvironments.</p>\n<h1
-        id=\"major-new-features-of-the-3.14-series-compared-to-3.13\">Major\nnew features
-        of the 3.14 series, compared to 3.13</h1>\n<p>Some of the major new features
-        and changes in Python 3.14 are:</p>\n<h2 id=\"new-features\">New features</h2>\n<ul>\n<li><a
-        href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pep649\">PEP\n649</a>:
-        The evaluation of type annotations is now deferred, improving\nthe semantics
-        of using annotations.</li>\n<li><a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pep750\">PEP\n750</a>:
-        Template string literals (t-strings) for custom string\nprocessing, using
-        the familiar syntax of f-strings.</li>\n<li><a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pep784\">PEP\n784</a>:
-        A new module <code>compression.zstd</code> providing support\nfor the Zstandard
-        compression algorithm.</li>\n<li><a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pep758\">PEP\n758</a>:
-        <code>except</code> and <code>except*</code> expressions may\nnow omit the
-        brackets.</li>\n<li><a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pyrepl-highlighting\">Syntax\nhighlighting
-        in PyREPL</a>, and support for color in <a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-color-unittest\">unittest</a>,\n<a
-        href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-color-argparse\">argparse</a>,\n<a
-        href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-color-json\">json</a>\nand
-        <a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-color-calendar\">calendar</a>\nCLIs.</li>\n<li><a
-        href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pep768\">PEP\n768</a>:
-        A zero-overhead external debugger interface for CPython.</li>\n<li><a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#uuid\">UUID\nversions
-        6-8</a> are now supported by the <code>uuid</code> module, and\ngeneration
-        of versions 3-5 and 8 are up to 40% faster.</li>\n<li><a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pep765\">PEP\n765</a>:
-        Disallow\n<code>return</code>/<code>break</code>/<code>continue</code> that
-        exit a\n<code>finally</code> block.</li>\n<li><a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pep741\">PEP\n741</a>:
-        An improved C API for configuring Python.</li>\n<li>A <a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-tail-call\">new\ntype
-        of interpreter</a>. For certain newer compilers, this interpreter\nprovides
-        significantly better performance. Opt-in for now, requires\nbuilding from
-        source.</li>\n<li><a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#improved-error-messages\">Improved\nerror
-        messages.</a></li>\n<li><a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#hmac\">Builtin\nimplementation
-        of HMAC</a> with formally verified code from the HACL*\nproject.</li>\n<li>A
-        <a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#asyncio-introspection-capabilities\">new\ncommand-line
-        interface</a> to inspect running Python processes using\nasynchronous tasks.</li>\n<li>The
-        pdb module now supports <a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#remote-attaching-to-a-running-python-process-with-pdb\">remote\nattaching
-        to a running Python process</a>.</li>\n</ul>\n<p><small>(Hey, <strong>fellow
-        core developer,</strong> if a feature you\nfind important is missing from
-        this list, let Hugo know.)</small></p>\n<p>For more details on the changes
-        to Python 3.14, see <a href=\"https://docs.python.org/3.14/whatsnew/3.14.html\">What&#8217;s
-        new in\nPython 3.14</a>. The next pre-release of Python 3.14 will be 3.14.0b3,\nscheduled
-        for 2025-06-17.</p>\n<h2 id=\"build-changes\">Build changes</h2>\n<ul>\n<li><a
-        href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pep761\">PEP\n761</a>:
-        Python 3.14 and onwards no longer provides PGP signatures for\nrelease artifacts.
-        Instead, Sigstore is recommended for verifiers.</li>\n<li>Official macOS and
-        Windows release binaries include an <a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-jit-compiler\"><em>experimental</em>\nJIT
-        compiler</a>.</li>\n</ul>\n<h2 id=\"incompatible-changes-removals-and-new-deprecations\">Incompatible\nchanges,
-        removals and new deprecations</h2>\n<ul>\n<li><a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#incompatible-changes\">Incompatible\nchanges</a></li>\n<li>Python
-        <a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#removed\">removals</a>\nand
-        <a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#deprecated\">deprecations</a></li>\n<li>C
-        API <a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#c-api-removed\">removals</a>\nand
-        <a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#c-api-deprecated\">deprecations</a></li>\n<li>Overview
-        of all <a href=\"https://docs.python.org/3.14/deprecations/index.html\">pending\ndeprecations</a></li>\n</ul>\n<h1
-        id=\"python-install-manager\">Python install manager</h1>\n<p>The installer
-        we offer for Windows is being replaced by our new\ninstall manager, which
-        can be installed from <a href=\"https://apps.microsoft.com/detail/9NQ7512CXL7T\">the
-        Windows\nStore</a> or <a href=\"https://www.python.org/ftp/python/pymanager/\">our\nFTP
-        page</a>. See <a href=\"https://docs.python.org/3.14/using/windows.html\">our\ndocumentation</a>
-        for more information. The JSON file available for\ndownload below contains
-        the list of all the installable packages\navailable as part of this release,
-        including file URLs and hashes, but\nis not required to install the latest
-        release. The traditional installer\nwill remain available throughout the 3.14
-        and 3.15 releases.</p>\n<h1 id=\"more-resources\">More resources</h1>\n<ul>\n<li><a
-        href=\"https://docs.python.org/3.14/\">Online\ndocumentation</a></li>\n<li><a
-        href=\"https://peps.python.org/pep-0745/\">PEP 745</a>, 3.14\nRelease Schedule</li>\n<li>Report
-        bugs at <a href=\"https://github.com/python/cpython/issues\">github.com/python/cpython/issues</a></li>\n<li><a
-        href=\"https://www.python.org/psf/donations/\">Help fund Python and\nits community</a></li>\n</ul>\n<h1
-        id=\"and-now-for-something-completely-different\">And now for\nsomething completely
-        different</h1>\n<p>In 1897, the State of Indiana almost passed a bill defining\n<em>\u03C0</em>
-        as 3.2.</p>\n<p>Of course, it&#8217;s not that simple.</p>\n<p>Edwin J. Goodwin,
-        M.D., claimed to have come up with a solution to an\nancient geometrical problem
-        called squaring the circle, first proposed\nin Greek mathematics. It involves
-        trying to draw a circle and a square\nwith the same area, using only a compass
-        and a straight edge. It turns\nout to be impossible because <em>\u03C0</em>
-        is transcendental (and this had\nbeen proved just 13 years earlier by Ferdinand
-        von Lindemann), but\nGoodwin fudged things so the value of <em>\u03C0</em>
-        was 3.2 (his writings\nhave included at least nine different values of <em>\u03C0</em>:
-        including 4,\n3.236, 3.232, 3.2325&#8230; and even 9.2376&#8230;).</p>\n<p>Goodwin
-        had copyrighted his proof and offered it to the State of\nIndiana to use in
-        their educational textbooks without paying royalties,\nprovided they endorsed
-        it. And so Indiana Bill No.&#160;246 was introduced to\nthe House on 18th
-        January 1897. It was not understood and initially\nreferred to the House Committee
-        on Canals, also called the Committee on\nSwamp Lands. They then referred it
-        to the Committee on Education, who\nduly recommended on 2nd February that
-        &#8220;said bill do pass&#8221;. It passed its\nsecond reading on the 5th
-        and the education chair moved that they\nsuspend the constitutional rule that
-        required bills to be read on three\nseparate days. This passed 72-0, and the
-        bill itself passed 67-0.</p>\n<p>The bill was referred to the Senate on 10th
-        February, had its first\nreading on the 11th, and was referred to the Committee
-        on Temperance,\nwhose chair on the 12th recommended &#8220;that said bill
-        do pass&#8221;.</p>\n<p>A mathematics professor, <a href=\"https://www.biodiversitylibrary.org/page/14641808#page/455/mode/1up\">Clarence\nAbiathar
-        Waldo</a>, happened to be in the State Capitol on the day the\nHouse passed
-        the bill and walked in during the debate to hear an\nex-teacher argue:</p>\n<blockquote>\n<p>The
-        case is perfectly simple. If we pass this bill which establishes\na new and
-        correct value for pi , the author offers to our state without\ncost the use
-        of his discovery and its free publication in our school\ntext books, while
-        everyone else must pay him a royalty.</p>\n</blockquote>\n<p>Waldo ensured
-        the senators were &#8220;properly coached&#8221;; and on the 12th,\nduring
-        the second reading, after an unsuccessful attempt to amend the\nbill it was
-        postponed indefinitely. But not before the senators had some\nfun.</p>\n<p>The
-        Indiana News reported on the 13th:</p>\n<blockquote>\n<p>&#8230;the bill was
-        brought up and made fun of. The Senators made bad puns\nabout it, ridiculed
-        it and laughed over it. The fun lasted half an hour.\nSenator Hubbell said
-        that it was not meet for the Senate, which was\ncosting the State $250 a day,
-        to waste its time in such frivolity. He\nsaid that in reading the leading
-        newspapers of Chicago and the East, he\nfound that the Indiana State Legislature
-        had laid itself open to\nridicule by the action already taken on the bill.
-        He thought\nconsideration of such a proposition was not dignified or worthy
-        of the\nSenate. He moved the indefinite postponement of the bill, and the
-        motion\ncarried.</p>\n</blockquote>\n<h1 id=\"enjoy-the-new-release\">Enjoy
-        the new release</h1>\n<p>Thanks to all of the many volunteers who help make
-        Python Development\nand these releases possible! Please consider supporting
-        our efforts by\nvolunteering yourself or through organisation contributions
-        to the <a href=\"https://www.python.org/psf-landing/\">Python Software\nFoundation</a>.</p>\n<p>Regards
-        from Helsinki, still light at 10pm,</p>\n<p>Your release team, <br>Hugo van
-        Kemenade<br>Ned Deily<br>Steve Dower<br>\u0141ukasz Langa</p>\n<div style='clear:
-        both;'></div>\n</div>\n<div class='post-footer'>\n<div class='post-footer-line
-        post-footer-line-1'><span class='post-author vcard'>\nPosted by\n<span class='fn'>Hugo</span>\n</span>\n<span
-        class='post-timestamp'>\nat\n<a class='timestamp-link' href='https://pythoninsider.blogspot.com/2025/05/python-3140-beta-2-is-here.html'
-        rel='bookmark' title='permanent link'><abbr class='published' title='2025-05-26T15:35:00-04:00'>3:35&#8239;PM</abbr></a>\n</span>\n<span
-        class='post-comment-link'>\n</span>\n<span class='post-icons'>\n</span>\n<div
-        class='post-share-buttons'>\n<a class='goog-inline-block share-button sb-email'
-        href='https://www.blogger.com/share-post.g?blogID=3941553907430899163&postID=8971055125507701901&target=email'
-        target='_blank' title='Email This'><span class='share-button-link-text'>Email
-        This</span></a><a class='goog-inline-block share-button sb-blog' href='https://www.blogger.com/share-post.g?blogID=3941553907430899163&postID=8971055125507701901&target=blog'
-        onclick='window.open(this.href, \"_blank\", \"height=270,width=475\"); return
-        false;' target='_blank' title='BlogThis!'><span class='share-button-link-text'>BlogThis!</span></a><a
-        class='goog-inline-block share-button sb-twitter' href='https://www.blogger.com/share-post.g?blogID=3941553907430899163&postID=8971055125507701901&target=twitter'
-        target='_blank' title='Share to X'><span class='share-button-link-text'>Share
-        to X</span></a><a class='goog-inline-block share-button sb-facebook' href='https://www.blogger.com/share-post.g?blogID=3941553907430899163&postID=8971055125507701901&target=facebook'
-        onclick='window.open(this.href, \"_blank\", \"height=430,width=640\"); return
-        false;' target='_blank' title='Share to Facebook'><span class='share-button-link-text'>Share
-        to Facebook</span></a><a class='goog-inline-block share-button sb-pinterest'
-        href='https://www.blogger.com/share-post.g?blogID=3941553907430899163&postID=8971055125507701901&target=pinterest'
-        target='_blank' title='Share to Pinterest'><span class='share-button-link-text'>Share
-        to Pinterest</span></a>\n</div>\n</div>\n<div class='post-footer-line post-footer-line-2'><span
-        class='post-labels'>\nLabels:\n<a href='https://pythoninsider.blogspot.com/search/label/releases'
-        rel='tag'>releases</a>\n</span>\n</div>\n<div class='post-footer-line post-footer-line-3'><span
-        class='post-location'>\n</span>\n</div>\n</div>\n</div>\n</div>\n\n          </div></div>\n
-        \       \n\n          <div class=\"date-outer\">\n        \n<h2 class='date-header'><span>Wednesday,
-        May 7, 2025</span></h2>\n\n          <div class=\"date-posts\">\n        \n<div
-        class='post-outer'>\n<div class='post hentry'>\n<a name='7865809690778671094'></a>\n<h3
-        class='post-title entry-title'>\n<a href='https://pythoninsider.blogspot.com/2025/05/python-3140-beta-1-is-here.html'>Python
-        3.14.0 beta 1 is here!</a>\n</h3>\n<div class='post-header'>\n<div class='post-header-line-1'></div>\n</div>\n<div
-        class='post-body entry-content'>\n<p>Only one day late, welcome to the first
-        beta!</p>\n<p><a class=\"uri\" href=\"https://www.python.org/downloads/release/python-3140b1/\">https://www.python.org/downloads/release/python-3140b1/</a></p>\n<p><strong>This
-        is a beta preview of Python 3.14</strong></p>\n<p>Python 3.14 is still in
-        development. This release, 3.14.0b1, is the\nfirst of four planned beta releases.</p>\n<p>Beta
-        release previews are intended to give the wider community the\nopportunity
-        to test new features and bug fixes and to prepare their\nprojects to support
-        the new feature release.</p>\n<p>We <strong><em>strongly encourage</em></strong>
-        maintainers of\nthird-party Python projects to <strong><em>test with 3.14</em></strong>\nduring
-        the beta phase and report issues found to <a href=\"https://github.com/python/cpython/issues\">the
-        Python bug\ntracker</a> as soon as possible. While the release is planned
-        to be\nfeature-complete entering the beta phase, it is possible that features\nmay
-        be modified or, in rare cases, deleted up until the start of the\nrelease
-        candidate phase (Tuesday 2025-07-22). Our goal is to have\n<strong><em>no
-        ABI changes</em></strong> after beta 4 and as few code\nchanges as possible
-        after the first release candidate. To achieve that,\nit will be <strong><em>extremely
-        important</em></strong> to get as much\nexposure for 3.14 as possible during
-        the beta phase.</p>\n<p>Please keep in mind that this is a preview release
-        and its use is\n<strong><em>not</em></strong> recommended for production\nenvironments.</p>\n<h1
-        id=\"major-new-features-of-the-3.14-series-compared-to-3.13\">Major\nnew features
-        of the 3.14 series, compared to 3.13</h1>\n<p>Some of the major new features
-        and changes in Python 3.14 are:</p>\n<h2 id=\"new-features\">New features</h2>\n<ul>\n<li><a
-        href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pep649\">PEP\n649</a>:
-        The evaluation of type annotations is now deferred, improving\nthe semantics
-        of using annotations.</li>\n<li><a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pep750\">PEP\n750</a>:
-        Template string literals (t-strings) for custom string\nprocessing, using
-        the familiar syntax of f-strings.</li>\n<li><a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pep784\">PEP\n784</a>:
-        A new module <code>compression.zstd</code> providing support\nfor the Zstandard
-        compression algorithm.</li>\n<li><a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pep758\">PEP\n758</a>:
-        <code>except</code> and <code>except*</code> expressions may\nnow omit the
-        brackets.</li>\n<li><a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pyrepl-highlighting\">Syntax\nhighlighting
-        in PyREPL</a>, and support for color in <a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-color-unittest\">unittest</a>,\n<a
-        href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-color-argparse\">argparse</a>,\n<a
-        href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-color-json\">json</a>\nand
-        <a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-color-calendar\">calendar</a>\nCLIs.</li>\n<li><a
-        href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pep768\">PEP\n768</a>:
-        A zero-overhead external debugger interface for CPython.</li>\n<li><a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#uuid\">UUID\nversions
-        6-8</a> are now supported by the <code>uuid</code> module, and\ngeneration
-        of versions 3-5 and 8 are up to 40% faster.</li>\n<li><a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pep765\">PEP\n765</a>:
-        Disallow\n<code>return</code>/<code>break</code>/<code>continue</code> that
-        exit a\n<code>finally</code> block.</li>\n<li><a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pep741\">PEP\n741</a>:
-        An improved C API for configuring Python.</li>\n<li>A <a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-tail-call\">new\ntype
-        of interpreter</a>. For certain newer compilers, this interpreter\nprovides
-        significantly better performance. Opt-in for now, requires\nbuilding from
-        source.</li>\n<li><a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#improved-error-messages\">Improved\nerror
-        messages.</a></li>\n<li>Builtin implementation of HMAC with formally verified
-        code from the\nHACL* project.</li>\n</ul>\n<p><small>(Hey, <strong>fellow
-        core developer,</strong> if a feature you\nfind important is missing from
-        this list, let Hugo know.)</small></p>\n<p>For more details on the changes
-        to Python 3.14, see <a href=\"https://docs.python.org/3.14/whatsnew/3.14.html\">What&#8217;s
-        new in\nPython 3.14</a>. The next pre-release of Python 3.14 will be 3.14.0b2,\nscheduled
-        for 2025-05-27.</p>\n<h2 id=\"build-changes\">Build changes</h2>\n<ul>\n<li><a
-        href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pep761\">PEP\n761</a>:
-        Python 3.14 and onwards no longer provides PGP signatures for\nrelease artifacts.
-        Instead, Sigstore is recommended for verifiers.</li>\n<li>Official macOS and
-        Windows release binaries include an <a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-jit-compiler\"><em>experimental</em>\nJIT
-        compiler</a>.</li>\n</ul>\n<h2 id=\"incompatible-changes-removals-and-new-deprecations\">Incompatible\nchanges,
-        removals and new deprecations</h2>\n<ul>\n<li><a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#incompatible-changes\">Incompatible\nchanges</a></li>\n<li>Python
-        <a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#removed\">removals</a>\nand
-        <a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#deprecated\">deprecations</a></li>\n<li>C
-        API <a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#c-api-removed\">removals</a>\nand
-        <a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#c-api-deprecated\">deprecations</a></li>\n<li>Overview
-        of all <a href=\"https://docs.python.org/3.14/deprecations/index.html\">pending\ndeprecations</a></li>\n</ul>\n<h1
-        id=\"python-install-manager\">Python install manager</h1>\n<p>The installer
-        we offer for Windows is being replaced by our new\ninstall manager, which
-        can be installed from <a href=\"https://apps.microsoft.com/detail/9NQ7512CXL7T\">the
-        Windows\nStore</a> or <a href=\"https://www.python.org/ftp/python/pymanager/\">our\nFTP
-        page</a>. See <a href=\"https://docs.python.org/3.14/using/windows.html\">our\ndocumentation</a>
-        for more information. The <a href=\"https://www.python.org/ftp/python/3.14.0/windows-3.14.0b1.json\">JSON
-        file available for\n  download</a>  contains the list of all the installable
-        packages\navailable as part of this release, including file URLs and hashes,
-        but\nis not required to install the latest release. The traditional installer\nwill
-        remain available throughout the 3.14 and 3.15 releases.</p>\n<h1 id=\"more-resources\">More
-        resources</h1>\n<ul>\n<li><a href=\"https://docs.python.org/3.14/\">Online\ndocumentation</a></li>\n<li><a
-        href=\"https://peps.python.org/pep-0745/\">PEP 745</a>, 3.14\nRelease Schedule</li>\n<li>Report
-        bugs at <a href=\"https://github.com/python/cpython/issues\">github.com/python/cpython/issues</a></li>\n<li><a
-        href=\"https://www.python.org/psf/donations/\">Help fund Python and\nits community</a></li>\n</ul>\n<h1
-        id=\"note\">Note</h1>\n<p>During the release process, we discovered a test
-        that only failed\nwhen run sequentially and only when run after a certain
-        number of other\ntests. This appears to be a problem with the test itself,
-        and we will\nmake it more robust for beta 2. For details, see <a href=\"https://github.com/python/cpython/issues/133532\">python/cpython#133532</a>.</p>\n<h1
-        id=\"and-now-for-something-completely-different\">And now for\nsomething completely
-        different</h1>\n<p>The mathematical constant pi is represented by the Greek
-        letter\n<em>\u03C0</em> and represents the ratio of a circle&#8217;s circumference
-        to its\ndiameter. The first person to use <em>\u03C0</em> as a symbol for
-        this ratio\nwas Welsh self-taught mathematician William Jones in 1706. He
-        was a\nfarmer&#8217;s son born in Llanfihangel Tre&#8217;r Beirdd on Angelsy
-        (Ynys M\xF4n) in\n1675 and only received a basic education at a local charity
-        school.\nHowever, the owner of his parents&#8217; farm noticed his mathematical
-        ability\nand arranged for him to move to London to work in a bank.</p>\n<p>By
-        age 20, he served at sea in the Royal Navy, teaching sailors\nmathematics
-        and helping with the ship&#8217;s navigation. On return to London\nseven years
-        later, he became a maths teacher in coffee houses and a\nprivate tutor. In
-        1706, Jones published <em>Synopsis Palmariorum\nMatheseos</em> which used
-        the symbol <em>\u03C0</em> for the ratio of a\ncircle&#8217;s circumference
-        to diameter (hunt for it on pages <a href=\"https://archive.org/details/SynopsisPalmariorumMatheseosOrANewIntroductionToTheMathematics/page/n261/mode/1up?view=theater\">243</a>\nand
-        <a href=\"https://archive.org/details/SynopsisPalmariorumMatheseosOrANewIntroductionToTheMathematics/page/n283/mode/1up?view=theater\">263</a>\nor
-        <a href=\"https://commons.wikimedia.org/wiki/File:Synopsis_Palmariorum_Matheseos_pi.jpg\">here</a>).\nJones
-        was also the first person to realise <em>\u03C0</em> is an irrational\nnumber,
-        meaning it can be written as decimal number that goes on\nforever, but cannot
-        be written as a fraction of two integers.</p>\n<p>But why <em>\u03C0</em>?
-        It&#8217;s thought Jones used the Greek letter\n<em>\u03C0</em> because it&#8217;s
-        the first letter in <em>perimetron</em> or\nperimeter. Jones was the first
-        to use <em>\u03C0</em> as our familiar ratio\nbut wasn&#8217;t the first to
-        use it in as part of the ratio. William\nOughtred, in his 1631 <em>Clavis
-        Mathematicae</em> (<em>The Key of\nMathematics</em>), used <em>\u03C0/\u03B4</em>
-        to represent what we now call pi.\nHis <em>\u03C0</em> was the circumference,
-        not the ratio of circumference to\ndiameter. James Gregory, in his 1668 <em>Geometriae
-        Pars\nUniversalis</em> (<em>The Universal Part of Geometry</em>) used\n<em>\u03C0/\u03C1</em>
-        instead, where <em>\u03C1</em> is the radius, making the ratio\n6.28&#8230;
-        or <a href=\"https://www.tauday.com/\"><em>\u03C4</em></a>. After Jones,\nLeonhard
-        Euler had used <em>\u03C0</em> for 6.28&#8230;, and also <em>p</em> for\n3.14&#8230;,
-        before settling on and popularising <em>\u03C0</em> for the famous\nratio.</p>\n<h1
-        id=\"enjoy-the-new-release\">Enjoy the new release</h1>\n<p>Thanks to all
-        of the many volunteers who help make Python Development\nand these releases
-        possible! Please consider supporting our efforts by\nvolunteering yourself
-        or through organisation contributions to the <a href=\"https://www.python.org/psf-landing/\">Python
-        Software\nFoundation</a>.</p>\n<p>Regards from Helsinki as the leaves begin
-        to appear on the trees,</p>\n<p>Your release team, <br>\n  <br>\nHugo van
-        Kemenade\n<br>\nNed Deily\n<br>\nSteve Dower\n<br>\n\u0141ukasz Langa</p>\n\n<div
-        style='clear: both;'></div>\n</div>\n<div class='post-footer'>\n<div class='post-footer-line
-        post-footer-line-1'><span class='post-author vcard'>\nPosted by\n<span class='fn'>Hugo</span>\n</span>\n<span
-        class='post-timestamp'>\nat\n<a class='timestamp-link' href='https://pythoninsider.blogspot.com/2025/05/python-3140-beta-1-is-here.html'
-        rel='bookmark' title='permanent link'><abbr class='published' title='2025-05-07T13:34:00-04:00'>1:34&#8239;PM</abbr></a>\n</span>\n<span
-        class='post-comment-link'>\n</span>\n<span class='post-icons'>\n</span>\n<div
-        class='post-share-buttons'>\n<a class='goog-inline-block share-button sb-email'
-        href='https://www.blogger.com/share-post.g?blogID=3941553907430899163&postID=7865809690778671094&target=email'
-        target='_blank' title='Email This'><span class='share-button-link-text'>Email
-        This</span></a><a class='goog-inline-block share-button sb-blog' href='https://www.blogger.com/share-post.g?blogID=3941553907430899163&postID=7865809690778671094&target=blog'
-        onclick='window.open(this.href, \"_blank\", \"height=270,width=475\"); return
-        false;' target='_blank' title='BlogThis!'><span class='share-button-link-text'>BlogThis!</span></a><a
-        class='goog-inline-block share-button sb-twitter' href='https://www.blogger.com/share-post.g?blogID=3941553907430899163&postID=7865809690778671094&target=twitter'
-        target='_blank' title='Share to X'><span class='share-button-link-text'>Share
-        to X</span></a><a class='goog-inline-block share-button sb-facebook' href='https://www.blogger.com/share-post.g?blogID=3941553907430899163&postID=7865809690778671094&target=facebook'
-        onclick='window.open(this.href, \"_blank\", \"height=430,width=640\"); return
-        false;' target='_blank' title='Share to Facebook'><span class='share-button-link-text'>Share
-        to Facebook</span></a><a class='goog-inline-block share-button sb-pinterest'
-        href='https://www.blogger.com/share-post.g?blogID=3941553907430899163&postID=7865809690778671094&target=pinterest'
-        target='_blank' title='Share to Pinterest'><span class='share-button-link-text'>Share
-        to Pinterest</span></a>\n</div>\n</div>\n<div class='post-footer-line post-footer-line-2'><span
-        class='post-labels'>\nLabels:\n<a href='https://pythoninsider.blogspot.com/search/label/releases'
-        rel='tag'>releases</a>\n</span>\n</div>\n<div class='post-footer-line post-footer-line-3'><span
-        class='post-location'>\n</span>\n</div>\n</div>\n</div>\n</div>\n\n        </div></div>\n
-        \     \n</div>\n<div class='blog-pager' id='blog-pager'>\n<span id='blog-pager-older-link'>\n<a
-        class='blog-pager-older-link' href='https://pythoninsider.blogspot.com/search?updated-max=2025-05-07T13:34:00-04:00&amp;max-results=7'
-        id='Blog1_blog-pager-older-link' title='Older Posts'>Older Posts</a>\n</span>\n<a
-        class='home-link' href='https://pythoninsider.blogspot.com/'>Home</a>\n</div>\n<div
-        class='clear'></div>\n<div class='blog-feeds'>\n<div class='feed-links'>\nSubscribe
-        to:\n<a class='feed-link' href='https://pythoninsider.blogspot.com/feeds/posts/default'
-        target='_blank' type='application/atom+xml'>Posts (Atom)</a>\n</div>\n</div>\n</div></div>\n</section>\n</div>\n<aside
-        id='cside'>\n<div class='wshad' id='sidebar1'>\n<div class='section' id='sidebar-right-1'><div
-        class='widget HTML' data-version='1' id='HTML1'>\n<h2 class='title'>Subscribe</h2>\n<div
-        class='widget-content'>\nSubscribe to Python Insider via <a href=\"https://blog.python.org/feeds/posts/default?alt=rss\">RSS</a>,
-        or <a href=\"http://twitter.com/PythonInsider\">Twitter</a>\n</div>\n<div
-        class='clear'></div>\n</div><div class='widget LinkList' data-version='1'
-        id='LinkList1'>\n<h2>Related Links</h2>\n<div class='widget-content'>\n<ul>\n<li><a
-        href='http://www.python.org/'>python.org</a></li>\n<li><a href='http://mail.python.org/mailman/listinfo/python-dev'>Python-Dev
-        mailing list</a></li>\n<li><a href='http://docs.python.org/devguide/'>Python
-        Developer's Guide</a></li>\n</ul>\n<div class='clear'></div>\n</div>\n</div><div
-        class='widget LinkList' data-version='1' id='LinkList2'>\n<h2>Translations</h2>\n<div
-        class='widget-content'>\n<ul>\n<li><a href='http://blog-cn.python.org/'>Chinese
-        (Simplified)</a></li>\n<li><a href='http://blog-tw.python.org/'>Chinese (Traditional)</a></li>\n<li><a
-        href='http://blog-fr.python.org/'>French</a></li>\n<li><a href='http://blog-de.python.org/'>German</a></li>\n<li><a
-        href='http://blog-ja.python.org/'>Japanese</a></li>\n<li><a href='http://blog-ko.python.org/'>Korean</a></li>\n<li><a
-        href='http://blog-pt.python.org/'>Portuguese</a></li>\n<li><a href='http://blog-ro.python.org/'>Romanian</a></li>\n<li><a
-        href='http://blog-ru.python.org/'>Russian</a></li>\n<li><a href='http://blog-es.python.org/'>Spanish</a></li>\n</ul>\n<div
-        class='clear'></div>\n</div>\n</div><div class='widget BlogList' data-version='1'
-        id='BlogList1'>\n<h2 class='title'>Python-Dev Blogs</h2>\n<div class='widget-content'>\n<div
-        class='blog-list-container' id='BlogList1_container'>\n<ul id='BlogList1_blogs'>\n<li
-        style='display: block;'>\n<div class='blog-icon'>\n</div>\n<div class='blog-content'>\n<div
-        class='blog-title'>\n<a href='https://eli.thegreenplace.net/' target='_blank'>\nEli
-        Bendersky</a>\n</div>\n<div class='item-content'>\n<span class='item-title'>\n<a
-        href='https://eli.thegreenplace.net/2025/notes-on-even-and-odd-functions/'
-        target='_blank'>\nNotes on even and odd functions\n</a>\n</span>\n<div class='item-time'>\n3
-        weeks ago\n</div>\n</div>\n</div>\n<div style='clear: both;'></div>\n</li>\n<li
-        style='display: block;'>\n<div class='blog-icon'>\n</div>\n<div class='blog-content'>\n<div
-        class='blog-title'>\n<a href='http://morepypy.blogspot.com/' target='_blank'>\nPyPy
-        Status Blog</a>\n</div>\n<div class='item-content'>\n<span class='item-title'>\n<a
-        href='http://morepypy.blogspot.com/2019/12/hpy-kick-off-sprint-report.html'
-        target='_blank'>\nHPy kick-off sprint report\n</a>\n</span>\n<div class='item-time'>\n5
-        years ago\n</div>\n</div>\n</div>\n<div style='clear: both;'></div>\n</li>\n<li
-        style='display: block;'>\n<div class='blog-icon'>\n</div>\n<div class='blog-content'>\n<div
-        class='blog-title'>\n<a href='http://www.wefearchange.org/' target='_blank'>\nPumpichank</a>\n</div>\n<div
-        class='item-content'>\n<span class='item-title'>\n<a href='http://www.wefearchange.org/2015/04/creating-python-snaps.html'
-        target='_blank'>\nCreating Python Snaps\n</a>\n</span>\n<div class='item-time'>\n10
-        years ago\n</div>\n</div>\n</div>\n<div style='clear: both;'></div>\n</li>\n<li
-        style='display: block;'>\n<div class='blog-icon'>\n</div>\n<div class='blog-content'>\n<div
-        class='blog-title'>\n<a href='http://ramblings.timgolden.me.uk' target='_blank'>\nTim
-        Golden</a>\n</div>\n<div class='item-content'>\n<span class='item-title'>\n<a
-        href='http://ramblings.timgolden.me.uk/2014/12/05/london-python-dojo-december-2014/'
-        target='_blank'>\nLondon Python Dojo December 2014\n</a>\n</span>\n<div class='item-time'>\n10
-        years ago\n</div>\n</div>\n</div>\n<div style='clear: both;'></div>\n</li>\n<li
-        style='display: block;'>\n<div class='blog-icon'>\n</div>\n<div class='blog-content'>\n<div
-        class='blog-title'>\n<a href='http://www.bitdance.com/blog' target='_blank'>\nR.
-        David Murray</a>\n</div>\n<div class='item-content'>\n<span class='item-title'>\n<a
-        href='http://www.bitdance.com/blog/2014/09/30_01_asycio_overview' target='_blank'>\nAsyncio
-        Implementation Overview\n</a>\n</span>\n<div class='item-time'>\n10 years
-        ago\n</div>\n</div>\n</div>\n<div style='clear: both;'></div>\n</li>\n<li
-        style='display: block;'>\n<div class='blog-icon'>\n</div>\n<div class='blog-content'>\n<div
-        class='blog-title'>\n<a href='http://www.voidspace.org.uk/python/weblog/index.shtml'
-        target='_blank'>\nThe Voidspace Techie Blog</a>\n</div>\n<div class='item-content'>\n<span
-        class='item-title'>\n<a href='http://www.voidspace.org.uk/python/weblog/arch_d7_2012_03_24.shtml#e1237'
-        target='_blank'>\nunittest.mock and mock 1.0 alpha 1\n</a>\n</span>\n<div
-        class='item-time'>\n13 years ago\n</div>\n</div>\n</div>\n<div style='clear:
-        both;'></div>\n</li>\n<li style='display: block;'>\n<div class='blog-icon'>\n</div>\n<div
-        class='blog-content'>\n<div class='blog-title'>\n<a href='https://tarekziade.wordpress.com'
-        target='_blank'>\nTarek Ziad\xE9</a>\n</div>\n<div class='item-content'>\n<span
-        class='item-title'>\n<a href='https://tarekziade.wordpress.com/2012/02/29/more-privacy-please/'
-        target='_blank'>\nMore privacy please\n</a>\n</span>\n<div class='item-time'>\n13
-        years ago\n</div>\n</div>\n</div>\n<div style='clear: both;'></div>\n</li>\n<li
-        style='display: block;'>\n<div class='blog-icon'>\n</div>\n<div class='blog-content'>\n<div
-        class='blog-title'>\n<a href='https://rhettinger.wordpress.com' target='_blank'>\nDeep
-        Thoughts by Raymond Hettinger</a>\n</div>\n<div class='item-content'>\n<span
-        class='item-title'>\n<a href='https://rhettinger.wordpress.com/2011/05/26/super-considered-super/'
-        target='_blank'>\nPython&#8217;s super() considered super!\n</a>\n</span>\n<div
-        class='item-time'>\n14 years ago\n</div>\n</div>\n</div>\n<div style='clear:
-        both;'></div>\n</li>\n<li style='display: block;'>\n<div class='blog-icon'>\n</div>\n<div
-        class='blog-content'>\n<div class='blog-title'>\n<a href='http://jessenoller.com/feed/'
-        target='_blank'>\nJesse Noller</a>\n</div>\n<div class='item-content'>\n<span
-        class='item-title'>\n<!--Can't find substitution for tag [item.itemTitle]-->\n</span>\n<div
-        class='item-time'>\n<!--Can't find substitution for tag [item.timePeriodSinceLastUpdate]-->\n</div>\n</div>\n</div>\n<div
-        style='clear: both;'></div>\n</li>\n<li style='display: block;'>\n<div class='blog-icon'>\n</div>\n<div
-        class='blog-content'>\n<div class='blog-title'>\n<a href='http://www.uthcode.com/blog/feeds/atom.xml'
-        target='_blank'>\nSenthil Kumaran</a>\n</div>\n<div class='item-content'>\n<span
-        class='item-title'>\n<!--Can't find substitution for tag [item.itemTitle]-->\n</span>\n<div
-        class='item-time'>\n<!--Can't find substitution for tag [item.timePeriodSinceLastUpdate]-->\n</div>\n</div>\n</div>\n<div
-        style='clear: both;'></div>\n</li>\n<li style='display: block;'>\n<div class='blog-icon'>\n</div>\n<div
-        class='blog-content'>\n<div class='blog-title'>\n<a href='http://feeds.feedburner.com/CoderWhoSaysPy'
-        target='_blank'>\nBrett Cannon</a>\n</div>\n<div class='item-content'>\n<span
-        class='item-title'>\n<!--Can't find substitution for tag [item.itemTitle]-->\n</span>\n<div
-        class='item-time'>\n<!--Can't find substitution for tag [item.timePeriodSinceLastUpdate]-->\n</div>\n</div>\n</div>\n<div
-        style='clear: both;'></div>\n</li>\n<li style='display: block;'>\n<div class='blog-icon'>\n</div>\n<div
-        class='blog-content'>\n<div class='blog-title'>\n<a href='http://www.boredomandlaziness.org/feeds/posts/default'
-        target='_blank'>\nBoredom & Laziness</a>\n</div>\n<div class='item-content'>\n<span
-        class='item-title'>\n<!--Can't find substitution for tag [item.itemTitle]-->\n</span>\n<div
-        class='item-time'>\n<!--Can't find substitution for tag [item.timePeriodSinceLastUpdate]-->\n</div>\n</div>\n</div>\n<div
-        style='clear: both;'></div>\n</li>\n<li style='display: block;'>\n<div class='blog-icon'>\n</div>\n<div
-        class='blog-content'>\n<div class='blog-title'>\n<a href='http://blog.briancurtin.com/feed/'
-        target='_blank'>\nBrian Curtin</a>\n</div>\n<div class='item-content'>\n<span
-        class='item-title'>\n<!--Can't find substitution for tag [item.itemTitle]-->\n</span>\n<div
-        class='item-time'>\n<!--Can't find substitution for tag [item.timePeriodSinceLastUpdate]-->\n</div>\n</div>\n</div>\n<div
-        style='clear: both;'></div>\n</li>\n</ul>\n<div class='clear'></div>\n</div>\n</div>\n</div><div
-        class='widget BlogArchive' data-version='1' id='BlogArchive1'>\n<h2>Blog Archive</h2>\n<div
-        class='widget-content'>\n<div id='ArchiveList'>\n<div id='BlogArchive1_ArchiveList'>\n<ul
-        class='hierarchy'>\n<li class='archivedate expanded'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy toggle-open'>\n\n        &#9660;&#160;\n      \n</span>\n</a>\n<a
-        class='post-count-link' href='https://pythoninsider.blogspot.com/2025/'>\n2025\n</a>\n<span
-        class='post-count' dir='ltr'>(12)</span>\n<ul class='hierarchy'>\n<li class='archivedate
-        expanded'>\n<a class='toggle' href='javascript:void(0)'>\n<span class='zippy
-        toggle-open'>\n\n        &#9660;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2025/07/'>\nJuly\n</a>\n<span class='post-count'
-        dir='ltr'>(2)</span>\n<ul class='posts'>\n<li><a href='https://pythoninsider.blogspot.com/2025/07/python-314-release-candidate-1-is-go.html'>Python
-        3.14 release candidate 1 is go!</a></li>\n<li><a href='https://pythoninsider.blogspot.com/2025/07/python-3140-beta-4-is-here.html'>Python
-        3.14.0 beta 4 is here!</a></li>\n</ul>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2025/06/'>\nJune\n</a>\n<span class='post-count'
-        dir='ltr'>(3)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li class='archivedate
-        collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span class='zippy'>\n\n
-        \       &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link' href='https://pythoninsider.blogspot.com/2025/05/'>\nMay\n</a>\n<span
-        class='post-count' dir='ltr'>(2)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2025/04/'>\nApril\n</a>\n<span class='post-count'
-        dir='ltr'>(1)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li class='archivedate
-        collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span class='zippy'>\n\n
-        \       &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link' href='https://pythoninsider.blogspot.com/2025/03/'>\nMarch\n</a>\n<span
-        class='post-count' dir='ltr'>(1)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2025/02/'>\nFebruary\n</a>\n<span
-        class='post-count' dir='ltr'>(2)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2025/01/'>\nJanuary\n</a>\n<span
-        class='post-count' dir='ltr'>(1)</span>\n</li>\n</ul>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2024/'>\n2024\n</a>\n<span class='post-count'
-        dir='ltr'>(22)</span>\n<ul class='hierarchy'>\n<li class='archivedate collapsed'>\n<a
-        class='toggle' href='javascript:void(0)'>\n<span class='zippy'>\n\n        &#9658;&#160;\n
-        \     \n</span>\n</a>\n<a class='post-count-link' href='https://pythoninsider.blogspot.com/2024/12/'>\nDecember\n</a>\n<span
-        class='post-count' dir='ltr'>(2)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2024/11/'>\nNovember\n</a>\n<span
-        class='post-count' dir='ltr'>(1)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2024/10/'>\nOctober\n</a>\n<span
-        class='post-count' dir='ltr'>(4)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2024/09/'>\nSeptember\n</a>\n<span
-        class='post-count' dir='ltr'>(1)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2024/08/'>\nAugust\n</a>\n<span class='post-count'
-        dir='ltr'>(2)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li class='archivedate
-        collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span class='zippy'>\n\n
-        \       &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link' href='https://pythoninsider.blogspot.com/2024/07/'>\nJuly\n</a>\n<span
-        class='post-count' dir='ltr'>(1)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2024/06/'>\nJune\n</a>\n<span class='post-count'
-        dir='ltr'>(3)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li class='archivedate
-        collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span class='zippy'>\n\n
-        \       &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link' href='https://pythoninsider.blogspot.com/2024/05/'>\nMay\n</a>\n<span
-        class='post-count' dir='ltr'>(1)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2024/04/'>\nApril\n</a>\n<span class='post-count'
-        dir='ltr'>(2)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li class='archivedate
-        collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span class='zippy'>\n\n
-        \       &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link' href='https://pythoninsider.blogspot.com/2024/03/'>\nMarch\n</a>\n<span
-        class='post-count' dir='ltr'>(2)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2024/02/'>\nFebruary\n</a>\n<span
-        class='post-count' dir='ltr'>(2)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2024/01/'>\nJanuary\n</a>\n<span
-        class='post-count' dir='ltr'>(1)</span>\n</li>\n</ul>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2023/'>\n2023\n</a>\n<span class='post-count'
-        dir='ltr'>(18)</span>\n<ul class='hierarchy'>\n<li class='archivedate collapsed'>\n<a
-        class='toggle' href='javascript:void(0)'>\n<span class='zippy'>\n\n        &#9658;&#160;\n
-        \     \n</span>\n</a>\n<a class='post-count-link' href='https://pythoninsider.blogspot.com/2023/12/'>\nDecember\n</a>\n<span
-        class='post-count' dir='ltr'>(2)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2023/11/'>\nNovember\n</a>\n<span
-        class='post-count' dir='ltr'>(1)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2023/10/'>\nOctober\n</a>\n<span
-        class='post-count' dir='ltr'>(3)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2023/09/'>\nSeptember\n</a>\n<span
-        class='post-count' dir='ltr'>(2)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2023/08/'>\nAugust\n</a>\n<span class='post-count'
-        dir='ltr'>(2)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li class='archivedate
-        collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span class='zippy'>\n\n
-        \       &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link' href='https://pythoninsider.blogspot.com/2023/07/'>\nJuly\n</a>\n<span
-        class='post-count' dir='ltr'>(1)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2023/06/'>\nJune\n</a>\n<span class='post-count'
-        dir='ltr'>(2)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li class='archivedate
-        collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span class='zippy'>\n\n
-        \       &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link' href='https://pythoninsider.blogspot.com/2023/05/'>\nMay\n</a>\n<span
-        class='post-count' dir='ltr'>(1)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2023/04/'>\nApril\n</a>\n<span class='post-count'
-        dir='ltr'>(1)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li class='archivedate
-        collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span class='zippy'>\n\n
-        \       &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link' href='https://pythoninsider.blogspot.com/2023/03/'>\nMarch\n</a>\n<span
-        class='post-count' dir='ltr'>(1)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2023/02/'>\nFebruary\n</a>\n<span
-        class='post-count' dir='ltr'>(1)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2023/01/'>\nJanuary\n</a>\n<span
-        class='post-count' dir='ltr'>(1)</span>\n</li>\n</ul>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2022/'>\n2022\n</a>\n<span class='post-count'
-        dir='ltr'>(23)</span>\n<ul class='hierarchy'>\n<li class='archivedate collapsed'>\n<a
-        class='toggle' href='javascript:void(0)'>\n<span class='zippy'>\n\n        &#9658;&#160;\n
-        \     \n</span>\n</a>\n<a class='post-count-link' href='https://pythoninsider.blogspot.com/2022/12/'>\nDecember\n</a>\n<span
-        class='post-count' dir='ltr'>(1)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2022/11/'>\nNovember\n</a>\n<span
-        class='post-count' dir='ltr'>(1)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2022/10/'>\nOctober\n</a>\n<span
-        class='post-count' dir='ltr'>(4)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2022/09/'>\nSeptember\n</a>\n<span
-        class='post-count' dir='ltr'>(2)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2022/08/'>\nAugust\n</a>\n<span class='post-count'
-        dir='ltr'>(2)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li class='archivedate
-        collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span class='zippy'>\n\n
-        \       &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link' href='https://pythoninsider.blogspot.com/2022/07/'>\nJuly\n</a>\n<span
-        class='post-count' dir='ltr'>(2)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2022/06/'>\nJune\n</a>\n<span class='post-count'
-        dir='ltr'>(2)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li class='archivedate
-        collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span class='zippy'>\n\n
-        \       &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link' href='https://pythoninsider.blogspot.com/2022/05/'>\nMay\n</a>\n<span
-        class='post-count' dir='ltr'>(3)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2022/04/'>\nApril\n</a>\n<span class='post-count'
-        dir='ltr'>(1)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li class='archivedate
-        collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span class='zippy'>\n\n
-        \       &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link' href='https://pythoninsider.blogspot.com/2022/03/'>\nMarch\n</a>\n<span
-        class='post-count' dir='ltr'>(3)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2022/02/'>\nFebruary\n</a>\n<span
-        class='post-count' dir='ltr'>(1)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2022/01/'>\nJanuary\n</a>\n<span
-        class='post-count' dir='ltr'>(1)</span>\n</li>\n</ul>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2021/'>\n2021\n</a>\n<span class='post-count'
-        dir='ltr'>(24)</span>\n<ul class='hierarchy'>\n<li class='archivedate collapsed'>\n<a
-        class='toggle' href='javascript:void(0)'>\n<span class='zippy'>\n\n        &#9658;&#160;\n
-        \     \n</span>\n</a>\n<a class='post-count-link' href='https://pythoninsider.blogspot.com/2021/12/'>\nDecember\n</a>\n<span
-        class='post-count' dir='ltr'>(2)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2021/11/'>\nNovember\n</a>\n<span
-        class='post-count' dir='ltr'>(2)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2021/10/'>\nOctober\n</a>\n<span
-        class='post-count' dir='ltr'>(2)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2021/09/'>\nSeptember\n</a>\n<span
-        class='post-count' dir='ltr'>(2)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2021/08/'>\nAugust\n</a>\n<span class='post-count'
-        dir='ltr'>(2)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li class='archivedate
-        collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span class='zippy'>\n\n
-        \       &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link' href='https://pythoninsider.blogspot.com/2021/07/'>\nJuly\n</a>\n<span
-        class='post-count' dir='ltr'>(1)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2021/06/'>\nJune\n</a>\n<span class='post-count'
-        dir='ltr'>(3)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li class='archivedate
-        collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span class='zippy'>\n\n
-        \       &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link' href='https://pythoninsider.blogspot.com/2021/05/'>\nMay\n</a>\n<span
-        class='post-count' dir='ltr'>(1)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2021/04/'>\nApril\n</a>\n<span class='post-count'
-        dir='ltr'>(3)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li class='archivedate
-        collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span class='zippy'>\n\n
-        \       &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link' href='https://pythoninsider.blogspot.com/2021/03/'>\nMarch\n</a>\n<span
-        class='post-count' dir='ltr'>(1)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2021/02/'>\nFebruary\n</a>\n<span
-        class='post-count' dir='ltr'>(4)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2021/01/'>\nJanuary\n</a>\n<span
-        class='post-count' dir='ltr'>(1)</span>\n</li>\n</ul>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2020/'>\n2020\n</a>\n<span class='post-count'
-        dir='ltr'>(32)</span>\n<ul class='hierarchy'>\n<li class='archivedate collapsed'>\n<a
-        class='toggle' href='javascript:void(0)'>\n<span class='zippy'>\n\n        &#9658;&#160;\n
-        \     \n</span>\n</a>\n<a class='post-count-link' href='https://pythoninsider.blogspot.com/2020/12/'>\nDecember\n</a>\n<span
-        class='post-count' dir='ltr'>(2)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2020/11/'>\nNovember\n</a>\n<span
-        class='post-count' dir='ltr'>(2)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2020/10/'>\nOctober\n</a>\n<span
-        class='post-count' dir='ltr'>(2)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2020/09/'>\nSeptember\n</a>\n<span
-        class='post-count' dir='ltr'>(3)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2020/08/'>\nAugust\n</a>\n<span class='post-count'
-        dir='ltr'>(3)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li class='archivedate
-        collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span class='zippy'>\n\n
-        \       &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link' href='https://pythoninsider.blogspot.com/2020/07/'>\nJuly\n</a>\n<span
-        class='post-count' dir='ltr'>(4)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2020/06/'>\nJune\n</a>\n<span class='post-count'
-        dir='ltr'>(4)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li class='archivedate
-        collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span class='zippy'>\n\n
-        \       &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link' href='https://pythoninsider.blogspot.com/2020/05/'>\nMay\n</a>\n<span
-        class='post-count' dir='ltr'>(2)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2020/04/'>\nApril\n</a>\n<span class='post-count'
-        dir='ltr'>(4)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li class='archivedate
-        collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span class='zippy'>\n\n
-        \       &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link' href='https://pythoninsider.blogspot.com/2020/03/'>\nMarch\n</a>\n<span
-        class='post-count' dir='ltr'>(3)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2020/02/'>\nFebruary\n</a>\n<span
-        class='post-count' dir='ltr'>(2)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2020/01/'>\nJanuary\n</a>\n<span
-        class='post-count' dir='ltr'>(1)</span>\n</li>\n</ul>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2019/'>\n2019\n</a>\n<span class='post-count'
-        dir='ltr'>(36)</span>\n<ul class='hierarchy'>\n<li class='archivedate collapsed'>\n<a
-        class='toggle' href='javascript:void(0)'>\n<span class='zippy'>\n\n        &#9658;&#160;\n
-        \     \n</span>\n</a>\n<a class='post-count-link' href='https://pythoninsider.blogspot.com/2019/12/'>\nDecember\n</a>\n<span
-        class='post-count' dir='ltr'>(3)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2019/11/'>\nNovember\n</a>\n<span
-        class='post-count' dir='ltr'>(1)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2019/10/'>\nOctober\n</a>\n<span
-        class='post-count' dir='ltr'>(8)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2019/09/'>\nSeptember\n</a>\n<span
-        class='post-count' dir='ltr'>(1)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2019/08/'>\nAugust\n</a>\n<span class='post-count'
-        dir='ltr'>(3)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li class='archivedate
-        collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span class='zippy'>\n\n
-        \       &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link' href='https://pythoninsider.blogspot.com/2019/07/'>\nJuly\n</a>\n<span
-        class='post-count' dir='ltr'>(5)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2019/06/'>\nJune\n</a>\n<span class='post-count'
-        dir='ltr'>(3)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li class='archivedate
-        collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span class='zippy'>\n\n
-        \       &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link' href='https://pythoninsider.blogspot.com/2019/05/'>\nMay\n</a>\n<span
-        class='post-count' dir='ltr'>(2)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2019/03/'>\nMarch\n</a>\n<span class='post-count'
-        dir='ltr'>(7)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li class='archivedate
-        collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span class='zippy'>\n\n
-        \       &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link' href='https://pythoninsider.blogspot.com/2019/02/'>\nFebruary\n</a>\n<span
-        class='post-count' dir='ltr'>(3)</span>\n</li>\n</ul>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2018/'>\n2018\n</a>\n<span class='post-count'
-        dir='ltr'>(24)</span>\n<ul class='hierarchy'>\n<li class='archivedate collapsed'>\n<a
-        class='toggle' href='javascript:void(0)'>\n<span class='zippy'>\n\n        &#9658;&#160;\n
-        \     \n</span>\n</a>\n<a class='post-count-link' href='https://pythoninsider.blogspot.com/2018/12/'>\nDecember\n</a>\n<span
-        class='post-count' dir='ltr'>(2)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2018/10/'>\nOctober\n</a>\n<span
-        class='post-count' dir='ltr'>(2)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2018/09/'>\nSeptember\n</a>\n<span
-        class='post-count' dir='ltr'>(1)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2018/08/'>\nAugust\n</a>\n<span class='post-count'
-        dir='ltr'>(1)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li class='archivedate
-        collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span class='zippy'>\n\n
-        \       &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link' href='https://pythoninsider.blogspot.com/2018/06/'>\nJune\n</a>\n<span
-        class='post-count' dir='ltr'>(2)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2018/05/'>\nMay\n</a>\n<span class='post-count'
-        dir='ltr'>(3)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li class='archivedate
-        collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span class='zippy'>\n\n
-        \       &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link' href='https://pythoninsider.blogspot.com/2018/04/'>\nApril\n</a>\n<span
-        class='post-count' dir='ltr'>(3)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2018/03/'>\nMarch\n</a>\n<span class='post-count'
-        dir='ltr'>(5)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li class='archivedate
-        collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span class='zippy'>\n\n
-        \       &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link' href='https://pythoninsider.blogspot.com/2018/02/'>\nFebruary\n</a>\n<span
-        class='post-count' dir='ltr'>(2)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2018/01/'>\nJanuary\n</a>\n<span
-        class='post-count' dir='ltr'>(3)</span>\n</li>\n</ul>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2017/'>\n2017\n</a>\n<span class='post-count'
-        dir='ltr'>(17)</span>\n<ul class='hierarchy'>\n<li class='archivedate collapsed'>\n<a
-        class='toggle' href='javascript:void(0)'>\n<span class='zippy'>\n\n        &#9658;&#160;\n
-        \     \n</span>\n</a>\n<a class='post-count-link' href='https://pythoninsider.blogspot.com/2017/12/'>\nDecember\n</a>\n<span
-        class='post-count' dir='ltr'>(2)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2017/10/'>\nOctober\n</a>\n<span
-        class='post-count' dir='ltr'>(2)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2017/09/'>\nSeptember\n</a>\n<span
-        class='post-count' dir='ltr'>(3)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2017/08/'>\nAugust\n</a>\n<span class='post-count'
-        dir='ltr'>(2)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li class='archivedate
-        collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span class='zippy'>\n\n
-        \       &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link' href='https://pythoninsider.blogspot.com/2017/07/'>\nJuly\n</a>\n<span
-        class='post-count' dir='ltr'>(3)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2017/06/'>\nJune\n</a>\n<span class='post-count'
-        dir='ltr'>(1)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li class='archivedate
-        collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span class='zippy'>\n\n
-        \       &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link' href='https://pythoninsider.blogspot.com/2017/03/'>\nMarch\n</a>\n<span
-        class='post-count' dir='ltr'>(2)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2017/01/'>\nJanuary\n</a>\n<span
-        class='post-count' dir='ltr'>(2)</span>\n</li>\n</ul>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2016/'>\n2016\n</a>\n<span class='post-count'
-        dir='ltr'>(18)</span>\n<ul class='hierarchy'>\n<li class='archivedate collapsed'>\n<a
-        class='toggle' href='javascript:void(0)'>\n<span class='zippy'>\n\n        &#9658;&#160;\n
-        \     \n</span>\n</a>\n<a class='post-count-link' href='https://pythoninsider.blogspot.com/2016/12/'>\nDecember\n</a>\n<span
-        class='post-count' dir='ltr'>(5)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2016/11/'>\nNovember\n</a>\n<span
-        class='post-count' dir='ltr'>(1)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2016/10/'>\nOctober\n</a>\n<span
-        class='post-count' dir='ltr'>(2)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2016/09/'>\nSeptember\n</a>\n<span
-        class='post-count' dir='ltr'>(2)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2016/08/'>\nAugust\n</a>\n<span class='post-count'
-        dir='ltr'>(1)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li class='archivedate
-        collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span class='zippy'>\n\n
-        \       &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link' href='https://pythoninsider.blogspot.com/2016/07/'>\nJuly\n</a>\n<span
-        class='post-count' dir='ltr'>(1)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2016/06/'>\nJune\n</a>\n<span class='post-count'
-        dir='ltr'>(5)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li class='archivedate
-        collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span class='zippy'>\n\n
-        \       &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link' href='https://pythoninsider.blogspot.com/2016/05/'>\nMay\n</a>\n<span
-        class='post-count' dir='ltr'>(1)</span>\n</li>\n</ul>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2015/'>\n2015\n</a>\n<span class='post-count'
-        dir='ltr'>(14)</span>\n<ul class='hierarchy'>\n<li class='archivedate collapsed'>\n<a
-        class='toggle' href='javascript:void(0)'>\n<span class='zippy'>\n\n        &#9658;&#160;\n
-        \     \n</span>\n</a>\n<a class='post-count-link' href='https://pythoninsider.blogspot.com/2015/12/'>\nDecember\n</a>\n<span
-        class='post-count' dir='ltr'>(2)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2015/11/'>\nNovember\n</a>\n<span
-        class='post-count' dir='ltr'>(1)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2015/09/'>\nSeptember\n</a>\n<span
-        class='post-count' dir='ltr'>(3)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2015/08/'>\nAugust\n</a>\n<span class='post-count'
-        dir='ltr'>(1)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li class='archivedate
-        collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span class='zippy'>\n\n
-        \       &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link' href='https://pythoninsider.blogspot.com/2015/07/'>\nJuly\n</a>\n<span
-        class='post-count' dir='ltr'>(1)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2015/06/'>\nJune\n</a>\n<span class='post-count'
-        dir='ltr'>(1)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li class='archivedate
-        collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span class='zippy'>\n\n
-        \       &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link' href='https://pythoninsider.blogspot.com/2015/05/'>\nMay\n</a>\n<span
-        class='post-count' dir='ltr'>(2)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2015/03/'>\nMarch\n</a>\n<span class='post-count'
-        dir='ltr'>(2)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li class='archivedate
-        collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span class='zippy'>\n\n
-        \       &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link' href='https://pythoninsider.blogspot.com/2015/01/'>\nJanuary\n</a>\n<span
-        class='post-count' dir='ltr'>(1)</span>\n</li>\n</ul>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2014/'>\n2014\n</a>\n<span class='post-count'
-        dir='ltr'>(8)</span>\n<ul class='hierarchy'>\n<li class='archivedate collapsed'>\n<a
-        class='toggle' href='javascript:void(0)'>\n<span class='zippy'>\n\n        &#9658;&#160;\n
-        \     \n</span>\n</a>\n<a class='post-count-link' href='https://pythoninsider.blogspot.com/2014/12/'>\nDecember\n</a>\n<span
-        class='post-count' dir='ltr'>(1)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2014/11/'>\nNovember\n</a>\n<span
-        class='post-count' dir='ltr'>(1)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2014/05/'>\nMay\n</a>\n<span class='post-count'
-        dir='ltr'>(1)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li class='archivedate
-        collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span class='zippy'>\n\n
-        \       &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link' href='https://pythoninsider.blogspot.com/2014/03/'>\nMarch\n</a>\n<span
-        class='post-count' dir='ltr'>(3)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2014/02/'>\nFebruary\n</a>\n<span
-        class='post-count' dir='ltr'>(2)</span>\n</li>\n</ul>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2013/'>\n2013\n</a>\n<span class='post-count'
-        dir='ltr'>(5)</span>\n<ul class='hierarchy'>\n<li class='archivedate collapsed'>\n<a
-        class='toggle' href='javascript:void(0)'>\n<span class='zippy'>\n\n        &#9658;&#160;\n
-        \     \n</span>\n</a>\n<a class='post-count-link' href='https://pythoninsider.blogspot.com/2013/11/'>\nNovember\n</a>\n<span
-        class='post-count' dir='ltr'>(2)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2013/10/'>\nOctober\n</a>\n<span
-        class='post-count' dir='ltr'>(1)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2013/03/'>\nMarch\n</a>\n<span class='post-count'
-        dir='ltr'>(1)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li class='archivedate
-        collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span class='zippy'>\n\n
-        \       &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link' href='https://pythoninsider.blogspot.com/2013/02/'>\nFebruary\n</a>\n<span
-        class='post-count' dir='ltr'>(1)</span>\n</li>\n</ul>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2012/'>\n2012\n</a>\n<span class='post-count'
-        dir='ltr'>(9)</span>\n<ul class='hierarchy'>\n<li class='archivedate collapsed'>\n<a
-        class='toggle' href='javascript:void(0)'>\n<span class='zippy'>\n\n        &#9658;&#160;\n
-        \     \n</span>\n</a>\n<a class='post-count-link' href='https://pythoninsider.blogspot.com/2012/12/'>\nDecember\n</a>\n<span
-        class='post-count' dir='ltr'>(1)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2012/11/'>\nNovember\n</a>\n<span
-        class='post-count' dir='ltr'>(1)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2012/10/'>\nOctober\n</a>\n<span
-        class='post-count' dir='ltr'>(2)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2012/08/'>\nAugust\n</a>\n<span class='post-count'
-        dir='ltr'>(1)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li class='archivedate
-        collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span class='zippy'>\n\n
-        \       &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link' href='https://pythoninsider.blogspot.com/2012/06/'>\nJune\n</a>\n<span
-        class='post-count' dir='ltr'>(2)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2012/05/'>\nMay\n</a>\n<span class='post-count'
-        dir='ltr'>(1)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li class='archivedate
-        collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span class='zippy'>\n\n
-        \       &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link' href='https://pythoninsider.blogspot.com/2012/03/'>\nMarch\n</a>\n<span
-        class='post-count' dir='ltr'>(1)</span>\n</li>\n</ul>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2011/'>\n2011\n</a>\n<span class='post-count'
-        dir='ltr'>(25)</span>\n<ul class='hierarchy'>\n<li class='archivedate collapsed'>\n<a
-        class='toggle' href='javascript:void(0)'>\n<span class='zippy'>\n\n        &#9658;&#160;\n
-        \     \n</span>\n</a>\n<a class='post-count-link' href='https://pythoninsider.blogspot.com/2011/08/'>\nAugust\n</a>\n<span
-        class='post-count' dir='ltr'>(2)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2011/07/'>\nJuly\n</a>\n<span class='post-count'
-        dir='ltr'>(3)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li class='archivedate
-        collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span class='zippy'>\n\n
-        \       &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link' href='https://pythoninsider.blogspot.com/2011/06/'>\nJune\n</a>\n<span
-        class='post-count' dir='ltr'>(1)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2011/05/'>\nMay\n</a>\n<span class='post-count'
-        dir='ltr'>(7)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li class='archivedate
-        collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span class='zippy'>\n\n
-        \       &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link' href='https://pythoninsider.blogspot.com/2011/04/'>\nApril\n</a>\n<span
-        class='post-count' dir='ltr'>(7)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2011/03/'>\nMarch\n</a>\n<span class='post-count'
-        dir='ltr'>(5)</span>\n</li>\n</ul>\n</li>\n</ul>\n</div>\n</div>\n<div class='clear'></div>\n</div>\n</div><div
-        class='widget Profile' data-version='1' id='Profile1'>\n<h2>Contributors</h2>\n<div
-        class='widget-content'>\n<ul>\n<li><a class='profile-name-link g-profile'
-        href='https://www.blogger.com/profile/14971120963699387108' style='background-image:
-        url(//www.blogger.com/img/logo-16.png);'>A.M. Kuchling</a></li>\n<li><a class='profile-name-link
-        g-profile' href='https://www.blogger.com/profile/02804541126912023065' style='background-image:
-        url(//www.blogger.com/img/logo-16.png);'>Alfonso de la Guarda</a></li>\n<li><a
-        class='profile-name-link g-profile' href='https://www.blogger.com/profile/03855116138400732464'
-        style='background-image: url(//www.blogger.com/img/logo-16.png);'>Anthony
-        Scopatz</a></li>\n<li><a class='profile-name-link g-profile' href='https://www.blogger.com/profile/08838587997498042260'
-        style='background-image: url(//www.blogger.com/img/logo-16.png);'>Antoine
-        P.</a></li>\n<li><a class='profile-name-link g-profile' href='https://www.blogger.com/profile/06955536323236904839'
-        style='background-image: url(//www.blogger.com/img/logo-16.png);'>Benjamin
-        Peterson</a></li>\n<li><a class='profile-name-link g-profile' href='https://www.blogger.com/profile/14604644394514192040'
-        style='background-image: url(//www.blogger.com/img/logo-16.png);'>Brian Curtin</a></li>\n<li><a
-        class='profile-name-link g-profile' href='https://www.blogger.com/profile/14913018830568213369'
-        style='background-image: url(//www.blogger.com/img/logo-16.png);'>Davidmh</a></li>\n<li><a
-        class='profile-name-link g-profile' href='https://www.blogger.com/profile/03794667532189865209'
-        style='background-image: url(//www.blogger.com/img/logo-16.png);'>Donald Stufft</a></li>\n<li><a
-        class='profile-name-link g-profile' href='https://www.blogger.com/profile/01892352754222143463'
-        style='background-image: url(//www.blogger.com/img/logo-16.png);'>Doug Hellmann</a></li>\n<li><a
-        class='profile-name-link g-profile' href='https://www.blogger.com/profile/13577459520968677064'
-        style='background-image: url(//www.blogger.com/img/logo-16.png);'>Ee Durbin</a></li>\n<li><a
-        class='profile-name-link g-profile' href='https://www.blogger.com/profile/06795605825443412201'
-        style='background-image: url(//www.blogger.com/img/logo-16.png);'>Ezio Melotti</a></li>\n<li><a
-        class='profile-name-link g-profile' href='https://www.blogger.com/profile/14973145408214215809'
-        style='background-image: url(//www.blogger.com/img/logo-16.png);'>Georg Brandl</a></li>\n<li><a
-        class='profile-name-link g-profile' href='https://www.blogger.com/profile/02811718172961252565'
-        style='background-image: url(//www.blogger.com/img/logo-16.png);'>Hugo</a></li>\n<li><a
-        class='profile-name-link g-profile' href='https://www.blogger.com/profile/07543015027323408421'
-        style='background-image: url(//www.blogger.com/img/logo-16.png);'>Jesse</a></li>\n<li><a
-        class='profile-name-link g-profile' href='https://www.blogger.com/profile/17574962105063127018'
-        style='background-image: url(//www.blogger.com/img/logo-16.png);'>Kelsey Hightower</a></li>\n<li><a
-        class='profile-name-link g-profile' href='https://www.blogger.com/profile/13232068831778121461'
-        style='background-image: url(//www.blogger.com/img/logo-16.png);'>Larry Hastings</a></li>\n<li><a
-        class='profile-name-link g-profile' href='https://www.blogger.com/profile/07757697862303956313'
-        style='background-image: url(//www.blogger.com/img/logo-16.png);'>Mathieu
-        Leduc-Hamel</a></li>\n<li><a class='profile-name-link g-profile' href='https://www.blogger.com/profile/08761481986934375758'
-        style='background-image: url(//www.blogger.com/img/logo-16.png);'>Michael
-        Markert</a></li>\n<li><a class='profile-name-link g-profile' href='https://www.blogger.com/profile/06351908417200979114'
-        style='background-image: url(//www.blogger.com/img/logo-16.png);'>Mike Driscoll</a></li>\n<li><a
-        class='profile-name-link g-profile' href='https://www.blogger.com/profile/17112379650586333719'
-        style='background-image: url(//www.blogger.com/img/logo-16.png);'>Ned Deily</a></li>\n<li><a
-        class='profile-name-link g-profile' href='https://www.blogger.com/profile/07923137967169776470'
-        style='background-image: url(//www.blogger.com/img/logo-16.png);'>Pablo Galindo</a></li>\n<li><a
-        class='profile-name-link g-profile' href='https://www.blogger.com/profile/17557923197983461835'
-        style='background-image: url(//www.blogger.com/img/logo-16.png);'>Paul Moore</a></li>\n<li><a
-        class='profile-name-link g-profile' href='https://www.blogger.com/profile/17437958274873977298'
-        style='background-image: url(//www.blogger.com/img/logo-16.png);'>Philip Jenvey</a></li>\n<li><a
-        class='profile-name-link g-profile' href='https://www.blogger.com/profile/08002085909817689325'
-        style='background-image: url(//www.blogger.com/img/logo-16.png);'>Sumana Harihareswara</a></li>\n<li><a
-        class='profile-name-link g-profile' href='https://www.blogger.com/profile/10346112333332923135'
-        style='background-image: url(//www.blogger.com/img/logo-16.png);'>Thomas Wouters</a></li>\n<li><a
-        class='profile-name-link g-profile' href='https://www.blogger.com/profile/14824694805745746190'
-        style='background-image: url(//www.blogger.com/img/logo-16.png);'>Unknown</a></li>\n<li><a
-        class='profile-name-link g-profile' href='https://www.blogger.com/profile/12361293458447621754'
-        style='background-image: url(//www.blogger.com/img/logo-16.png);'>Unknown</a></li>\n<li><a
-        class='profile-name-link g-profile' href='https://www.blogger.com/profile/01161413896843370614'
-        style='background-image: url(//www.blogger.com/img/logo-16.png);'>\u0141ukasz
-        Langa</a></li>\n<li><a class='profile-name-link g-profile' href='https://www.blogger.com/profile/10522887977715879728'
-        style='background-image: url(//www.blogger.com/img/logo-16.png);'>\xC9ric
-        Araujo</a></li>\n<li><a class='profile-name-link g-profile' href='https://www.blogger.com/profile/07473216746644389812'
-        style='background-image: url(//www.blogger.com/img/logo-16.png);'>e</a></li>\n<li><a
-        class='profile-name-link g-profile' href='https://www.blogger.com/profile/14658404449913582628'
-        style='background-image: url(//www.blogger.com/img/logo-16.png);'>haypo</a></li>\n<li><a
-        class='profile-name-link g-profile' href='https://www.blogger.com/profile/07627402554307001461'
-        style='background-image: url(//www.blogger.com/img/logo-16.png);'>tp</a></li>\n</ul>\n<div
-        class='clear'></div>\n</div>\n</div><div class='widget HTML' data-version='1'
-        id='HTML3'>\n<h2 class='title'>Copyright</h2>\n<div class='widget-content'>\n<a
-        rel=\"license\" href=\"http://creativecommons.org/licenses/by-nc-sa/3.0/\"><img
-        alt=\"Creative Commons License\" style=\"border-width:0\" src=\"https://lh3.googleusercontent.com/blogger_img_proxy/AEn0k_vNLny9gJ_IQG1Qf4JxKrpmu05hsQ2a9YpNHEhxz5icgnVuJGaLDAXKIV8r2GvIk7_RlCwnA_hN3UkzpssffI9wZ3eCjjwgrXmVrwSgqC4SjC2S_tUe7mTr=s0-d\"></a><br
-        /><span xmlns:dct=\"http://purl.org/dc/terms/\" href=\"http://purl.org/dc/dcmitype/Text\"
-        property=\"dct:title\" rel=\"dct:type\">Python Insider</span> by <a xmlns:cc=\"http://creativecommons.org/ns#\"
-        href=\"http://www.python.org/\" property=\"cc:attributionName\" rel=\"cc:attributionURL\">the
-        Python Core Developers</a> is licensed under a <a rel=\"license\" href=\"http://creativecommons.org/licenses/by-nc-sa/3.0/\">Creative
-        Commons Attribution-NonCommercial-ShareAlike 3.0 Unported License</a>.<br
-        />Based on a work at <a xmlns:dct=\"http://purl.org/dc/terms/\" href=\"http://blog.python.org/\"
-        rel=\"dct:source\">blog.python.org</a>.\n</div>\n<div class='clear'></div>\n</div></div>\n<div
-        id='attribution1'>\n<div class='section' id='attribution'><div class='widget
-        Attribution' data-version='1' id='Attribution1'>\n<div class='widget-content'
-        style='text-align: center;'>\nPowered by <a href='https://www.blogger.com'
-        target='_blank'>Blogger</a>.\n</div>\n<div class='clear'></div>\n</div></div>\n</div>\n</div>\n</aside>\n<div
-        style='clear:both'>&nbsp;</div>\n</div>\n\n<script type=\"text/javascript\"
-        src=\"https://www.blogger.com/static/v1/widgets/3000588928-widgets.js\"></script>\n<script
-        type='text/javascript'>\nwindow['__wavt'] = 'AOuZoY4ly9BmOafHTO2GRrsaLYhZTAbH9A:1753779282144';_WidgetManager._Init('//www.blogger.com/rearrange?blogID\\x3d3941553907430899163','//pythoninsider.blogspot.com/','3941553907430899163');\n_WidgetManager._SetDataContext([{'name':
-        'blog', 'data': {'blogId': '3941553907430899163', 'title': 'Python Insider',
-        'url': 'https://pythoninsider.blogspot.com/', 'canonicalUrl': 'https://pythoninsider.blogspot.com/',
-        'homepageUrl': 'https://pythoninsider.blogspot.com/', 'searchUrl': 'https://pythoninsider.blogspot.com/search',
-        'canonicalHomepageUrl': 'https://pythoninsider.blogspot.com/', 'blogspotFaviconUrl':
-        'https://pythoninsider.blogspot.com/favicon.ico', 'bloggerUrl': 'https://www.blogger.com',
-        'hasCustomDomain': false, 'httpsEnabled': true, 'enabledCommentProfileImages':
-        true, 'gPlusViewType': 'FILTERED_POSTMOD', 'adultContent': false, 'analyticsAccountNumber':
-        '', 'encoding': 'UTF-8', 'locale': 'en', 'localeUnderscoreDelimited': 'en',
-        'languageDirection': 'ltr', 'isPrivate': false, 'isMobile': false, 'isMobileRequest':
-        false, 'mobileClass': '', 'isPrivateBlog': false, 'isDynamicViewsAvailable':
-        false, 'feedLinks': '\\x3clink rel\\x3d\\x22alternate\\x22 type\\x3d\\x22application/atom+xml\\x22
-        title\\x3d\\x22Python Insider - Atom\\x22 href\\x3d\\x22https://pythoninsider.blogspot.com/feeds/posts/default\\x22
-        /\\x3e\\n\\x3clink rel\\x3d\\x22alternate\\x22 type\\x3d\\x22application/rss+xml\\x22
-        title\\x3d\\x22Python Insider - RSS\\x22 href\\x3d\\x22https://pythoninsider.blogspot.com/feeds/posts/default?alt\\x3drss\\x22
-        /\\x3e\\n\\x3clink rel\\x3d\\x22service.post\\x22 type\\x3d\\x22application/atom+xml\\x22
-        title\\x3d\\x22Python Insider - Atom\\x22 href\\x3d\\x22https://www.blogger.com/feeds/3941553907430899163/posts/default\\x22
-        /\\x3e\\n', 'meTag': '', 'adsenseHostId': 'ca-host-pub-1556223355139109',
-        'adsenseHasAds': false, 'adsenseAutoAds': false, 'boqCommentIframeForm': true,
-        'loginRedirectParam': '', 'view': '', 'dynamicViewsCommentsSrc': '//www.blogblog.com/dynamicviews/4224c15c4e7c9321/js/comments.js',
-        'dynamicViewsScriptSrc': '//www.blogblog.com/dynamicviews/aec9a2fc4235c5ac',
-        'plusOneApiSrc': 'https://apis.google.com/js/platform.js', 'disableGComments':
-        true, 'interstitialAccepted': false, 'sharing': {'platforms': [{'name': 'Get
-        link', 'key': 'link', 'shareMessage': 'Get link', 'target': ''}, {'name':
-        'Facebook', 'key': 'facebook', 'shareMessage': 'Share to Facebook', 'target':
-        'facebook'}, {'name': 'BlogThis!', 'key': 'blogThis', 'shareMessage': 'BlogThis!',
-        'target': 'blog'}, {'name': 'X', 'key': 'twitter', 'shareMessage': 'Share
-        to X', 'target': 'twitter'}, {'name': 'Pinterest', 'key': 'pinterest', 'shareMessage':
-        'Share to Pinterest', 'target': 'pinterest'}, {'name': 'Email', 'key': 'email',
-        'shareMessage': 'Email', 'target': 'email'}], 'disableGooglePlus': true, 'googlePlusShareButtonWidth':
-        0, 'googlePlusBootstrap': '\\x3cscript type\\x3d\\x22text/javascript\\x22\\x3ewindow.___gcfg
-        \\x3d {\\x27lang\\x27: \\x27en\\x27};\\x3c/script\\x3e'}, 'hasCustomJumpLinkMessage':
-        false, 'jumpLinkMessage': 'Read more', 'pageType': 'index', 'pageName': '',
-        'pageTitle': 'Python Insider'}}, {'name': 'features', 'data': {}}, {'name':
-        'messages', 'data': {'edit': 'Edit', 'linkCopiedToClipboard': 'Link copied
-        to clipboard!', 'ok': 'Ok', 'postLink': 'Post Link'}}, {'name': 'template',
-        'data': {'name': 'custom', 'localizedName': 'Custom', 'isResponsive': false,
-        'isAlternateRendering': false, 'isCustom': true}}, {'name': 'view', 'data':
-        {'classic': {'name': 'classic', 'url': '?view\\x3dclassic'}, 'flipcard': {'name':
-        'flipcard', 'url': '?view\\x3dflipcard'}, 'magazine': {'name': 'magazine',
-        'url': '?view\\x3dmagazine'}, 'mosaic': {'name': 'mosaic', 'url': '?view\\x3dmosaic'},
-        'sidebar': {'name': 'sidebar', 'url': '?view\\x3dsidebar'}, 'snapshot': {'name':
-        'snapshot', 'url': '?view\\x3dsnapshot'}, 'timeslide': {'name': 'timeslide',
-        'url': '?view\\x3dtimeslide'}, 'isMobile': false, 'title': 'Python Insider',
-        'description': 'Python core development news and information.', 'url': 'https://pythoninsider.blogspot.com/',
-        'type': 'feed', 'isSingleItem': false, 'isMultipleItems': true, 'isError':
-        false, 'isPage': false, 'isPost': false, 'isHomepage': true, 'isArchive':
-        false, 'isLabelSearch': false}}]);\n_WidgetManager._RegisterWidget('_NavbarView',
-        new _WidgetInfo('Navbar1', 'navbar', document.getElementById('Navbar1'), {},
-        'displayModeFull'));\n_WidgetManager._RegisterWidget('_HeaderView', new _WidgetInfo('Header1',
-        'header', document.getElementById('Header1'), {}, 'displayModeFull'));\n_WidgetManager._RegisterWidget('_BlogView',
-        new _WidgetInfo('Blog1', 'main', document.getElementById('Blog1'), {'cmtInteractionsEnabled':
-        false, 'lightboxEnabled': true, 'lightboxModuleUrl': 'https://www.blogger.com/static/v1/jsbin/249874-lbx.js',
-        'lightboxCssUrl': 'https://www.blogger.com/static/v1/v-css/123180807-lightbox_bundle.css'},
-        'displayModeFull'));\n_WidgetManager._RegisterWidget('_HTMLView', new _WidgetInfo('HTML1',
-        'sidebar-right-1', document.getElementById('HTML1'), {}, 'displayModeFull'));\n_WidgetManager._RegisterWidget('_LinkListView',
-        new _WidgetInfo('LinkList1', 'sidebar-right-1', document.getElementById('LinkList1'),
-        {}, 'displayModeFull'));\n_WidgetManager._RegisterWidget('_LinkListView',
-        new _WidgetInfo('LinkList2', 'sidebar-right-1', document.getElementById('LinkList2'),
-        {}, 'displayModeFull'));\n_WidgetManager._RegisterWidget('_BlogListView',
-        new _WidgetInfo('BlogList1', 'sidebar-right-1', document.getElementById('BlogList1'),
-        {'numItemsToShow': 0, 'totalItems': 13}, 'displayModeFull'));\n_WidgetManager._RegisterWidget('_BlogArchiveView',
-        new _WidgetInfo('BlogArchive1', 'sidebar-right-1', document.getElementById('BlogArchive1'),
-        {'languageDirection': 'ltr', 'loadingMessage': 'Loading\\x26hellip;'}, 'displayModeFull'));\n_WidgetManager._RegisterWidget('_ProfileView',
-        new _WidgetInfo('Profile1', 'sidebar-right-1', document.getElementById('Profile1'),
-        {}, 'displayModeFull'));\n_WidgetManager._RegisterWidget('_HTMLView', new
-        _WidgetInfo('HTML3', 'sidebar-right-1', document.getElementById('HTML3'),
-        {}, 'displayModeFull'));\n_WidgetManager._RegisterWidget('_AttributionView',
-        new _WidgetInfo('Attribution1', 'attribution', document.getElementById('Attribution1'),
-        {}, 'displayModeFull'));\n</script>\n</body>\n</html>"
-    headers:
-      accept-ranges:
-      - bytes
-      cache-control:
-      - private, max-age=0
-      content-encoding:
-      - gzip
-      content-type:
-      - text/html; charset=UTF-8
-      date:
-      - Tue, 29 Jul 2025 09:02:44 GMT
-      etag:
-      - W/"4e50f1f1e6aea1309a53eb57cf2eead310a79291d2758e5ee1289fb1be60f537"
-      expires:
-      - Tue, 29 Jul 2025 09:02:44 GMT
-      last-modified:
-      - Tue, 22 Jul 2025 20:13:02 GMT
-      server:
-      - envoy
-      transfer-encoding:
-      - chunked
-      via:
-      - 1.1 varnish, 1.1 varnish
-      x-cache:
-      - MISS, MISS
-      x-cache-hits:
-      - 0, 0
-      x-content-type-options:
-      - nosniff
-      x-envoy-upstream-service-time:
-      - '167'
-      x-served-by:
-      - cache-lga21922-LGA, cache-dfw-kdfw8210141-DFW
-      x-timer:
-      - S1753779764.170943,VS0,VE125
-      x-xss-protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - python-requests/2.31.0
-    method: GET
-    uri: https://proxy:8080/
-  response:
-    body:
-      string: "<!DOCTYPE html>\n<html class='v2' dir='ltr' xmlns='http://www.w3.org/1999/xhtml'
-        xmlns:b='http://www.google.com/2005/gml/b' xmlns:data='http://www.google.com/2005/gml/data'
-        xmlns:expr='http://www.google.com/2005/gml/expr'>\n<head>\n<link href='https://www.blogger.com/static/v1/widgets/573632073-css_bundle_v2.css'
-        rel='stylesheet' type='text/css'/>\n<script data-domain='pythoninsider.blogspot.com'
-        defer='defer' src='https://analytics.python.org/js/script.outbound-links.js'></script>\n<link
-        href='https://blog.python.org/favicon.ico' rel='icon' type='image/x-icon'/>\n<meta
-        content='blogger' name='generator'/>\n<link href='https://blog.python.org/feeds/posts/default'
-        rel='alternate' title='Python Insider - Atom' type='application/atom+xml'/>\n<link
-        href='https://blog.python.org/feeds/posts/default?alt=rss' rel='alternate'
-        title='Python Insider - RSS' type='application/rss+xml'/>\n<link href='https://www.blogger.com/feeds/3941553907430899163/posts/default'
-        rel='service.post' title='Python Insider - Atom' type='application/atom+xml'/>\n<!--[if
-        IE]><script type=\"text/javascript\" src=\"https://www.blogger.com/static/v1/jsbin/2591933621-ieretrofit.js\"></script>
-        <![endif]-->\n<meta content='https://blog.python.org/' name='og:url:domain'/>\n<!--[if
-        IE]> <script> (function() { var html5 = (\"abbr,article,aside,audio,canvas,datalist,details,\"
-        + \"figure,footer,header,hgroup,mark,menu,meter,nav,output,\" + \"progress,section,time,video\").split(',');
-        for (var i = 0; i < html5.length; i++) { document.createElement(html5[i]);
-        } try { document.execCommand('BackgroundImageCache', false, true); } catch(e)
-        {} })(); </script> <![endif]-->\n<title>Python Insider</title>\n<meta name='author'
-        value='The Python Community'/>\n<style id='page-skin-1' type='text/css'><!--\n\n--></style>\n<style
-        id='template-skin-1' type='text/css'><!--\n\n--></style>\n<!--[if lt IE 9]>
-        <script src=\"http://html5shiv.googlecode.com/svn/trunk/html5.js\"></script>
-        <![endif]-->\n<style type='text/css'>\nbody {\n  font-family: Arial,Tahoma,Helvetica,FreeSans,sans-serif;\n
-        \ font-size: 12px;\n  color: #111;\n  background:#3272ac;\n\n  background-image:
-        -webkit-gradient(\n    linear,\n    left bottom,\n    left top,\n    color-stop(0.21,
-        rgb(50,114,172)),\n    color-stop(0.84, rgb(250,229,164))\n);\nbackground-image:
-        -moz-linear-gradient(\n    center bottom,\n    #3272ac 21%,\n    #fae5a4 84%\n);\n\nbackground-repeat:no-repeat;\n}\n\nh2
-        {font-size: 1em; }\nh3 { font-size: 1.2em}\n\n#wholeC {\n  background-color:#fff;\n
-        \ width: 90%;\n  margin: 0 auto 2em auto;\n}\n\n#cmain {\n  float:left;\n
-        \ width: 68%;\n  padding:0;\n  margin: 2em 0 2em 2%;\n}\n#cside {\n  float:right;\n
-        \ width: 23%;\n  margin-right: 2%;\n  margin-top: 2em;\n  margin-bottom: 3em;\n
-        \ padding-bottom: 3em;\n  font-size: 0.95em;\n}\n#cside a {\nfont-size: 0.95em\n}\n#cside
-        h2 {\ntext-transform:uppercase;\ncolor: #715707\n}\n\na { color: #142f46 }\na:hover
-        { color: #557 }\na:visited { color: #334 }\n\nh2.date-header { font-size:
-        13px; }\nh3.post-title { font-size: 16px; margin-bottom: 1em; }\n\ndiv.date-outer
-        {\n/* blog post container */\nmargin: 0 0 2em 0;\npadding: 0;\nfont-size:13px;\nline-height:133%;\n}\n\nheader#chead
-        {\ndisplay: block;\nmargin: 0 auto 1em auto;\npadding: 0;\nwidth: 70%;\nheight:145px;\noverflow:
-        hidden;\ncolor: #222;\nbackground: #fff;\nborder-bottom: 1px solid #ddd; \n\n}\n#Header1
-        {\nfont-size:16px;\n}\n#Header1 .description {\nposition:relative;\ntop: -35px;\nleft:
-        116px;\n}\n\n.wshad {\n    padding: 2em 8px;\n    border: 1px solid #99A;\n
-        \   -moz-box-shadow: 0 5px 10px #222;\n    -webkit-box-shadow: 0 5px 10px
-        #222;\n    box-shadow: 0 5px 10px #222;\n}\n\n.post-footer {\nborder-top:1px
-        outset #ddd;border-right:1px inset #ddd;\nbackground-color: #f5f5f5;\npadding:
-        10px 5px;\nposition:relative;\nleft:-1.2em;\nopacity: 0.75;\nfont-size:0.9em;\n}\n\n</style>\n<script
-        src='https://code.jquery.com/jquery-3.2.1.slim.min.js'></script>\n<script>\n$(document).ready(function()
-        {\n  $(\"a\").each(function() {\n    var i = $(this).attr(\"href\");\n    if
-        (!i) {\n      return;\n    }\n    var n = i.replace(\"https://pythoninsider.blogspot.com\",
-        \"https://blog.python.org\");\n    $(this).attr(\"href\", function() {\n      return
-        n\n    })\n  })\n});\n</script>\n<link href='https://www.blogger.com/dyn-css/authorization.css?targetBlogID=3941553907430899163&amp;zx=eb47a3b4-8679-40a3-a3c9-0305e654ac4c'
-        media='none' onload='if(media!=&#39;all&#39;)media=&#39;all&#39;' rel='stylesheet'/><noscript><link
-        href='https://www.blogger.com/dyn-css/authorization.css?targetBlogID=3941553907430899163&amp;zx=eb47a3b4-8679-40a3-a3c9-0305e654ac4c'
-        rel='stylesheet'/></noscript>\n<meta name='google-adsense-platform-account'
-        content='ca-host-pub-1556223355139109'/>\n<meta name='google-adsense-platform-domain'
-        content='blogspot.com'/>\n\n</head>\n<body>\n<div class='navbar section' id='navbar'><div
-        class='widget Navbar' data-version='1' id='Navbar1'><script type=\"text/javascript\">\n
-        \   function setAttributeOnload(object, attribute, val) {\n      if(window.addEventListener)
-        {\n        window.addEventListener('load',\n          function(){ object[attribute]
-        = val; }, false);\n      } else {\n        window.attachEvent('onload', function(){
-        object[attribute] = val; });\n      }\n    }\n  </script>\n<div id=\"navbar-iframe-container\"></div>\n<script
-        type=\"text/javascript\" src=\"https://apis.google.com/js/platform.js\"></script>\n<script
-        type=\"text/javascript\">\n      gapi.load(\"gapi.iframes:gapi.iframes.style.bubble\",
-        function() {\n        if (gapi.iframes && gapi.iframes.getContext) {\n          gapi.iframes.getContext().openChild({\n
-        \             url: 'https://www.blogger.com/navbar/3941553907430899163?origin\\x3dhttps://pythoninsider.blogspot.com',\n
-        \             where: document.getElementById(\"navbar-iframe-container\"),\n
-        \             id: \"navbar-iframe\"\n          });\n        }\n      });\n
-        \   </script><script type=\"text/javascript\">\n(function() {\nvar script
-        = document.createElement('script');\nscript.type = 'text/javascript';\nscript.src
-        = '//pagead2.googlesyndication.com/pagead/js/google_top_exp.js';\nvar head
-        = document.getElementsByTagName('head')[0];\nif (head) {\nhead.appendChild(script);\n}})();\n</script>\n</div></div>\n<div
-        id='wholeC'>\n<header id='chead'>\n<div class='header section' id='header'><div
-        class='widget Header' data-version='1' id='Header1'>\n<div id='header-inner'>\n<a
-        href='https://pythoninsider.blogspot.com/' style='display: block'>\n<img alt='Python
-        Insider' height='139px; ' id='Header1_headerimg' src='https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEiaYv-cjwDu6xU0AXLrBK0BEw19ERUxBEsbApijz0uyz_ouDUsdt-RS8Ims7R2PCwvlQAFhxxA15m7zgeB582M-Wsz9bSTpLk7WkzBdwwrMVRJPE-OstLYwR3TFITAh77gF2XEEnIzJAGRK/s1600/python-insider-header.png'
-        style='display: block' width='600px; '/>\n</a>\n<div class='descriptionwrapper'>\n<p
-        class='description'><span>Python core development news and information.</span></p>\n</div>\n</div>\n</div></div>\n</header>\n<div
-        id='cmain'>\n<section id='ccontent'>\n<div class='main section' id='main'><div
-        class='widget Blog' data-version='1' id='Blog1'>\n<div class='blog-posts hfeed'>\n\n
-        \         <div class=\"date-outer\">\n        \n<h2 class='date-header'><span>Tuesday,
-        July 22, 2025</span></h2>\n\n          <div class=\"date-posts\">\n        \n<div
-        class='post-outer'>\n<div class='post hentry'>\n<a name='8412948848050014787'></a>\n<h3
-        class='post-title entry-title'>\n<a href='https://pythoninsider.blogspot.com/2025/07/python-314-release-candidate-1-is-go.html'>Python
-        3.14 release candidate 1 is go!</a>\n</h3>\n<div class='post-header'>\n<div
-        class='post-header-line-1'></div>\n</div>\n<div class='post-body entry-content'>\n<p><a
-        href=\"https://www.youtube.com/watch?v=ydyXFUmv6S4\">It&#8217;s</a> the\nfirst
-        3.14 release candidate!</p>\n<p><a class=\"uri\" href=\"https://www.python.org/downloads/release/python-3140rc1/\">https://www.python.org/downloads/release/python-3140rc1/</a></p>\n<p><strong>This
-        is the first release candidate of Python\n3.14</strong></p>\n<p>This release,
-        <strong>3.14.0rc1</strong>, is the penultimate release\npreview. Entering
-        the release candidate phase, only reviewed code\nchanges which are clear bug
-        fixes are allowed between this release\ncandidate and the final release. The
-        second candidate (and the last\nplanned release preview) is scheduled for
-        Tuesday, 2025-08-26, while the\nofficial release of 3.14.0 is scheduled for
-        Tuesday, 2025-10-07.</p>\n<p>There will be <strong><em>no ABI changes</em></strong>
-        from this\npoint forward in the 3.14 series, and the goal is that there will
-        be as\nfew code changes as possible.</p>\n<h1 id=\"call-to-action\">Call to
-        action</h1>\n<p>We <strong><em>strongly encourage</em></strong> maintainers
-        of\nthird-party Python projects to prepare their projects for 3.14 during\nthis
-        phase, and where necessary publish Python 3.14 wheels on PyPI to be\nready
-        for the final release of 3.14.0, and to help other projects do\ntheir own
-        testing. Any binary wheels built against Python 3.14.0rc1\n<strong><em>will
-        work</em></strong> with future versions of Python 3.14.\nAs always, report
-        any issues to <a href=\"https://github.com/python/cpython/issues\">the Python
-        bug\ntracker</a>.</p>\n<p>Please keep in mind that this is a preview release
-        and while it&#8217;s as\nclose to the final release as we can get it, its
-        use is\n<strong><em>not</em></strong> recommended for production\nenvironments.</p>\n<h2
-        id=\"core-developers-time-to-work-on-documentation-now\">Core\ndevelopers:
-        time to work on documentation now</h2>\n<ul>\n<li>Are all your changes properly
-        documented?</li>\n<li>Are they mentioned in <a href=\"https://docs.python.org/3.14/whatsnew/3.14.html\">What&#8217;s\nNew</a>?</li>\n<li>Did
-        you notice other changes you know of to have insufficient\ndocumentation?</li>\n</ul>\n<h1
-        id=\"major-new-features-of-the-3.14-series-compared-to-3.13\">Major\nnew features
-        of the 3.14 series, compared to 3.13</h1>\n<p>Some of the major new features
-        and changes in Python 3.14 are:</p>\n<h2 id=\"new-features\">New features</h2>\n<ul>\n<li><a
-        href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pep779\">PEP\n779</a>:
-        Free-threaded Python is officially supported</li>\n<li><a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pep649\">PEP\n649</a>:
-        The evaluation of type annotations is now deferred, improving\nthe semantics
-        of using annotations.</li>\n<li><a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pep750\">PEP\n750</a>:
-        Template string literals (t-strings) for custom string\nprocessing, using
-        the familiar syntax of f-strings.</li>\n<li><a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pep734\">PEP\n734</a>:
-        Multiple interpreters in the stdlib.</li>\n<li><a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pep784\">PEP\n784</a>:
-        A new module <code>compression.zstd</code> providing support\nfor the Zstandard
-        compression algorithm.</li>\n<li><a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pep758\">PEP\n758</a>:
-        <code>except</code> and <code>except*</code> expressions may\nnow omit the
-        brackets.</li>\n<li><a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pyrepl-highlighting\">Syntax\nhighlighting
-        in PyREPL</a>, and support for color in <a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-color-unittest\">unittest</a>,\n<a
-        href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-color-argparse\">argparse</a>,\n<a
-        href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-color-json\">json</a>\nand
-        <a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-color-calendar\">calendar</a>\nCLIs.</li>\n<li><a
-        href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pep768\">PEP\n768</a>:
-        A zero-overhead external debugger interface for CPython.</li>\n<li><a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#uuid\">UUID\nversions
-        6-8</a> are now supported by the <code>uuid</code> module, and\ngeneration
-        of versions 3-5 are up to 40% faster.</li>\n<li><a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pep765\">PEP\n765</a>:
-        Disallow\n<code>return</code>/<code>break</code>/<code>continue</code> that
-        exit a\n<code>finally</code> block.</li>\n<li><a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pep741\">PEP\n741</a>:
-        An improved C API for configuring Python.</li>\n<li>A <a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-tail-call\">new\ntype
-        of interpreter</a>. For certain newer compilers, this interpreter\nprovides
-        significantly better performance. Opt-in for now, requires\nbuilding from
-        source.</li>\n<li><a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#improved-error-messages\">Improved\nerror
-        messages.</a></li>\n<li><a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#hmac\">Builtin\nimplementation
-        of HMAC</a> with formally verified code from the HACL*\nproject.</li>\n<li>A
-        <a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#asyncio-introspection-capabilities\">new\ncommand-line
-        interface</a> to inspect running Python processes using\nasynchronous tasks.</li>\n<li>The
-        pdb module now supports <a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#remote-attaching-to-a-running-python-process-with-pdb\">remote\nattaching
-        to a running Python process</a>.</li>\n</ul>\n<p><small>(Hey, <strong>fellow
-        core developer,</strong> if a feature you\nfind important is missing from
-        this list, let Hugo know.)</small></p>\n<p>For more details on the changes
-        to Python 3.14, see <a href=\"https://docs.python.org/3.14/whatsnew/3.14.html\">What&#8217;s
-        new in\nPython 3.14</a>. The next pre-release of Python 3.14 will be the final\nrelease
-        candidate, 3.14.0rc2, scheduled for 2025-08-26.</p>\n<h2 id=\"build-changes\">Build
-        changes</h2>\n<ul>\n<li><a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pep761\">PEP\n761</a>:
-        Python 3.14 and onwards no longer provides PGP signatures for\nrelease artifacts.
-        Instead, Sigstore is recommended for verifiers.</li>\n<li>Official macOS and
-        Windows release binaries include an <a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-jit-compiler\"><em>experimental</em>\nJIT
-        compiler</a>.</li>\n</ul>\n<h2 id=\"incompatible-changes-removals-and-new-deprecations\">Incompatible\nchanges,
-        removals and new deprecations</h2>\n<ul>\n<li><a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#incompatible-changes\">Incompatible\nchanges</a></li>\n<li>Python
-        <a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#removed\">removals</a>\nand
-        <a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#deprecated\">deprecations</a></li>\n<li>C
-        API <a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#c-api-removed\">removals</a>\nand
-        <a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#c-api-deprecated\">deprecations</a></li>\n<li>Overview
-        of all <a href=\"https://docs.python.org/3.14/deprecations/index.html\">pending\ndeprecations</a></li>\n</ul>\n<h1
-        id=\"python-install-manager\">Python install manager</h1>\n<p>The installer
-        we offer for Windows is being replaced by our new\ninstall manager, which
-        can be installed from <a href=\"https://apps.microsoft.com/detail/9NQ7512CXL7T\">the
-        Windows\nStore</a> or from its <a href=\"https://www.python.org/downloads/latest/pymanager/\">download\npage</a>.
-        See <a href=\"https://docs.python.org/3.14/using/windows.html\">our\ndocumentation</a>
-        for more information. The JSON file available for\ndownload below contains
-        the list of all the installable packages\navailable as part of this release,
-        including file URLs and hashes, but\nis not required to install the latest
-        release. The traditional installer\nwill remain available throughout the 3.14
-        and 3.15 releases.</p>\n<h1 id=\"more-resources\">More resources</h1>\n<ul>\n<li><a
-        href=\"https://docs.python.org/3.14/\">Online\ndocumentation</a></li>\n<li><a
-        href=\"https://peps.python.org/pep-0745/\">PEP 745</a>, 3.14\nRelease Schedule</li>\n<li>Report
-        bugs at <a href=\"https://github.com/python/cpython/issues\">github.com/python/cpython/issues</a></li>\n<li><a
-        href=\"https://www.python.org/psf/donations/\">Help fund Python and\nits community</a></li>\n</ul>\n<h1
-        id=\"and-now-for-something-completely-different\">And now for\nsomething completely
-        different</h1>\n<p>Today, 22nd July, is Pi Approximation Day, because 22/7
-        is a common\napproximation of <em>\u03C0</em> and closer to <em>\u03C0</em>
-        than 3.14.</p>\n<p>22/7 is a Diophantine approximation, named after Diophantus
-        of\nAlexandria (3rd century CE), which is a way of estimating a real number\nas
-        a ratio of two integers. 22/7 has been known since antiquity;\nArchimedes
-        (3rd century BCE) wrote the first known proof that 22/7\noverestimates <em>\u03C0</em>
-        by comparing 96-sided polygons to the circle it\ncircumscribes.</p>\n<p>Another
-        approximation is 355/113. In Chinese mathematics, 22/7 and\n355/113 are respectively
-        known as Yuel\xFC (\u7EA6\u7387; yu\u0113l\u01DC; &#8220;approximate\nratio&#8221;)
-        and Mil\xFC (\u5BC6\u7387; m\xECl\u01DC; &#8220;close ratio&#8221;).</p>\n<p>Happy
-        <a href=\"https://piapproximationday.com/\">Pi Approximation\nDay</a>!</p>\n<h1
-        id=\"enjoy-the-new-release\">Enjoy the new release</h1>\n<p>Thanks to all
-        of the many volunteers who help make Python Development\nand these releases
-        possible! Please consider supporting our efforts by\nvolunteering yourself
-        or through organisation contributions to the <a href=\"https://www.python.org/psf-landing/\">Python
-        Software\nFoundation</a>.</p>\n<p>Regards from a Helsinki heatwave after an
-        excellent <a href=\"https://ep2025.europython.eu/\">EuroPython</a>,</p>\n<p>Your
-        release team, <br>Hugo van Kemenade \n  <br>Ned Deily\n  <br>Steve Dower\n
-        \ <br>\u0141ukasz Langa\n</p>\n<div style='clear: both;'></div>\n</div>\n<div
-        class='post-footer'>\n<div class='post-footer-line post-footer-line-1'><span
-        class='post-author vcard'>\nPosted by\n<span class='fn'>Hugo</span>\n</span>\n<span
-        class='post-timestamp'>\nat\n<a class='timestamp-link' href='https://pythoninsider.blogspot.com/2025/07/python-314-release-candidate-1-is-go.html'
-        rel='bookmark' title='permanent link'><abbr class='published' title='2025-07-22T15:47:00-04:00'>3:47&#8239;PM</abbr></a>\n</span>\n<span
-        class='post-comment-link'>\n</span>\n<span class='post-icons'>\n</span>\n<div
-        class='post-share-buttons'>\n<a class='goog-inline-block share-button sb-email'
-        href='https://www.blogger.com/share-post.g?blogID=3941553907430899163&postID=8412948848050014787&target=email'
-        target='_blank' title='Email This'><span class='share-button-link-text'>Email
-        This</span></a><a class='goog-inline-block share-button sb-blog' href='https://www.blogger.com/share-post.g?blogID=3941553907430899163&postID=8412948848050014787&target=blog'
-        onclick='window.open(this.href, \"_blank\", \"height=270,width=475\"); return
-        false;' target='_blank' title='BlogThis!'><span class='share-button-link-text'>BlogThis!</span></a><a
-        class='goog-inline-block share-button sb-twitter' href='https://www.blogger.com/share-post.g?blogID=3941553907430899163&postID=8412948848050014787&target=twitter'
-        target='_blank' title='Share to X'><span class='share-button-link-text'>Share
-        to X</span></a><a class='goog-inline-block share-button sb-facebook' href='https://www.blogger.com/share-post.g?blogID=3941553907430899163&postID=8412948848050014787&target=facebook'
-        onclick='window.open(this.href, \"_blank\", \"height=430,width=640\"); return
-        false;' target='_blank' title='Share to Facebook'><span class='share-button-link-text'>Share
-        to Facebook</span></a><a class='goog-inline-block share-button sb-pinterest'
-        href='https://www.blogger.com/share-post.g?blogID=3941553907430899163&postID=8412948848050014787&target=pinterest'
-        target='_blank' title='Share to Pinterest'><span class='share-button-link-text'>Share
-        to Pinterest</span></a>\n</div>\n</div>\n<div class='post-footer-line post-footer-line-2'><span
-        class='post-labels'>\nLabels:\n<a href='https://pythoninsider.blogspot.com/search/label/releases'
-        rel='tag'>releases</a>\n</span>\n</div>\n<div class='post-footer-line post-footer-line-3'><span
-        class='post-location'>\n</span>\n</div>\n</div>\n</div>\n</div>\n\n          </div></div>\n
-        \       \n\n          <div class=\"date-outer\">\n        \n<h2 class='date-header'><span>Tuesday,
-        July 8, 2025</span></h2>\n\n          <div class=\"date-posts\">\n        \n<div
-        class='post-outer'>\n<div class='post hentry'>\n<a name='2902244612701978117'></a>\n<h3
-        class='post-title entry-title'>\n<a href='https://pythoninsider.blogspot.com/2025/07/python-3140-beta-4-is-here.html'>Python
-        3.14.0 beta 4 is here!</a>\n</h3>\n<div class='post-header'>\n<div class='post-header-line-1'></div>\n</div>\n<div
-        class='post-body entry-content'>\n<p><a href=\"https://www.youtube.com/watch?v=cCim90WO1-4\">It&#8217;s</a>
-        the\nfinal 3.14 beta!</p>\n<p><a class=\"uri\" href=\"https://www.python.org/downloads/release/python-3140b4/\">https://www.python.org/downloads/release/python-3140b4/</a></p>\n<p><strong>This
-        is a beta preview of Python 3.14</strong></p>\n<p>Python 3.14 is still in
-        development. This release, 3.14.0b4, is the\nlast of four planned beta releases.</p>\n<p>Beta
-        release previews are intended to give the wider community the\nopportunity
-        to test new features and bug fixes and to prepare their\nprojects to support
-        the new feature release.</p>\n<p>We <strong><em>strongly encourage</em></strong>
-        maintainers of\nthird-party Python projects to <strong><em>test with 3.14</em></strong>\nduring
-        the beta phase and report issues found to <a href=\"https://github.com/python/cpython/issues\">the
-        Python bug\ntracker</a> as soon as possible. While the release is planned
-        to be\nfeature-complete entering the beta phase, it is possible that features\nmay
-        be modified or, in rare cases, deleted up until the start of the\nrelease
-        candidate phase (Tuesday 2025-07-22). Our goal is to have\n<strong><em>no
-        ABI changes</em></strong> after beta 4 and as few code\nchanges as possible
-        after the first release candidate. To achieve that,\nit will be <strong><em>extremely
-        important</em></strong> to get as much\nexposure for 3.14 as possible during
-        the beta phase.</p>\n<p>This includes creating pre-release wheels for 3.14,
-        as it helps other\nprojects to do their own testing. However, we recommend
-        that your\nregular production releases wait until 3.14.0rc1, to avoid the
-        risk of\nABI breaks.</p>\n<p>Please keep in mind that this is a preview release
-        and its use is\n<strong><em>not</em></strong> recommended for production\nenvironments.</p>\n<h1
-        id=\"major-new-features-of-the-3.14-series-compared-to-3.13\">Major\nnew features
-        of the 3.14 series, compared to 3.13</h1>\n<p>Some of the major new features
-        and changes in Python 3.14 are:</p>\n<h2 id=\"new-features\">New features</h2>\n<p><em>Note
-        that PEPs <a href=\"https://discuss.python.org/t/pep-734-multiple-interpreters-in-the-stdlib/41147/36\">734</a>\nand
-        <a href=\"https://discuss.python.org/t/pep-779-criteria-for-supported-status-for-free-threaded-python/84319/123\">779</a>\nare
-        exceptionally new in beta 3!</em></p>\n<ul>\n<li><a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pep779\">PEP\n779</a>:
-        Free-threaded Python is officially supported</li>\n<li><a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pep649\">PEP\n649</a>:
-        The evaluation of type annotations is now deferred, improving\nthe semantics
-        of using annotations.</li>\n<li><a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pep750\">PEP\n750</a>:
-        Template string literals (t-strings) for custom string\nprocessing, using
-        the familiar syntax of f-strings.</li>\n<li><a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pep734\">PEP\n734</a>:
-        Multiple interpreters in the stdlib.</li>\n<li><a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pep784\">PEP\n784</a>:
-        A new module <code>compression.zstd</code> providing support\nfor the Zstandard
-        compression algorithm.</li>\n<li><a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pep758\">PEP\n758</a>:
-        <code>except</code> and <code>except*</code> expressions may\nnow omit the
-        brackets.</li>\n<li><a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pyrepl-highlighting\">Syntax\nhighlighting
-        in PyREPL</a>, and support for color in <a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-color-unittest\">unittest</a>,\n<a
-        href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-color-argparse\">argparse</a>,\n<a
-        href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-color-json\">json</a>\nand
-        <a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-color-calendar\">calendar</a>\nCLIs.</li>\n<li><a
-        href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pep768\">PEP\n768</a>:
-        A zero-overhead external debugger interface for CPython.</li>\n<li><a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#uuid\">UUID\nversions
-        6-8</a> are now supported by the <code>uuid</code> module, and\ngeneration
-        of versions 3-5 and 8 are up to 40% faster.</li>\n<li><a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pep765\">PEP\n765</a>:
-        Disallow\n<code>return</code>/<code>break</code>/<code>continue</code> that
-        exit a\n<code>finally</code> block.</li>\n<li><a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pep741\">PEP\n741</a>:
-        An improved C API for configuring Python.</li>\n<li>A <a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-tail-call\">new\ntype
-        of interpreter</a>. For certain newer compilers, this interpreter\nprovides
-        significantly better performance. Opt-in for now, requires\nbuilding from
-        source.</li>\n<li><a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#improved-error-messages\">Improved\nerror
-        messages.</a></li>\n<li><a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#hmac\">Builtin\nimplementation
-        of HMAC</a> with formally verified code from the HACL*\nproject.</li>\n<li>A
-        <a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#asyncio-introspection-capabilities\">new\ncommand-line
-        interface</a> to inspect running Python processes using\nasynchronous tasks.</li>\n<li>The
-        pdb module now supports <a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#remote-attaching-to-a-running-python-process-with-pdb\">remote\nattaching
-        to a running Python process</a>.</li>\n</ul>\n<p><small>(Hey, <strong>fellow
-        core developer,</strong> if a feature you\nfind important is missing from
-        this list, let Hugo know.)</small></p>\n<p>For more details on the changes
-        to Python 3.14, see <a href=\"https://docs.python.org/3.14/whatsnew/3.14.html\">What&#8217;s
-        new in\nPython 3.14</a>. The next pre-release of Python 3.14 will be the first\nrelease
-        candidate, 3.14.0rc1, scheduled for 2025-07-22.</p>\n<h2 id=\"build-changes\">Build
-        changes</h2>\n<ul>\n<li><a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pep761\">PEP\n761</a>:
-        Python 3.14 and onwards no longer provides PGP signatures for\nrelease artifacts.
-        Instead, Sigstore is recommended for verifiers.</li>\n<li>Official macOS and
-        Windows release binaries include an <a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-jit-compiler\"><em>experimental</em>\nJIT
-        compiler</a>.</li>\n</ul>\n<h2 id=\"incompatible-changes-removals-and-new-deprecations\">Incompatible\nchanges,
-        removals and new deprecations</h2>\n<ul>\n<li><a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#incompatible-changes\">Incompatible\nchanges</a></li>\n<li>Python
-        <a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#removed\">removals</a>\nand
-        <a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#deprecated\">deprecations</a></li>\n<li>C
-        API <a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#c-api-removed\">removals</a>\nand
-        <a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#c-api-deprecated\">deprecations</a></li>\n<li>Overview
-        of all <a href=\"https://docs.python.org/3.14/deprecations/index.html\">pending\ndeprecations</a></li>\n</ul>\n<h1
-        id=\"python-install-manager\">Python install manager</h1>\n<p>The installer
-        we offer for Windows is being replaced by our new\ninstall manager, which
-        can be installed from <a href=\"https://apps.microsoft.com/detail/9NQ7512CXL7T\">the
-        Windows\nStore</a> or from its <a href=\"https://www.python.org/downloads/latest/pymanager/\">download\npage</a>.
-        See <a href=\"https://docs.python.org/3.14/using/windows.html\">our\ndocumentation</a>
-        for more information. The JSON file available for\ndownload below contains
-        the list of all the installable packages\navailable as part of this release,
-        including file URLs and hashes, but\nis not required to install the latest
-        release. The traditional installer\nwill remain available throughout the 3.14
-        and 3.15 releases.</p>\n<h1 id=\"more-resources\">More resources</h1>\n<ul>\n<li><a
-        href=\"https://docs.python.org/3.14/\">Online\ndocumentation</a></li>\n<li><a
-        href=\"https://peps.python.org/pep-0745/\">PEP 745</a>, 3.14\nRelease Schedule</li>\n<li>Report
-        bugs at <a href=\"https://github.com/python/cpython/issues\">github.com/python/cpython/issues</a></li>\n<li><a
-        href=\"https://www.python.org/psf/donations/\">Help fund Python and\nits community</a></li>\n</ul>\n<h1
-        id=\"and-now-for-something-completely-different\">And now for\nsomething completely
-        different</h1>\n<p>All this talk of <em>\u03C0</em> and yet some say <em>\u03C0</em>
-        is wrong. <a href=\"https://www.tauday.com/\">Tau Day</a> (June 28th, 6/28
-        in the US)\ncelebrates <em>\u03C4</em> as the &#8220;true circle constant&#8221;,
-        as the ratio of a\ncircle&#8217;s circumference to its radius, <em>C/r</em>
-        = 6.283185&#8230; The <a href=\"https://www.tauday.com/tau-manifesto\">Tau
-        Manifesto</a> declares\n<em>\u03C0</em> &#8220;a confusing and unnatural choice
-        for the circle constant&#8221;,\nin part because &#8220;<em>2\u03C0</em> occurs
-        with astonishing frequency\nthroughout mathematics&#8221;.</p>\n<p>If you
-        wish to embrace <em>\u03C4</em> the good news is <a href=\"https://peps.python.org/pep-0628/\">PEP
-        628</a> added <a href=\"https://docs.python.org/3/library/math.html#math.tau\"><code>math.tau</code></a>\nto
-        Python 3.6 in 2016:</p>\n<blockquote>\n<p>When working with radians, it is
-        trivial to convert any given\nfraction of a circle to a value in radians in
-        terms of <code>tau</code>.\nA quarter circle is <code>tau/4</code>, a half
-        circle is\n<code>tau/2</code>, seven 25ths is <code>7*tau/25</code>, etc.
-        In\ncontrast with the equivalent expressions in terms of <code>pi</code>\n(<code>pi/2</code>,
-        <code>pi</code>, <code>14*pi/25</code>), the\nunnecessary and needlessly confusing
-        multiplication by two is gone.</p>\n</blockquote>\n<h1 id=\"enjoy-the-new-release\">Enjoy
-        the new release</h1>\n<p>Thanks to all of the many volunteers who help make
-        Python Development\nand these releases possible! Please consider supporting
-        our efforts by\nvolunteering yourself or through organisation contributions
-        to the <a href=\"https://www.python.org/psf-landing/\">Python Software\nFoundation</a>.</p>\n<p>Regards
-        from a cloudy Helsinki, looking forward to Prague and <a href=\"https://ep2025.europython.eu/\">EuroPython</a>
-        next week,</p>\n<p>Your release team, <br>Hugo van Kemenade <br>Ned Deily
-        <br>Steve\nDower <br>\u0141ukasz Langa</p>\n<div style='clear: both;'></div>\n</div>\n<div
-        class='post-footer'>\n<div class='post-footer-line post-footer-line-1'><span
-        class='post-author vcard'>\nPosted by\n<span class='fn'>Hugo</span>\n</span>\n<span
-        class='post-timestamp'>\nat\n<a class='timestamp-link' href='https://pythoninsider.blogspot.com/2025/07/python-3140-beta-4-is-here.html'
-        rel='bookmark' title='permanent link'><abbr class='published' title='2025-07-08T11:04:00-04:00'>11:04&#8239;AM</abbr></a>\n</span>\n<span
-        class='post-comment-link'>\n</span>\n<span class='post-icons'>\n</span>\n<div
-        class='post-share-buttons'>\n<a class='goog-inline-block share-button sb-email'
-        href='https://www.blogger.com/share-post.g?blogID=3941553907430899163&postID=2902244612701978117&target=email'
-        target='_blank' title='Email This'><span class='share-button-link-text'>Email
-        This</span></a><a class='goog-inline-block share-button sb-blog' href='https://www.blogger.com/share-post.g?blogID=3941553907430899163&postID=2902244612701978117&target=blog'
-        onclick='window.open(this.href, \"_blank\", \"height=270,width=475\"); return
-        false;' target='_blank' title='BlogThis!'><span class='share-button-link-text'>BlogThis!</span></a><a
-        class='goog-inline-block share-button sb-twitter' href='https://www.blogger.com/share-post.g?blogID=3941553907430899163&postID=2902244612701978117&target=twitter'
-        target='_blank' title='Share to X'><span class='share-button-link-text'>Share
-        to X</span></a><a class='goog-inline-block share-button sb-facebook' href='https://www.blogger.com/share-post.g?blogID=3941553907430899163&postID=2902244612701978117&target=facebook'
-        onclick='window.open(this.href, \"_blank\", \"height=430,width=640\"); return
-        false;' target='_blank' title='Share to Facebook'><span class='share-button-link-text'>Share
-        to Facebook</span></a><a class='goog-inline-block share-button sb-pinterest'
-        href='https://www.blogger.com/share-post.g?blogID=3941553907430899163&postID=2902244612701978117&target=pinterest'
-        target='_blank' title='Share to Pinterest'><span class='share-button-link-text'>Share
-        to Pinterest</span></a>\n</div>\n</div>\n<div class='post-footer-line post-footer-line-2'><span
-        class='post-labels'>\nLabels:\n<a href='https://pythoninsider.blogspot.com/search/label/releases'
-        rel='tag'>releases</a>\n</span>\n</div>\n<div class='post-footer-line post-footer-line-3'><span
-        class='post-location'>\n</span>\n</div>\n</div>\n</div>\n</div>\n\n          </div></div>\n
-        \       \n\n          <div class=\"date-outer\">\n        \n<h2 class='date-header'><span>Tuesday,
-        June 17, 2025</span></h2>\n\n          <div class=\"date-posts\">\n        \n<div
-        class='post-outer'>\n<div class='post hentry'>\n<a name='6430176619474922622'></a>\n<h3
-        class='post-title entry-title'>\n<a href='https://pythoninsider.blogspot.com/2025/06/python-3140-beta-3-is-here.html'>Python
-        3.14.0 beta 3 is here!</a>\n</h3>\n<div class='post-header'>\n<div class='post-header-line-1'></div>\n</div>\n<div
-        class='post-body entry-content'>\n<p>It&#8217;s 3.14 beta 3!</p>\n<p><a class=\"uri\"
-        href=\"https://www.python.org/downloads/release/python-3140b3/\">https://www.python.org/downloads/release/python-3140b3/</a></p>\n<p><strong>This
-        is a beta preview of Python 3.14</strong></p>\n<p>Python 3.14 is still in
-        development. This release, 3.14.0b3, is the\nthird of four planned beta releases.</p>\n<p>Beta
-        release previews are intended to give the wider community the\nopportunity
-        to test new features and bug fixes and to prepare their\nprojects to support
-        the new feature release.</p>\n<p>We <strong><em>strongly encourage</em></strong>
-        maintainers of\nthird-party Python projects to <strong><em>test with 3.14</em></strong>\nduring
-        the beta phase and report issues found to <a href=\"https://github.com/python/cpython/issues\">the
-        Python bug\ntracker</a> as soon as possible. While the release is planned
-        to be\nfeature-complete entering the beta phase, it is possible that features\nmay
-        be modified or, in rare cases, deleted up until the start of the\nrelease
-        candidate phase (Tuesday 2025-07-22). Our goal is to have\n<strong><em>no
-        ABI changes</em></strong> after beta 4 and as few code\nchanges as possible
-        after the first release candidate. To achieve that,\nit will be <strong><em>extremely
-        important</em></strong> to get as much\nexposure for 3.14 as possible during
-        the beta phase.</p>\n<p>This includes creating pre-release wheels for 3.14,
-        as it helps other\nprojects to do their own testing. However, we recommend
-        that your\nregular production releases wait until 3.14.0rc1, to avoid the
-        risk of\nABI breaks.</p>\n<p>Please keep in mind that this is a preview release
-        and its use is\n<strong><em>not</em></strong> recommended for production\nenvironments.</p>\n<h1
-        id=\"major-new-features-of-the-3.14-series-compared-to-3.13\">Major\nnew features
-        of the 3.14 series, compared to 3.13</h1>\n<p>Some of the major new features
-        and changes in Python 3.14 are:</p>\n<h2 id=\"new-features\">New features</h2>\n<p><em>Note
-        that PEPs <a href=\"https://discuss.python.org/t/pep-734-multiple-interpreters-in-the-stdlib/41147/36\">734</a>\nand
-        <a href=\"https://discuss.python.org/t/pep-779-criteria-for-supported-status-for-free-threaded-python/84319/123\">779</a>\nare
-        exceptionally new in beta 3!</em></p>\n<ul>\n<li><a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pep779\">PEP\n779</a>:
-        Free-threaded Python is officially supported</li>\n<li><a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pep649\">PEP\n649</a>:
-        The evaluation of type annotations is now deferred, improving\nthe semantics
-        of using annotations.</li>\n<li><a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pep750\">PEP\n750</a>:
-        Template string literals (t-strings) for custom string\nprocessing, using
-        the familiar syntax of f-strings.</li>\n<li><a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pep734\">PEP\n734</a>:
-        Multiple interpreters in the stdlib.</li>\n<li><a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pep784\">PEP\n784</a>:
-        A new module <code>compression.zstd</code> providing support\nfor the Zstandard
-        compression algorithm.</li>\n<li><a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pep758\">PEP\n758</a>:
-        <code>except</code> and <code>except*</code> expressions may\nnow omit the
-        brackets.</li>\n<li><a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pyrepl-highlighting\">Syntax\nhighlighting
-        in PyREPL</a>, and support for color in <a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-color-unittest\">unittest</a>,\n<a
-        href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-color-argparse\">argparse</a>,\n<a
-        href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-color-json\">json</a>\nand
-        <a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-color-calendar\">calendar</a>\nCLIs.</li>\n<li><a
-        href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pep768\">PEP\n768</a>:
-        A zero-overhead external debugger interface for CPython.</li>\n<li><a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#uuid\">UUID\nversions
-        6-8</a> are now supported by the <code>uuid</code> module, and\ngeneration
-        of versions 3-5 and 8 are up to 40% faster.</li>\n<li><a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pep765\">PEP\n765</a>:
-        Disallow\n<code>return</code>/<code>break</code>/<code>continue</code> that
-        exit a\n<code>finally</code> block.</li>\n<li><a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pep741\">PEP\n741</a>:
-        An improved C API for configuring Python.</li>\n<li>A <a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-tail-call\">new\ntype
-        of interpreter</a>. For certain newer compilers, this interpreter\nprovides
-        significantly better performance. Opt-in for now, requires\nbuilding from
-        source.</li>\n<li><a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#improved-error-messages\">Improved\nerror
-        messages.</a></li>\n<li><a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#hmac\">Builtin\nimplementation
-        of HMAC</a> with formally verified code from the HACL*\nproject.</li>\n<li>A
-        <a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#asyncio-introspection-capabilities\">new\ncommand-line
-        interface</a> to inspect running Python processes using\nasynchronous tasks.</li>\n<li>The
-        pdb module now supports <a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#remote-attaching-to-a-running-python-process-with-pdb\">remote\nattaching
-        to a running Python process</a>.</li>\n</ul>\n<p><small>(Hey, <strong>fellow
-        core developer,</strong> if a feature you\nfind important is missing from
-        this list, let Hugo know.)</small></p>\n<p>For more details on the changes
-        to Python 3.14, see <a href=\"https://docs.python.org/3.14/whatsnew/3.14.html\">What&#8217;s
-        new in\nPython 3.14</a>. The next pre-release of Python 3.14 will be the final\nbeta,
-        3.14.0b4, scheduled for 2025-07-08.</p>\n<h2 id=\"build-changes\">Build changes</h2>\n<ul>\n<li><a
-        href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pep761\">PEP\n761</a>:
-        Python 3.14 and onwards no longer provides PGP signatures for\nrelease artifacts.
-        Instead, Sigstore is recommended for verifiers.</li>\n<li>Official macOS and
-        Windows release binaries include an <a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-jit-compiler\"><em>experimental</em>\nJIT
-        compiler</a>.</li>\n</ul>\n<h2 id=\"incompatible-changes-removals-and-new-deprecations\">Incompatible\nchanges,
-        removals and new deprecations</h2>\n<ul>\n<li><a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#incompatible-changes\">Incompatible\nchanges</a></li>\n<li>Python
-        <a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#removed\">removals</a>\nand
-        <a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#deprecated\">deprecations</a></li>\n<li>C
-        API <a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#c-api-removed\">removals</a>\nand
-        <a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#c-api-deprecated\">deprecations</a></li>\n<li>Overview
-        of all <a href=\"https://docs.python.org/3.14/deprecations/index.html\">pending\ndeprecations</a></li>\n</ul>\n<h1
-        id=\"python-install-manager\">Python install manager</h1>\n<p>The installer
-        we offer for Windows is being replaced by our new\ninstall manager, which
-        can be installed from <a href=\"https://apps.microsoft.com/detail/9NQ7512CXL7T\">the
-        Windows\nStore</a> or <a href=\"https://www.python.org/ftp/python/pymanager/\">our\nFTP
-        page</a>. See <a href=\"https://docs.python.org/3.14/using/windows.html\">our\ndocumentation</a>
-        for more information. The JSON file available for\ndownload below contains
-        the list of all the installable packages\navailable as part of this release,
-        including file URLs and hashes, but\nis not required to install the latest
-        release. The traditional installer\nwill remain available throughout the 3.14
-        and 3.15 releases.</p>\n<h1 id=\"more-resources\">More resources</h1>\n<ul>\n<li><a
-        href=\"https://docs.python.org/3.14/\">Online\ndocumentation</a></li>\n<li><a
-        href=\"https://peps.python.org/pep-0745/\">PEP 745</a>, 3.14\nRelease Schedule</li>\n<li>Report
-        bugs at <a href=\"https://github.com/python/cpython/issues\">github.com/python/cpython/issues</a></li>\n<li><a
-        href=\"https://www.python.org/psf/donations/\">Help fund Python and\nits community</a></li>\n</ul>\n<h1
-        id=\"and-now-for-something-completely-different\">And now for\nsomething completely
-        different</h1>\n<p>If you&#8217;re heading out to sea, remember the <a href=\"https://xkcd.com/3023/\">Maritime
-        Approximation</a>:</p>\n<blockquote>\n<p><em>\u03C0</em> mph = <em>e</em>
-        knots</p>\n</blockquote>\n<h1 id=\"enjoy-the-new-release\">Enjoy the new release</h1>\n<p>Thanks
-        to all of the many volunteers who help make Python Development\nand these
-        releases possible! Please consider supporting our efforts by\nvolunteering
-        yourself or through organisation contributions to the <a href=\"https://www.python.org/psf-landing/\">Python
-        Software\nFoundation</a>.</p>\n<p>Regards from sunny Helsinki with 19 hours
-        of daylight,</p>\n<p>Your release team, \n  <br>Hugo van Kemenade\n  <br>Ned
-        Deily\n  <br>Steve Dower\n  <br>\u0141ukasz Langa\n</p>\n<div style='clear:
-        both;'></div>\n</div>\n<div class='post-footer'>\n<div class='post-footer-line
-        post-footer-line-1'><span class='post-author vcard'>\nPosted by\n<span class='fn'>Hugo</span>\n</span>\n<span
-        class='post-timestamp'>\nat\n<a class='timestamp-link' href='https://pythoninsider.blogspot.com/2025/06/python-3140-beta-3-is-here.html'
-        rel='bookmark' title='permanent link'><abbr class='published' title='2025-06-17T14:43:00-04:00'>2:43&#8239;PM</abbr></a>\n</span>\n<span
-        class='post-comment-link'>\n</span>\n<span class='post-icons'>\n</span>\n<div
-        class='post-share-buttons'>\n<a class='goog-inline-block share-button sb-email'
-        href='https://www.blogger.com/share-post.g?blogID=3941553907430899163&postID=6430176619474922622&target=email'
-        target='_blank' title='Email This'><span class='share-button-link-text'>Email
-        This</span></a><a class='goog-inline-block share-button sb-blog' href='https://www.blogger.com/share-post.g?blogID=3941553907430899163&postID=6430176619474922622&target=blog'
-        onclick='window.open(this.href, \"_blank\", \"height=270,width=475\"); return
-        false;' target='_blank' title='BlogThis!'><span class='share-button-link-text'>BlogThis!</span></a><a
-        class='goog-inline-block share-button sb-twitter' href='https://www.blogger.com/share-post.g?blogID=3941553907430899163&postID=6430176619474922622&target=twitter'
-        target='_blank' title='Share to X'><span class='share-button-link-text'>Share
-        to X</span></a><a class='goog-inline-block share-button sb-facebook' href='https://www.blogger.com/share-post.g?blogID=3941553907430899163&postID=6430176619474922622&target=facebook'
-        onclick='window.open(this.href, \"_blank\", \"height=430,width=640\"); return
-        false;' target='_blank' title='Share to Facebook'><span class='share-button-link-text'>Share
-        to Facebook</span></a><a class='goog-inline-block share-button sb-pinterest'
-        href='https://www.blogger.com/share-post.g?blogID=3941553907430899163&postID=6430176619474922622&target=pinterest'
-        target='_blank' title='Share to Pinterest'><span class='share-button-link-text'>Share
-        to Pinterest</span></a>\n</div>\n</div>\n<div class='post-footer-line post-footer-line-2'><span
-        class='post-labels'>\nLabels:\n<a href='https://pythoninsider.blogspot.com/search/label/releases'
-        rel='tag'>releases</a>\n</span>\n</div>\n<div class='post-footer-line post-footer-line-3'><span
-        class='post-location'>\n</span>\n</div>\n</div>\n</div>\n</div>\n\n          </div></div>\n
-        \       \n\n          <div class=\"date-outer\">\n        \n<h2 class='date-header'><span>Wednesday,
-        June 11, 2025</span></h2>\n\n          <div class=\"date-posts\">\n        \n<div
-        class='post-outer'>\n<div class='post hentry'>\n<a name='6912588868872774611'></a>\n<h3
-        class='post-title entry-title'>\n<a href='https://pythoninsider.blogspot.com/2025/06/python-3135-is-now-available.html'>Python
-        3.13.5 is now available!</a>\n</h3>\n<div class='post-header'>\n<div class='post-header-line-1'></div>\n</div>\n<div
-        class='post-body entry-content'>\n<p>When I was younger we would call this
-        a brown paper bag release, but \nactually, we shouldn&#8217;t hide from our
-        mistakes. We&#8217;re only human. So, \nplease enjoy:</p>\n<h1 style=\"text-align:
-        left;\"><a class=\"anchor\" href=\"https://discuss.python.org/t/python-3-13-5-is-now-available-yes-really/95211#p-254481-python-3135-1\"
-        name=\"p-254481-python-3135-1\"></a>Python 3.13.5</h1><div style=\"text-align:
-        left;\">&nbsp;</div><div style=\"text-align: left;\"><a href=\"https://www.python.org/downloads/release/python-3135/\">&nbsp;https://www.python.org/downloads/release/python-3135/</a></div><h3
-        style=\"text-align: left;\"><a class=\"anchor\" href=\"https://discuss.python.org/t/python-3-13-5-is-now-available-yes-really/95211#p-254481-this-is-the-fifth-maintenance-release-of-python-313-2\"
-        name=\"p-254481-this-is-the-fifth-maintenance-release-of-python-313-2\"></a>&nbsp;</h3><h3
-        style=\"text-align: left;\">This is the fifth maintenance release of Python
-        3.13</h3>\n<p>Python 3.13 is the newest major release of the Python programming
-        \nlanguage, and it contains many new features and optimizations compared \nto
-        Python 3.12. 3.13.5 is the fifth maintenance release of 3.13.</p>\n<p>3.13.5
-        is an expedited release to fix a couple of significant issues with the 3.13.4
-        release:</p>\n<ul><li><a href=\"https://github.com/python/cpython/issues/135151\">gh-135151</a>:
-        Building extension modules on Windows for the regular (non-free-threaded)
-        build failed.</li><li><a aria-label=\"gh-135171 link clicked 1 time\" data-clicks=\"1\"
-        href=\"https://github.com/python/cpython/issues/135171\">gh-135171</a>: Generator
-        expressions stopped raising <code>TypeError</code> (when iterating over non-iterable
-        objects) at creation time, delaying it to first use.</li><li><a href=\"https://github.com/python/cpython/issues/135326\">gh-135326</a>:
-        Passing int-like objects (like <code>numpy.int64</code>) to <code>random.getrandbits()</code>
-        failed, when it worked before.</li></ul>\n<p>Several other bug fixes (which
-        would otherwise have waited until the \nnext release) are also included. Special
-        thanks to everyone who worked \nhard the last couple of days to fix these
-        issues as quickly as possible.</p>\n<p><a href=\"https://docs.python.org/release/3.13.5/whatsnew/changelog.html#python-3-13-5\">Full
-        Changelog</a></p>\n<h3 style=\"text-align: left;\"><a class=\"anchor\" href=\"https://discuss.python.org/t/python-3-13-5-is-now-available-yes-really/95211#p-254481-more-resources-3\"
-        name=\"p-254481-more-resources-3\"></a>More resources</h3>\n<ul><li><a href=\"https://docs.python.org/3.13/\">Online
-        Documentation</a></li><li><a aria-label=\"PEP 719 link clicked 1 time\" data-clicks=\"1\"
-        href=\"https://peps.python.org/pep-0719/\">PEP 719</a>, 3.13 Release Schedule
-        (not that you&#8217;ll find this release on there yet.)</li><li>Report bugs
-        via <a href=\"https://github.com/python/cpython/issues\">GitHub</a>.</li><li><a
-        href=\"https://www.python.org/psf/donations/python-dev/\">Help fund Python
-        directly</a> (or <a href=\"https://github.com/sponsors/python\">via GitHub
-        Sponsors</a>), and support <a href=\"https://www.python.org/psf/donations/\">the
-        Python community</a>.</li></ul>\n<h3 style=\"text-align: left;\"><a class=\"anchor\"
-        href=\"https://discuss.python.org/t/python-3-13-5-is-now-available-yes-really/95211#p-254481-stay-safe-and-upgrade-4\"
-        name=\"p-254481-stay-safe-and-upgrade-4\"></a>&nbsp;</h3><h3 style=\"text-align:
-        left;\">Stay safe and upgrade!</h3>\n<p>As always, upgrading is highly recommended
-        to all users of 3.13.</p>\n<h3 style=\"text-align: left;\"><a class=\"anchor\"
-        href=\"https://discuss.python.org/t/python-3-13-5-is-now-available-yes-really/95211#p-254481-enjoy-the-new-releases-5\"
-        name=\"p-254481-enjoy-the-new-releases-5\"></a>&nbsp;</h3><h3 style=\"text-align:
-        left;\">Enjoy the new releases</h3>\n<p>Thanks to all of the many volunteers
-        who help make Python Development\n and these releases possible! Please consider
-        supporting our efforts by \nvolunteering yourself or through organization
-        contributions to the \nPython Software Foundation.</p>\n<p>Regards from hey,
-        it&#8217;s us again, your release team,<br />\nThomas Wouters <br />\nNed
-        Deily <br />\nSteve Dower <br />\n\u0141ukasz Langa <br /></p>\n<div style='clear:
-        both;'></div>\n</div>\n<div class='post-footer'>\n<div class='post-footer-line
-        post-footer-line-1'><span class='post-author vcard'>\nPosted by\n<span class='fn'>Thomas
-        Wouters</span>\n</span>\n<span class='post-timestamp'>\nat\n<a class='timestamp-link'
-        href='https://pythoninsider.blogspot.com/2025/06/python-3135-is-now-available.html'
-        rel='bookmark' title='permanent link'><abbr class='published' title='2025-06-11T18:03:00-04:00'>6:03&#8239;PM</abbr></a>\n</span>\n<span
-        class='post-comment-link'>\n</span>\n<span class='post-icons'>\n</span>\n<div
-        class='post-share-buttons'>\n<a class='goog-inline-block share-button sb-email'
-        href='https://www.blogger.com/share-post.g?blogID=3941553907430899163&postID=6912588868872774611&target=email'
-        target='_blank' title='Email This'><span class='share-button-link-text'>Email
-        This</span></a><a class='goog-inline-block share-button sb-blog' href='https://www.blogger.com/share-post.g?blogID=3941553907430899163&postID=6912588868872774611&target=blog'
-        onclick='window.open(this.href, \"_blank\", \"height=270,width=475\"); return
-        false;' target='_blank' title='BlogThis!'><span class='share-button-link-text'>BlogThis!</span></a><a
-        class='goog-inline-block share-button sb-twitter' href='https://www.blogger.com/share-post.g?blogID=3941553907430899163&postID=6912588868872774611&target=twitter'
-        target='_blank' title='Share to X'><span class='share-button-link-text'>Share
-        to X</span></a><a class='goog-inline-block share-button sb-facebook' href='https://www.blogger.com/share-post.g?blogID=3941553907430899163&postID=6912588868872774611&target=facebook'
-        onclick='window.open(this.href, \"_blank\", \"height=430,width=640\"); return
-        false;' target='_blank' title='Share to Facebook'><span class='share-button-link-text'>Share
-        to Facebook</span></a><a class='goog-inline-block share-button sb-pinterest'
-        href='https://www.blogger.com/share-post.g?blogID=3941553907430899163&postID=6912588868872774611&target=pinterest'
-        target='_blank' title='Share to Pinterest'><span class='share-button-link-text'>Share
-        to Pinterest</span></a>\n</div>\n</div>\n<div class='post-footer-line post-footer-line-2'><span
-        class='post-labels'>\n</span>\n</div>\n<div class='post-footer-line post-footer-line-3'><span
-        class='post-location'>\n</span>\n</div>\n</div>\n</div>\n</div>\n\n          </div></div>\n
-        \       \n\n          <div class=\"date-outer\">\n        \n<h2 class='date-header'><span>Tuesday,
-        June 3, 2025</span></h2>\n\n          <div class=\"date-posts\">\n        \n<div
-        class='post-outer'>\n<div class='post hentry'>\n<a name='8911393060938687340'></a>\n<h3
-        class='post-title entry-title'>\n<a href='https://pythoninsider.blogspot.com/2025/06/python-3134-31211-31113-31018-and-3923.html'>Python
-        3.13.4, 3.12.11, 3.11.13, 3.10.18 and 3.9.23 are now available</a>\n</h3>\n<div
-        class='post-header'>\n<div class='post-header-line-1'></div>\n</div>\n<div
-        class='post-body entry-content'>\n<p>&nbsp;</p><h1 style=\"text-align: left;\">Python
-        Release Party</h1>\n<p>It was only meant to be release day for 3.13.4 today,
-        but poor number\n 13 looked so lonely&#8230; And hey, we had a couple of tarfile
-        CVEs that we \nhad to fix. So most of the Release Managers and all the \nDevelopers-in-Residence
-        (including Security Developer-in-Residence Seth Michael Larson) came together
-        to make it a full release party.</p>\n<h1 style=\"text-align: left;\">Security
-        content in these releases</h1>\n<ul><li><a href=\"https://github.com/python/cpython/issues/135034\">gh-135034</a>:
-        Fixes multiple issues that allowed <code>tarfile</code> extraction filters
-        (<code>filter=\"data\"</code> and <code>filter=\"tar\"</code>) to be bypassed
-        using crafted symlinks and hard links.Addresses <a href=\"https://www.cve.org/CVERecord?id=CVE-2024-12718\"><b>CVE
-        2024-12718</b></a>, <a href=\"https://www.cve.org/CVERecord?id=CVE-2025-4138\"><b>CVE
-        2025-4138</b></a>, <a href=\"https://www.cve.org/CVERecord?id=CVE-2025-4330\"><b>CVE
-        2025-4330</b></a>, and <a href=\"https://www.cve.org/CVERecord?id=CVE-2025-4517\"><b>CVE
-        2025-4517</b></a>.</li><li><a href=\"https://github.com/python/cpython/issues/133767\">gh-133767</a>:
-        Fix use-after-free in the &#8220;unicode-escape&#8221; decoder with a non-&#8220;strict&#8221;
-        error handler.</li><li><a href=\"https://github.com/python/cpython/issues/128840\">gh-128840</a>:
-        Short-circuit the processing of long IPv6 addresses early in <a href=\"https://docs.python.org/release/3.13.4/library/ipaddress.html#module-ipaddress\"><code>ipaddress</code></a>
-        to prevent excessive memory consumption and a minor denial-of-service.</li></ul>\n<p>In
-        addition to the security fixed mentioned above, a few additional changes to
-        the <code>ipaddress</code> were backported to make the security fixes feasible.
-        (See the full changelogs for each release for more details.)</p>\n<h1 style=\"text-align:
-        left;\">Python 3.13.4</h1>\n<p>In addition to the security fixes, the fourth
-        maintenance release of \nPython 3.13 contains more than 300 bugfixes, build
-        improvements and \ndocumentation changes.</p><p><a href=\"https://www.python.org/downloads/release/python-3134/\">https://www.python.org/downloads/release/python-3134/</a></p>\n\n<h1
-        style=\"text-align: left;\">Python 3.12.11</h1><p><a href=\"https://www.python.org/downloads/release/python-31211/\">https://www.python.org/downloads/release/python-31211/</a></p><h1
-        style=\"text-align: left;\">Python 3.11.13</h1><p>&nbsp;<a href=\"https://www.python.org/downloads/release/python-31113/\">https://www.python.org/downloads/release/python-31113/</a></p><h1
-        style=\"text-align: left;\">Python 3.10.18</h1>\n<aside class=\"onebox allowlistedgeneric\"
-        data-onebox-src=\"https://www.python.org/downloads/release/python-31018/\"><br
-        /></aside><aside class=\"onebox allowlistedgeneric\" data-onebox-src=\"https://www.python.org/downloads/release/python-31018/\"><a
-        href=\"https://www.python.org/downloads/release/python-31018/\">https://www.python.org/downloads/release/python-31018/</a></aside><aside
-        class=\"onebox allowlistedgeneric\" data-onebox-src=\"https://www.python.org/downloads/release/python-31018/\">&nbsp;</aside>\n\n<h1
-        style=\"text-align: left;\">Python 3.9.23</h1>\n<p>Additional security content
-        in this release (already fixed in older releases for the other versions):</p>\n<ul><li><a
-        href=\"https://github.com/python/cpython/issues/80222\">gh-80222</a>:\n Fix
-        bug in the folding of quoted strings when flattening an email \nmessage using
-        a modern email policy. Previously when a quoted string was\n folded so that
-        it spanned more than one line, the surrounding quotes \nand internal escapes
-        would be omitted. This could theoretically be used \nto spoof header lines
-        using a carefully constructed quoted string if the\n resulting rendered email
-        was transmitted or re-parsed.</li></ul>\n<aside class=\"onebox allowlistedgeneric\"
-        data-onebox-src=\"https://www.python.org/downloads/release/python-3923/\"><a
-        href=\"https://www.python.org/downloads/release/python-3923\">https://www.python.org/downloads/release/python-3923</a><div
-        class=\"onebox-metadata\">\n    \n    \n  </div>\n\n  \n<br /></aside>\n\n<h1
-        style=\"text-align: left;\">Stay safe and upgrade!</h1>\n<p>As always, upgrading
-        is highly recommended to all users of affected versions.</p>\n<h1 style=\"text-align:
-        left;\">Enjoy the new releases</h1>\n<p>Thanks to all of the many volunteers
-        who help make Python Development\n and these releases possible! Please consider
-        supporting our efforts by \nvolunteering yourself or through organization
-        contributions to the \nPython Software Foundation.</p>\n<p>Regards from your
-        very <s>tired</s> tireless release team,<br />\nThomas Wouters <br />\nPablo
-        Galindo Salgado <br />\n\u0141ukasz Langa <br />\nNed Deily <br />\nSteve
-        Dower <br /></p>\n<div style='clear: both;'></div>\n</div>\n<div class='post-footer'>\n<div
-        class='post-footer-line post-footer-line-1'><span class='post-author vcard'>\nPosted
-        by\n<span class='fn'>Thomas Wouters</span>\n</span>\n<span class='post-timestamp'>\nat\n<a
-        class='timestamp-link' href='https://pythoninsider.blogspot.com/2025/06/python-3134-31211-31113-31018-and-3923.html'
-        rel='bookmark' title='permanent link'><abbr class='published' title='2025-06-03T17:04:00-04:00'>5:04&#8239;PM</abbr></a>\n</span>\n<span
-        class='post-comment-link'>\n</span>\n<span class='post-icons'>\n</span>\n<div
-        class='post-share-buttons'>\n<a class='goog-inline-block share-button sb-email'
-        href='https://www.blogger.com/share-post.g?blogID=3941553907430899163&postID=8911393060938687340&target=email'
-        target='_blank' title='Email This'><span class='share-button-link-text'>Email
-        This</span></a><a class='goog-inline-block share-button sb-blog' href='https://www.blogger.com/share-post.g?blogID=3941553907430899163&postID=8911393060938687340&target=blog'
-        onclick='window.open(this.href, \"_blank\", \"height=270,width=475\"); return
-        false;' target='_blank' title='BlogThis!'><span class='share-button-link-text'>BlogThis!</span></a><a
-        class='goog-inline-block share-button sb-twitter' href='https://www.blogger.com/share-post.g?blogID=3941553907430899163&postID=8911393060938687340&target=twitter'
-        target='_blank' title='Share to X'><span class='share-button-link-text'>Share
-        to X</span></a><a class='goog-inline-block share-button sb-facebook' href='https://www.blogger.com/share-post.g?blogID=3941553907430899163&postID=8911393060938687340&target=facebook'
-        onclick='window.open(this.href, \"_blank\", \"height=430,width=640\"); return
-        false;' target='_blank' title='Share to Facebook'><span class='share-button-link-text'>Share
-        to Facebook</span></a><a class='goog-inline-block share-button sb-pinterest'
-        href='https://www.blogger.com/share-post.g?blogID=3941553907430899163&postID=8911393060938687340&target=pinterest'
-        target='_blank' title='Share to Pinterest'><span class='share-button-link-text'>Share
-        to Pinterest</span></a>\n</div>\n</div>\n<div class='post-footer-line post-footer-line-2'><span
-        class='post-labels'>\n</span>\n</div>\n<div class='post-footer-line post-footer-line-3'><span
-        class='post-location'>\n</span>\n</div>\n</div>\n</div>\n</div>\n\n          </div></div>\n
-        \       \n\n          <div class=\"date-outer\">\n        \n<h2 class='date-header'><span>Monday,
-        May 26, 2025</span></h2>\n\n          <div class=\"date-posts\">\n        \n<div
-        class='post-outer'>\n<div class='post hentry'>\n<a name='8971055125507701901'></a>\n<h3
-        class='post-title entry-title'>\n<a href='https://pythoninsider.blogspot.com/2025/05/python-3140-beta-2-is-here.html'>Python
-        3.14.0 beta 2 is here!</a>\n</h3>\n<div class='post-header'>\n<div class='post-header-line-1'></div>\n</div>\n<div
-        class='post-body entry-content'>\n<p>Here&#8217;s the second 3.14 beta.</p>\n<p><a
-        class=\"uri\" href=\"https://www.python.org/downloads/release/python-3140b2/\">https://www.python.org/downloads/release/python-3140b2/</a></p>\n<p><strong>This
-        is a beta preview of Python 3.14</strong></p>\n<p>Python 3.14 is still in
-        development. This release, 3.14.0b2, is the\nsecond of four planned beta releases.</p>\n<p>Beta
-        release previews are intended to give the wider community the\nopportunity
-        to test new features and bug fixes and to prepare their\nprojects to support
-        the new feature release.</p>\n<p>We <strong><em>strongly encourage</em></strong>
-        maintainers of\nthird-party Python projects to <strong><em>test with 3.14</em></strong>\nduring
-        the beta phase and report issues found to <a href=\"https://github.com/python/cpython/issues\">the
-        Python bug\ntracker</a> as soon as possible. While the release is planned
-        to be\nfeature-complete entering the beta phase, it is possible that features\nmay
-        be modified or, in rare cases, deleted up until the start of the\nrelease
-        candidate phase (Tuesday 2025-07-22). Our goal is to have\n<strong><em>no
-        ABI changes</em></strong> after beta 4 and as few code\nchanges as possible
-        after the first release candidate. To achieve that,\nit will be <strong><em>extremely
-        important</em></strong> to get as much\nexposure for 3.14 as possible during
-        the beta phase.</p>\n<p>This includes creating pre-release wheels for 3.14,
-        as it helps other\nprojects to do their own testing. However, we recommend
-        that your\nregular production releases wait until 3.14.0rc1, to avoid the
-        risk of\nABI breaks.</p>\n<p>Please keep in mind that this is a preview release
-        and its use is\n<strong><em>not</em></strong> recommended for production\nenvironments.</p>\n<h1
-        id=\"major-new-features-of-the-3.14-series-compared-to-3.13\">Major\nnew features
-        of the 3.14 series, compared to 3.13</h1>\n<p>Some of the major new features
-        and changes in Python 3.14 are:</p>\n<h2 id=\"new-features\">New features</h2>\n<ul>\n<li><a
-        href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pep649\">PEP\n649</a>:
-        The evaluation of type annotations is now deferred, improving\nthe semantics
-        of using annotations.</li>\n<li><a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pep750\">PEP\n750</a>:
-        Template string literals (t-strings) for custom string\nprocessing, using
-        the familiar syntax of f-strings.</li>\n<li><a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pep784\">PEP\n784</a>:
-        A new module <code>compression.zstd</code> providing support\nfor the Zstandard
-        compression algorithm.</li>\n<li><a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pep758\">PEP\n758</a>:
-        <code>except</code> and <code>except*</code> expressions may\nnow omit the
-        brackets.</li>\n<li><a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pyrepl-highlighting\">Syntax\nhighlighting
-        in PyREPL</a>, and support for color in <a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-color-unittest\">unittest</a>,\n<a
-        href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-color-argparse\">argparse</a>,\n<a
-        href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-color-json\">json</a>\nand
-        <a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-color-calendar\">calendar</a>\nCLIs.</li>\n<li><a
-        href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pep768\">PEP\n768</a>:
-        A zero-overhead external debugger interface for CPython.</li>\n<li><a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#uuid\">UUID\nversions
-        6-8</a> are now supported by the <code>uuid</code> module, and\ngeneration
-        of versions 3-5 and 8 are up to 40% faster.</li>\n<li><a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pep765\">PEP\n765</a>:
-        Disallow\n<code>return</code>/<code>break</code>/<code>continue</code> that
-        exit a\n<code>finally</code> block.</li>\n<li><a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pep741\">PEP\n741</a>:
-        An improved C API for configuring Python.</li>\n<li>A <a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-tail-call\">new\ntype
-        of interpreter</a>. For certain newer compilers, this interpreter\nprovides
-        significantly better performance. Opt-in for now, requires\nbuilding from
-        source.</li>\n<li><a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#improved-error-messages\">Improved\nerror
-        messages.</a></li>\n<li><a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#hmac\">Builtin\nimplementation
-        of HMAC</a> with formally verified code from the HACL*\nproject.</li>\n<li>A
-        <a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#asyncio-introspection-capabilities\">new\ncommand-line
-        interface</a> to inspect running Python processes using\nasynchronous tasks.</li>\n<li>The
-        pdb module now supports <a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#remote-attaching-to-a-running-python-process-with-pdb\">remote\nattaching
-        to a running Python process</a>.</li>\n</ul>\n<p><small>(Hey, <strong>fellow
-        core developer,</strong> if a feature you\nfind important is missing from
-        this list, let Hugo know.)</small></p>\n<p>For more details on the changes
-        to Python 3.14, see <a href=\"https://docs.python.org/3.14/whatsnew/3.14.html\">What&#8217;s
-        new in\nPython 3.14</a>. The next pre-release of Python 3.14 will be 3.14.0b3,\nscheduled
-        for 2025-06-17.</p>\n<h2 id=\"build-changes\">Build changes</h2>\n<ul>\n<li><a
-        href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pep761\">PEP\n761</a>:
-        Python 3.14 and onwards no longer provides PGP signatures for\nrelease artifacts.
-        Instead, Sigstore is recommended for verifiers.</li>\n<li>Official macOS and
-        Windows release binaries include an <a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-jit-compiler\"><em>experimental</em>\nJIT
-        compiler</a>.</li>\n</ul>\n<h2 id=\"incompatible-changes-removals-and-new-deprecations\">Incompatible\nchanges,
-        removals and new deprecations</h2>\n<ul>\n<li><a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#incompatible-changes\">Incompatible\nchanges</a></li>\n<li>Python
-        <a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#removed\">removals</a>\nand
-        <a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#deprecated\">deprecations</a></li>\n<li>C
-        API <a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#c-api-removed\">removals</a>\nand
-        <a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#c-api-deprecated\">deprecations</a></li>\n<li>Overview
-        of all <a href=\"https://docs.python.org/3.14/deprecations/index.html\">pending\ndeprecations</a></li>\n</ul>\n<h1
-        id=\"python-install-manager\">Python install manager</h1>\n<p>The installer
-        we offer for Windows is being replaced by our new\ninstall manager, which
-        can be installed from <a href=\"https://apps.microsoft.com/detail/9NQ7512CXL7T\">the
-        Windows\nStore</a> or <a href=\"https://www.python.org/ftp/python/pymanager/\">our\nFTP
-        page</a>. See <a href=\"https://docs.python.org/3.14/using/windows.html\">our\ndocumentation</a>
-        for more information. The JSON file available for\ndownload below contains
-        the list of all the installable packages\navailable as part of this release,
-        including file URLs and hashes, but\nis not required to install the latest
-        release. The traditional installer\nwill remain available throughout the 3.14
-        and 3.15 releases.</p>\n<h1 id=\"more-resources\">More resources</h1>\n<ul>\n<li><a
-        href=\"https://docs.python.org/3.14/\">Online\ndocumentation</a></li>\n<li><a
-        href=\"https://peps.python.org/pep-0745/\">PEP 745</a>, 3.14\nRelease Schedule</li>\n<li>Report
-        bugs at <a href=\"https://github.com/python/cpython/issues\">github.com/python/cpython/issues</a></li>\n<li><a
-        href=\"https://www.python.org/psf/donations/\">Help fund Python and\nits community</a></li>\n</ul>\n<h1
-        id=\"and-now-for-something-completely-different\">And now for\nsomething completely
-        different</h1>\n<p>In 1897, the State of Indiana almost passed a bill defining\n<em>\u03C0</em>
-        as 3.2.</p>\n<p>Of course, it&#8217;s not that simple.</p>\n<p>Edwin J. Goodwin,
-        M.D., claimed to have come up with a solution to an\nancient geometrical problem
-        called squaring the circle, first proposed\nin Greek mathematics. It involves
-        trying to draw a circle and a square\nwith the same area, using only a compass
-        and a straight edge. It turns\nout to be impossible because <em>\u03C0</em>
-        is transcendental (and this had\nbeen proved just 13 years earlier by Ferdinand
-        von Lindemann), but\nGoodwin fudged things so the value of <em>\u03C0</em>
-        was 3.2 (his writings\nhave included at least nine different values of <em>\u03C0</em>:
-        including 4,\n3.236, 3.232, 3.2325&#8230; and even 9.2376&#8230;).</p>\n<p>Goodwin
-        had copyrighted his proof and offered it to the State of\nIndiana to use in
-        their educational textbooks without paying royalties,\nprovided they endorsed
-        it. And so Indiana Bill No.&#160;246 was introduced to\nthe House on 18th
-        January 1897. It was not understood and initially\nreferred to the House Committee
-        on Canals, also called the Committee on\nSwamp Lands. They then referred it
-        to the Committee on Education, who\nduly recommended on 2nd February that
-        &#8220;said bill do pass&#8221;. It passed its\nsecond reading on the 5th
-        and the education chair moved that they\nsuspend the constitutional rule that
-        required bills to be read on three\nseparate days. This passed 72-0, and the
-        bill itself passed 67-0.</p>\n<p>The bill was referred to the Senate on 10th
-        February, had its first\nreading on the 11th, and was referred to the Committee
-        on Temperance,\nwhose chair on the 12th recommended &#8220;that said bill
-        do pass&#8221;.</p>\n<p>A mathematics professor, <a href=\"https://www.biodiversitylibrary.org/page/14641808#page/455/mode/1up\">Clarence\nAbiathar
-        Waldo</a>, happened to be in the State Capitol on the day the\nHouse passed
-        the bill and walked in during the debate to hear an\nex-teacher argue:</p>\n<blockquote>\n<p>The
-        case is perfectly simple. If we pass this bill which establishes\na new and
-        correct value for pi , the author offers to our state without\ncost the use
-        of his discovery and its free publication in our school\ntext books, while
-        everyone else must pay him a royalty.</p>\n</blockquote>\n<p>Waldo ensured
-        the senators were &#8220;properly coached&#8221;; and on the 12th,\nduring
-        the second reading, after an unsuccessful attempt to amend the\nbill it was
-        postponed indefinitely. But not before the senators had some\nfun.</p>\n<p>The
-        Indiana News reported on the 13th:</p>\n<blockquote>\n<p>&#8230;the bill was
-        brought up and made fun of. The Senators made bad puns\nabout it, ridiculed
-        it and laughed over it. The fun lasted half an hour.\nSenator Hubbell said
-        that it was not meet for the Senate, which was\ncosting the State $250 a day,
-        to waste its time in such frivolity. He\nsaid that in reading the leading
-        newspapers of Chicago and the East, he\nfound that the Indiana State Legislature
-        had laid itself open to\nridicule by the action already taken on the bill.
-        He thought\nconsideration of such a proposition was not dignified or worthy
-        of the\nSenate. He moved the indefinite postponement of the bill, and the
-        motion\ncarried.</p>\n</blockquote>\n<h1 id=\"enjoy-the-new-release\">Enjoy
-        the new release</h1>\n<p>Thanks to all of the many volunteers who help make
-        Python Development\nand these releases possible! Please consider supporting
-        our efforts by\nvolunteering yourself or through organisation contributions
-        to the <a href=\"https://www.python.org/psf-landing/\">Python Software\nFoundation</a>.</p>\n<p>Regards
-        from Helsinki, still light at 10pm,</p>\n<p>Your release team, <br>Hugo van
-        Kemenade<br>Ned Deily<br>Steve Dower<br>\u0141ukasz Langa</p>\n<div style='clear:
-        both;'></div>\n</div>\n<div class='post-footer'>\n<div class='post-footer-line
-        post-footer-line-1'><span class='post-author vcard'>\nPosted by\n<span class='fn'>Hugo</span>\n</span>\n<span
-        class='post-timestamp'>\nat\n<a class='timestamp-link' href='https://pythoninsider.blogspot.com/2025/05/python-3140-beta-2-is-here.html'
-        rel='bookmark' title='permanent link'><abbr class='published' title='2025-05-26T15:35:00-04:00'>3:35&#8239;PM</abbr></a>\n</span>\n<span
-        class='post-comment-link'>\n</span>\n<span class='post-icons'>\n</span>\n<div
-        class='post-share-buttons'>\n<a class='goog-inline-block share-button sb-email'
-        href='https://www.blogger.com/share-post.g?blogID=3941553907430899163&postID=8971055125507701901&target=email'
-        target='_blank' title='Email This'><span class='share-button-link-text'>Email
-        This</span></a><a class='goog-inline-block share-button sb-blog' href='https://www.blogger.com/share-post.g?blogID=3941553907430899163&postID=8971055125507701901&target=blog'
-        onclick='window.open(this.href, \"_blank\", \"height=270,width=475\"); return
-        false;' target='_blank' title='BlogThis!'><span class='share-button-link-text'>BlogThis!</span></a><a
-        class='goog-inline-block share-button sb-twitter' href='https://www.blogger.com/share-post.g?blogID=3941553907430899163&postID=8971055125507701901&target=twitter'
-        target='_blank' title='Share to X'><span class='share-button-link-text'>Share
-        to X</span></a><a class='goog-inline-block share-button sb-facebook' href='https://www.blogger.com/share-post.g?blogID=3941553907430899163&postID=8971055125507701901&target=facebook'
-        onclick='window.open(this.href, \"_blank\", \"height=430,width=640\"); return
-        false;' target='_blank' title='Share to Facebook'><span class='share-button-link-text'>Share
-        to Facebook</span></a><a class='goog-inline-block share-button sb-pinterest'
-        href='https://www.blogger.com/share-post.g?blogID=3941553907430899163&postID=8971055125507701901&target=pinterest'
-        target='_blank' title='Share to Pinterest'><span class='share-button-link-text'>Share
-        to Pinterest</span></a>\n</div>\n</div>\n<div class='post-footer-line post-footer-line-2'><span
-        class='post-labels'>\nLabels:\n<a href='https://pythoninsider.blogspot.com/search/label/releases'
-        rel='tag'>releases</a>\n</span>\n</div>\n<div class='post-footer-line post-footer-line-3'><span
-        class='post-location'>\n</span>\n</div>\n</div>\n</div>\n</div>\n\n          </div></div>\n
-        \       \n\n          <div class=\"date-outer\">\n        \n<h2 class='date-header'><span>Wednesday,
-        May 7, 2025</span></h2>\n\n          <div class=\"date-posts\">\n        \n<div
-        class='post-outer'>\n<div class='post hentry'>\n<a name='7865809690778671094'></a>\n<h3
-        class='post-title entry-title'>\n<a href='https://pythoninsider.blogspot.com/2025/05/python-3140-beta-1-is-here.html'>Python
-        3.14.0 beta 1 is here!</a>\n</h3>\n<div class='post-header'>\n<div class='post-header-line-1'></div>\n</div>\n<div
-        class='post-body entry-content'>\n<p>Only one day late, welcome to the first
-        beta!</p>\n<p><a class=\"uri\" href=\"https://www.python.org/downloads/release/python-3140b1/\">https://www.python.org/downloads/release/python-3140b1/</a></p>\n<p><strong>This
-        is a beta preview of Python 3.14</strong></p>\n<p>Python 3.14 is still in
-        development. This release, 3.14.0b1, is the\nfirst of four planned beta releases.</p>\n<p>Beta
-        release previews are intended to give the wider community the\nopportunity
-        to test new features and bug fixes and to prepare their\nprojects to support
-        the new feature release.</p>\n<p>We <strong><em>strongly encourage</em></strong>
-        maintainers of\nthird-party Python projects to <strong><em>test with 3.14</em></strong>\nduring
-        the beta phase and report issues found to <a href=\"https://github.com/python/cpython/issues\">the
-        Python bug\ntracker</a> as soon as possible. While the release is planned
-        to be\nfeature-complete entering the beta phase, it is possible that features\nmay
-        be modified or, in rare cases, deleted up until the start of the\nrelease
-        candidate phase (Tuesday 2025-07-22). Our goal is to have\n<strong><em>no
-        ABI changes</em></strong> after beta 4 and as few code\nchanges as possible
-        after the first release candidate. To achieve that,\nit will be <strong><em>extremely
-        important</em></strong> to get as much\nexposure for 3.14 as possible during
-        the beta phase.</p>\n<p>Please keep in mind that this is a preview release
-        and its use is\n<strong><em>not</em></strong> recommended for production\nenvironments.</p>\n<h1
-        id=\"major-new-features-of-the-3.14-series-compared-to-3.13\">Major\nnew features
-        of the 3.14 series, compared to 3.13</h1>\n<p>Some of the major new features
-        and changes in Python 3.14 are:</p>\n<h2 id=\"new-features\">New features</h2>\n<ul>\n<li><a
-        href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pep649\">PEP\n649</a>:
-        The evaluation of type annotations is now deferred, improving\nthe semantics
-        of using annotations.</li>\n<li><a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pep750\">PEP\n750</a>:
-        Template string literals (t-strings) for custom string\nprocessing, using
-        the familiar syntax of f-strings.</li>\n<li><a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pep784\">PEP\n784</a>:
-        A new module <code>compression.zstd</code> providing support\nfor the Zstandard
-        compression algorithm.</li>\n<li><a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pep758\">PEP\n758</a>:
-        <code>except</code> and <code>except*</code> expressions may\nnow omit the
-        brackets.</li>\n<li><a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pyrepl-highlighting\">Syntax\nhighlighting
-        in PyREPL</a>, and support for color in <a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-color-unittest\">unittest</a>,\n<a
-        href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-color-argparse\">argparse</a>,\n<a
-        href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-color-json\">json</a>\nand
-        <a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-color-calendar\">calendar</a>\nCLIs.</li>\n<li><a
-        href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pep768\">PEP\n768</a>:
-        A zero-overhead external debugger interface for CPython.</li>\n<li><a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#uuid\">UUID\nversions
-        6-8</a> are now supported by the <code>uuid</code> module, and\ngeneration
-        of versions 3-5 and 8 are up to 40% faster.</li>\n<li><a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pep765\">PEP\n765</a>:
-        Disallow\n<code>return</code>/<code>break</code>/<code>continue</code> that
-        exit a\n<code>finally</code> block.</li>\n<li><a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pep741\">PEP\n741</a>:
-        An improved C API for configuring Python.</li>\n<li>A <a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-tail-call\">new\ntype
-        of interpreter</a>. For certain newer compilers, this interpreter\nprovides
-        significantly better performance. Opt-in for now, requires\nbuilding from
-        source.</li>\n<li><a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#improved-error-messages\">Improved\nerror
-        messages.</a></li>\n<li>Builtin implementation of HMAC with formally verified
-        code from the\nHACL* project.</li>\n</ul>\n<p><small>(Hey, <strong>fellow
-        core developer,</strong> if a feature you\nfind important is missing from
-        this list, let Hugo know.)</small></p>\n<p>For more details on the changes
-        to Python 3.14, see <a href=\"https://docs.python.org/3.14/whatsnew/3.14.html\">What&#8217;s
-        new in\nPython 3.14</a>. The next pre-release of Python 3.14 will be 3.14.0b2,\nscheduled
-        for 2025-05-27.</p>\n<h2 id=\"build-changes\">Build changes</h2>\n<ul>\n<li><a
-        href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pep761\">PEP\n761</a>:
-        Python 3.14 and onwards no longer provides PGP signatures for\nrelease artifacts.
-        Instead, Sigstore is recommended for verifiers.</li>\n<li>Official macOS and
-        Windows release binaries include an <a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-jit-compiler\"><em>experimental</em>\nJIT
-        compiler</a>.</li>\n</ul>\n<h2 id=\"incompatible-changes-removals-and-new-deprecations\">Incompatible\nchanges,
-        removals and new deprecations</h2>\n<ul>\n<li><a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#incompatible-changes\">Incompatible\nchanges</a></li>\n<li>Python
-        <a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#removed\">removals</a>\nand
-        <a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#deprecated\">deprecations</a></li>\n<li>C
-        API <a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#c-api-removed\">removals</a>\nand
-        <a href=\"https://docs.python.org/3.14/whatsnew/3.14.html#c-api-deprecated\">deprecations</a></li>\n<li>Overview
-        of all <a href=\"https://docs.python.org/3.14/deprecations/index.html\">pending\ndeprecations</a></li>\n</ul>\n<h1
-        id=\"python-install-manager\">Python install manager</h1>\n<p>The installer
-        we offer for Windows is being replaced by our new\ninstall manager, which
-        can be installed from <a href=\"https://apps.microsoft.com/detail/9NQ7512CXL7T\">the
-        Windows\nStore</a> or <a href=\"https://www.python.org/ftp/python/pymanager/\">our\nFTP
-        page</a>. See <a href=\"https://docs.python.org/3.14/using/windows.html\">our\ndocumentation</a>
-        for more information. The <a href=\"https://www.python.org/ftp/python/3.14.0/windows-3.14.0b1.json\">JSON
-        file available for\n  download</a>  contains the list of all the installable
-        packages\navailable as part of this release, including file URLs and hashes,
-        but\nis not required to install the latest release. The traditional installer\nwill
-        remain available throughout the 3.14 and 3.15 releases.</p>\n<h1 id=\"more-resources\">More
-        resources</h1>\n<ul>\n<li><a href=\"https://docs.python.org/3.14/\">Online\ndocumentation</a></li>\n<li><a
-        href=\"https://peps.python.org/pep-0745/\">PEP 745</a>, 3.14\nRelease Schedule</li>\n<li>Report
-        bugs at <a href=\"https://github.com/python/cpython/issues\">github.com/python/cpython/issues</a></li>\n<li><a
-        href=\"https://www.python.org/psf/donations/\">Help fund Python and\nits community</a></li>\n</ul>\n<h1
-        id=\"note\">Note</h1>\n<p>During the release process, we discovered a test
-        that only failed\nwhen run sequentially and only when run after a certain
-        number of other\ntests. This appears to be a problem with the test itself,
-        and we will\nmake it more robust for beta 2. For details, see <a href=\"https://github.com/python/cpython/issues/133532\">python/cpython#133532</a>.</p>\n<h1
-        id=\"and-now-for-something-completely-different\">And now for\nsomething completely
-        different</h1>\n<p>The mathematical constant pi is represented by the Greek
-        letter\n<em>\u03C0</em> and represents the ratio of a circle&#8217;s circumference
-        to its\ndiameter. The first person to use <em>\u03C0</em> as a symbol for
-        this ratio\nwas Welsh self-taught mathematician William Jones in 1706. He
-        was a\nfarmer&#8217;s son born in Llanfihangel Tre&#8217;r Beirdd on Angelsy
-        (Ynys M\xF4n) in\n1675 and only received a basic education at a local charity
-        school.\nHowever, the owner of his parents&#8217; farm noticed his mathematical
-        ability\nand arranged for him to move to London to work in a bank.</p>\n<p>By
-        age 20, he served at sea in the Royal Navy, teaching sailors\nmathematics
-        and helping with the ship&#8217;s navigation. On return to London\nseven years
-        later, he became a maths teacher in coffee houses and a\nprivate tutor. In
-        1706, Jones published <em>Synopsis Palmariorum\nMatheseos</em> which used
-        the symbol <em>\u03C0</em> for the ratio of a\ncircle&#8217;s circumference
-        to diameter (hunt for it on pages <a href=\"https://archive.org/details/SynopsisPalmariorumMatheseosOrANewIntroductionToTheMathematics/page/n261/mode/1up?view=theater\">243</a>\nand
-        <a href=\"https://archive.org/details/SynopsisPalmariorumMatheseosOrANewIntroductionToTheMathematics/page/n283/mode/1up?view=theater\">263</a>\nor
-        <a href=\"https://commons.wikimedia.org/wiki/File:Synopsis_Palmariorum_Matheseos_pi.jpg\">here</a>).\nJones
-        was also the first person to realise <em>\u03C0</em> is an irrational\nnumber,
-        meaning it can be written as decimal number that goes on\nforever, but cannot
-        be written as a fraction of two integers.</p>\n<p>But why <em>\u03C0</em>?
-        It&#8217;s thought Jones used the Greek letter\n<em>\u03C0</em> because it&#8217;s
-        the first letter in <em>perimetron</em> or\nperimeter. Jones was the first
-        to use <em>\u03C0</em> as our familiar ratio\nbut wasn&#8217;t the first to
-        use it in as part of the ratio. William\nOughtred, in his 1631 <em>Clavis
-        Mathematicae</em> (<em>The Key of\nMathematics</em>), used <em>\u03C0/\u03B4</em>
-        to represent what we now call pi.\nHis <em>\u03C0</em> was the circumference,
-        not the ratio of circumference to\ndiameter. James Gregory, in his 1668 <em>Geometriae
-        Pars\nUniversalis</em> (<em>The Universal Part of Geometry</em>) used\n<em>\u03C0/\u03C1</em>
-        instead, where <em>\u03C1</em> is the radius, making the ratio\n6.28&#8230;
-        or <a href=\"https://www.tauday.com/\"><em>\u03C4</em></a>. After Jones,\nLeonhard
-        Euler had used <em>\u03C0</em> for 6.28&#8230;, and also <em>p</em> for\n3.14&#8230;,
-        before settling on and popularising <em>\u03C0</em> for the famous\nratio.</p>\n<h1
-        id=\"enjoy-the-new-release\">Enjoy the new release</h1>\n<p>Thanks to all
-        of the many volunteers who help make Python Development\nand these releases
-        possible! Please consider supporting our efforts by\nvolunteering yourself
-        or through organisation contributions to the <a href=\"https://www.python.org/psf-landing/\">Python
-        Software\nFoundation</a>.</p>\n<p>Regards from Helsinki as the leaves begin
-        to appear on the trees,</p>\n<p>Your release team, <br>\n  <br>\nHugo van
-        Kemenade\n<br>\nNed Deily\n<br>\nSteve Dower\n<br>\n\u0141ukasz Langa</p>\n\n<div
-        style='clear: both;'></div>\n</div>\n<div class='post-footer'>\n<div class='post-footer-line
-        post-footer-line-1'><span class='post-author vcard'>\nPosted by\n<span class='fn'>Hugo</span>\n</span>\n<span
-        class='post-timestamp'>\nat\n<a class='timestamp-link' href='https://pythoninsider.blogspot.com/2025/05/python-3140-beta-1-is-here.html'
-        rel='bookmark' title='permanent link'><abbr class='published' title='2025-05-07T13:34:00-04:00'>1:34&#8239;PM</abbr></a>\n</span>\n<span
-        class='post-comment-link'>\n</span>\n<span class='post-icons'>\n</span>\n<div
-        class='post-share-buttons'>\n<a class='goog-inline-block share-button sb-email'
-        href='https://www.blogger.com/share-post.g?blogID=3941553907430899163&postID=7865809690778671094&target=email'
-        target='_blank' title='Email This'><span class='share-button-link-text'>Email
-        This</span></a><a class='goog-inline-block share-button sb-blog' href='https://www.blogger.com/share-post.g?blogID=3941553907430899163&postID=7865809690778671094&target=blog'
-        onclick='window.open(this.href, \"_blank\", \"height=270,width=475\"); return
-        false;' target='_blank' title='BlogThis!'><span class='share-button-link-text'>BlogThis!</span></a><a
-        class='goog-inline-block share-button sb-twitter' href='https://www.blogger.com/share-post.g?blogID=3941553907430899163&postID=7865809690778671094&target=twitter'
-        target='_blank' title='Share to X'><span class='share-button-link-text'>Share
-        to X</span></a><a class='goog-inline-block share-button sb-facebook' href='https://www.blogger.com/share-post.g?blogID=3941553907430899163&postID=7865809690778671094&target=facebook'
-        onclick='window.open(this.href, \"_blank\", \"height=430,width=640\"); return
-        false;' target='_blank' title='Share to Facebook'><span class='share-button-link-text'>Share
-        to Facebook</span></a><a class='goog-inline-block share-button sb-pinterest'
-        href='https://www.blogger.com/share-post.g?blogID=3941553907430899163&postID=7865809690778671094&target=pinterest'
-        target='_blank' title='Share to Pinterest'><span class='share-button-link-text'>Share
-        to Pinterest</span></a>\n</div>\n</div>\n<div class='post-footer-line post-footer-line-2'><span
-        class='post-labels'>\nLabels:\n<a href='https://pythoninsider.blogspot.com/search/label/releases'
-        rel='tag'>releases</a>\n</span>\n</div>\n<div class='post-footer-line post-footer-line-3'><span
-        class='post-location'>\n</span>\n</div>\n</div>\n</div>\n</div>\n\n        </div></div>\n
-        \     \n</div>\n<div class='blog-pager' id='blog-pager'>\n<span id='blog-pager-older-link'>\n<a
-        class='blog-pager-older-link' href='https://pythoninsider.blogspot.com/search?updated-max=2025-05-07T13:34:00-04:00&amp;max-results=7'
-        id='Blog1_blog-pager-older-link' title='Older Posts'>Older Posts</a>\n</span>\n<a
-        class='home-link' href='https://pythoninsider.blogspot.com/'>Home</a>\n</div>\n<div
-        class='clear'></div>\n<div class='blog-feeds'>\n<div class='feed-links'>\nSubscribe
-        to:\n<a class='feed-link' href='https://pythoninsider.blogspot.com/feeds/posts/default'
-        target='_blank' type='application/atom+xml'>Posts (Atom)</a>\n</div>\n</div>\n</div></div>\n</section>\n</div>\n<aside
-        id='cside'>\n<div class='wshad' id='sidebar1'>\n<div class='section' id='sidebar-right-1'><div
-        class='widget HTML' data-version='1' id='HTML1'>\n<h2 class='title'>Subscribe</h2>\n<div
-        class='widget-content'>\nSubscribe to Python Insider via <a href=\"https://blog.python.org/feeds/posts/default?alt=rss\">RSS</a>,
-        or <a href=\"http://twitter.com/PythonInsider\">Twitter</a>\n</div>\n<div
-        class='clear'></div>\n</div><div class='widget LinkList' data-version='1'
-        id='LinkList1'>\n<h2>Related Links</h2>\n<div class='widget-content'>\n<ul>\n<li><a
-        href='http://www.python.org/'>python.org</a></li>\n<li><a href='http://mail.python.org/mailman/listinfo/python-dev'>Python-Dev
-        mailing list</a></li>\n<li><a href='http://docs.python.org/devguide/'>Python
-        Developer's Guide</a></li>\n</ul>\n<div class='clear'></div>\n</div>\n</div><div
-        class='widget LinkList' data-version='1' id='LinkList2'>\n<h2>Translations</h2>\n<div
-        class='widget-content'>\n<ul>\n<li><a href='http://blog-cn.python.org/'>Chinese
-        (Simplified)</a></li>\n<li><a href='http://blog-tw.python.org/'>Chinese (Traditional)</a></li>\n<li><a
-        href='http://blog-fr.python.org/'>French</a></li>\n<li><a href='http://blog-de.python.org/'>German</a></li>\n<li><a
-        href='http://blog-ja.python.org/'>Japanese</a></li>\n<li><a href='http://blog-ko.python.org/'>Korean</a></li>\n<li><a
-        href='http://blog-pt.python.org/'>Portuguese</a></li>\n<li><a href='http://blog-ro.python.org/'>Romanian</a></li>\n<li><a
-        href='http://blog-ru.python.org/'>Russian</a></li>\n<li><a href='http://blog-es.python.org/'>Spanish</a></li>\n</ul>\n<div
-        class='clear'></div>\n</div>\n</div><div class='widget BlogList' data-version='1'
-        id='BlogList1'>\n<h2 class='title'>Python-Dev Blogs</h2>\n<div class='widget-content'>\n<div
-        class='blog-list-container' id='BlogList1_container'>\n<ul id='BlogList1_blogs'>\n<li
-        style='display: block;'>\n<div class='blog-icon'>\n</div>\n<div class='blog-content'>\n<div
-        class='blog-title'>\n<a href='https://eli.thegreenplace.net/' target='_blank'>\nEli
-        Bendersky</a>\n</div>\n<div class='item-content'>\n<span class='item-title'>\n<a
-        href='https://eli.thegreenplace.net/2025/notes-on-even-and-odd-functions/'
-        target='_blank'>\nNotes on even and odd functions\n</a>\n</span>\n<div class='item-time'>\n3
-        weeks ago\n</div>\n</div>\n</div>\n<div style='clear: both;'></div>\n</li>\n<li
-        style='display: block;'>\n<div class='blog-icon'>\n</div>\n<div class='blog-content'>\n<div
-        class='blog-title'>\n<a href='http://morepypy.blogspot.com/' target='_blank'>\nPyPy
-        Status Blog</a>\n</div>\n<div class='item-content'>\n<span class='item-title'>\n<a
-        href='http://morepypy.blogspot.com/2019/12/hpy-kick-off-sprint-report.html'
-        target='_blank'>\nHPy kick-off sprint report\n</a>\n</span>\n<div class='item-time'>\n5
-        years ago\n</div>\n</div>\n</div>\n<div style='clear: both;'></div>\n</li>\n<li
-        style='display: block;'>\n<div class='blog-icon'>\n</div>\n<div class='blog-content'>\n<div
-        class='blog-title'>\n<a href='http://www.wefearchange.org/' target='_blank'>\nPumpichank</a>\n</div>\n<div
-        class='item-content'>\n<span class='item-title'>\n<a href='http://www.wefearchange.org/2015/04/creating-python-snaps.html'
-        target='_blank'>\nCreating Python Snaps\n</a>\n</span>\n<div class='item-time'>\n10
-        years ago\n</div>\n</div>\n</div>\n<div style='clear: both;'></div>\n</li>\n<li
-        style='display: block;'>\n<div class='blog-icon'>\n</div>\n<div class='blog-content'>\n<div
-        class='blog-title'>\n<a href='http://ramblings.timgolden.me.uk' target='_blank'>\nTim
-        Golden</a>\n</div>\n<div class='item-content'>\n<span class='item-title'>\n<a
-        href='http://ramblings.timgolden.me.uk/2014/12/05/london-python-dojo-december-2014/'
-        target='_blank'>\nLondon Python Dojo December 2014\n</a>\n</span>\n<div class='item-time'>\n10
-        years ago\n</div>\n</div>\n</div>\n<div style='clear: both;'></div>\n</li>\n<li
-        style='display: block;'>\n<div class='blog-icon'>\n</div>\n<div class='blog-content'>\n<div
-        class='blog-title'>\n<a href='http://www.bitdance.com/blog' target='_blank'>\nR.
-        David Murray</a>\n</div>\n<div class='item-content'>\n<span class='item-title'>\n<a
-        href='http://www.bitdance.com/blog/2014/09/30_01_asycio_overview' target='_blank'>\nAsyncio
-        Implementation Overview\n</a>\n</span>\n<div class='item-time'>\n10 years
-        ago\n</div>\n</div>\n</div>\n<div style='clear: both;'></div>\n</li>\n<li
-        style='display: block;'>\n<div class='blog-icon'>\n</div>\n<div class='blog-content'>\n<div
-        class='blog-title'>\n<a href='http://www.voidspace.org.uk/python/weblog/index.shtml'
-        target='_blank'>\nThe Voidspace Techie Blog</a>\n</div>\n<div class='item-content'>\n<span
-        class='item-title'>\n<a href='http://www.voidspace.org.uk/python/weblog/arch_d7_2012_03_24.shtml#e1237'
-        target='_blank'>\nunittest.mock and mock 1.0 alpha 1\n</a>\n</span>\n<div
-        class='item-time'>\n13 years ago\n</div>\n</div>\n</div>\n<div style='clear:
-        both;'></div>\n</li>\n<li style='display: block;'>\n<div class='blog-icon'>\n</div>\n<div
-        class='blog-content'>\n<div class='blog-title'>\n<a href='https://tarekziade.wordpress.com'
-        target='_blank'>\nTarek Ziad\xE9</a>\n</div>\n<div class='item-content'>\n<span
-        class='item-title'>\n<a href='https://tarekziade.wordpress.com/2012/02/29/more-privacy-please/'
-        target='_blank'>\nMore privacy please\n</a>\n</span>\n<div class='item-time'>\n13
-        years ago\n</div>\n</div>\n</div>\n<div style='clear: both;'></div>\n</li>\n<li
-        style='display: block;'>\n<div class='blog-icon'>\n</div>\n<div class='blog-content'>\n<div
-        class='blog-title'>\n<a href='https://rhettinger.wordpress.com' target='_blank'>\nDeep
-        Thoughts by Raymond Hettinger</a>\n</div>\n<div class='item-content'>\n<span
-        class='item-title'>\n<a href='https://rhettinger.wordpress.com/2011/05/26/super-considered-super/'
-        target='_blank'>\nPython&#8217;s super() considered super!\n</a>\n</span>\n<div
-        class='item-time'>\n14 years ago\n</div>\n</div>\n</div>\n<div style='clear:
-        both;'></div>\n</li>\n<li style='display: block;'>\n<div class='blog-icon'>\n</div>\n<div
-        class='blog-content'>\n<div class='blog-title'>\n<a href='http://jessenoller.com/feed/'
-        target='_blank'>\nJesse Noller</a>\n</div>\n<div class='item-content'>\n<span
-        class='item-title'>\n<!--Can't find substitution for tag [item.itemTitle]-->\n</span>\n<div
-        class='item-time'>\n<!--Can't find substitution for tag [item.timePeriodSinceLastUpdate]-->\n</div>\n</div>\n</div>\n<div
-        style='clear: both;'></div>\n</li>\n<li style='display: block;'>\n<div class='blog-icon'>\n</div>\n<div
-        class='blog-content'>\n<div class='blog-title'>\n<a href='http://www.uthcode.com/blog/feeds/atom.xml'
-        target='_blank'>\nSenthil Kumaran</a>\n</div>\n<div class='item-content'>\n<span
-        class='item-title'>\n<!--Can't find substitution for tag [item.itemTitle]-->\n</span>\n<div
-        class='item-time'>\n<!--Can't find substitution for tag [item.timePeriodSinceLastUpdate]-->\n</div>\n</div>\n</div>\n<div
-        style='clear: both;'></div>\n</li>\n<li style='display: block;'>\n<div class='blog-icon'>\n</div>\n<div
-        class='blog-content'>\n<div class='blog-title'>\n<a href='http://feeds.feedburner.com/CoderWhoSaysPy'
-        target='_blank'>\nBrett Cannon</a>\n</div>\n<div class='item-content'>\n<span
-        class='item-title'>\n<!--Can't find substitution for tag [item.itemTitle]-->\n</span>\n<div
-        class='item-time'>\n<!--Can't find substitution for tag [item.timePeriodSinceLastUpdate]-->\n</div>\n</div>\n</div>\n<div
-        style='clear: both;'></div>\n</li>\n<li style='display: block;'>\n<div class='blog-icon'>\n</div>\n<div
-        class='blog-content'>\n<div class='blog-title'>\n<a href='http://www.boredomandlaziness.org/feeds/posts/default'
-        target='_blank'>\nBoredom & Laziness</a>\n</div>\n<div class='item-content'>\n<span
-        class='item-title'>\n<!--Can't find substitution for tag [item.itemTitle]-->\n</span>\n<div
-        class='item-time'>\n<!--Can't find substitution for tag [item.timePeriodSinceLastUpdate]-->\n</div>\n</div>\n</div>\n<div
-        style='clear: both;'></div>\n</li>\n<li style='display: block;'>\n<div class='blog-icon'>\n</div>\n<div
-        class='blog-content'>\n<div class='blog-title'>\n<a href='http://blog.briancurtin.com/feed/'
-        target='_blank'>\nBrian Curtin</a>\n</div>\n<div class='item-content'>\n<span
-        class='item-title'>\n<!--Can't find substitution for tag [item.itemTitle]-->\n</span>\n<div
-        class='item-time'>\n<!--Can't find substitution for tag [item.timePeriodSinceLastUpdate]-->\n</div>\n</div>\n</div>\n<div
-        style='clear: both;'></div>\n</li>\n</ul>\n<div class='clear'></div>\n</div>\n</div>\n</div><div
-        class='widget BlogArchive' data-version='1' id='BlogArchive1'>\n<h2>Blog Archive</h2>\n<div
-        class='widget-content'>\n<div id='ArchiveList'>\n<div id='BlogArchive1_ArchiveList'>\n<ul
-        class='hierarchy'>\n<li class='archivedate expanded'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy toggle-open'>\n\n        &#9660;&#160;\n      \n</span>\n</a>\n<a
-        class='post-count-link' href='https://pythoninsider.blogspot.com/2025/'>\n2025\n</a>\n<span
-        class='post-count' dir='ltr'>(12)</span>\n<ul class='hierarchy'>\n<li class='archivedate
-        expanded'>\n<a class='toggle' href='javascript:void(0)'>\n<span class='zippy
-        toggle-open'>\n\n        &#9660;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2025/07/'>\nJuly\n</a>\n<span class='post-count'
-        dir='ltr'>(2)</span>\n<ul class='posts'>\n<li><a href='https://pythoninsider.blogspot.com/2025/07/python-314-release-candidate-1-is-go.html'>Python
-        3.14 release candidate 1 is go!</a></li>\n<li><a href='https://pythoninsider.blogspot.com/2025/07/python-3140-beta-4-is-here.html'>Python
-        3.14.0 beta 4 is here!</a></li>\n</ul>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2025/06/'>\nJune\n</a>\n<span class='post-count'
-        dir='ltr'>(3)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li class='archivedate
-        collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span class='zippy'>\n\n
-        \       &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link' href='https://pythoninsider.blogspot.com/2025/05/'>\nMay\n</a>\n<span
-        class='post-count' dir='ltr'>(2)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2025/04/'>\nApril\n</a>\n<span class='post-count'
-        dir='ltr'>(1)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li class='archivedate
-        collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span class='zippy'>\n\n
-        \       &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link' href='https://pythoninsider.blogspot.com/2025/03/'>\nMarch\n</a>\n<span
-        class='post-count' dir='ltr'>(1)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2025/02/'>\nFebruary\n</a>\n<span
-        class='post-count' dir='ltr'>(2)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2025/01/'>\nJanuary\n</a>\n<span
-        class='post-count' dir='ltr'>(1)</span>\n</li>\n</ul>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2024/'>\n2024\n</a>\n<span class='post-count'
-        dir='ltr'>(22)</span>\n<ul class='hierarchy'>\n<li class='archivedate collapsed'>\n<a
-        class='toggle' href='javascript:void(0)'>\n<span class='zippy'>\n\n        &#9658;&#160;\n
-        \     \n</span>\n</a>\n<a class='post-count-link' href='https://pythoninsider.blogspot.com/2024/12/'>\nDecember\n</a>\n<span
-        class='post-count' dir='ltr'>(2)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2024/11/'>\nNovember\n</a>\n<span
-        class='post-count' dir='ltr'>(1)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2024/10/'>\nOctober\n</a>\n<span
-        class='post-count' dir='ltr'>(4)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2024/09/'>\nSeptember\n</a>\n<span
-        class='post-count' dir='ltr'>(1)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2024/08/'>\nAugust\n</a>\n<span class='post-count'
-        dir='ltr'>(2)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li class='archivedate
-        collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span class='zippy'>\n\n
-        \       &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link' href='https://pythoninsider.blogspot.com/2024/07/'>\nJuly\n</a>\n<span
-        class='post-count' dir='ltr'>(1)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2024/06/'>\nJune\n</a>\n<span class='post-count'
-        dir='ltr'>(3)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li class='archivedate
-        collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span class='zippy'>\n\n
-        \       &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link' href='https://pythoninsider.blogspot.com/2024/05/'>\nMay\n</a>\n<span
-        class='post-count' dir='ltr'>(1)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2024/04/'>\nApril\n</a>\n<span class='post-count'
-        dir='ltr'>(2)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li class='archivedate
-        collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span class='zippy'>\n\n
-        \       &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link' href='https://pythoninsider.blogspot.com/2024/03/'>\nMarch\n</a>\n<span
-        class='post-count' dir='ltr'>(2)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2024/02/'>\nFebruary\n</a>\n<span
-        class='post-count' dir='ltr'>(2)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2024/01/'>\nJanuary\n</a>\n<span
-        class='post-count' dir='ltr'>(1)</span>\n</li>\n</ul>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2023/'>\n2023\n</a>\n<span class='post-count'
-        dir='ltr'>(18)</span>\n<ul class='hierarchy'>\n<li class='archivedate collapsed'>\n<a
-        class='toggle' href='javascript:void(0)'>\n<span class='zippy'>\n\n        &#9658;&#160;\n
-        \     \n</span>\n</a>\n<a class='post-count-link' href='https://pythoninsider.blogspot.com/2023/12/'>\nDecember\n</a>\n<span
-        class='post-count' dir='ltr'>(2)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2023/11/'>\nNovember\n</a>\n<span
-        class='post-count' dir='ltr'>(1)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2023/10/'>\nOctober\n</a>\n<span
-        class='post-count' dir='ltr'>(3)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2023/09/'>\nSeptember\n</a>\n<span
-        class='post-count' dir='ltr'>(2)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2023/08/'>\nAugust\n</a>\n<span class='post-count'
-        dir='ltr'>(2)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li class='archivedate
-        collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span class='zippy'>\n\n
-        \       &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link' href='https://pythoninsider.blogspot.com/2023/07/'>\nJuly\n</a>\n<span
-        class='post-count' dir='ltr'>(1)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2023/06/'>\nJune\n</a>\n<span class='post-count'
-        dir='ltr'>(2)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li class='archivedate
-        collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span class='zippy'>\n\n
-        \       &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link' href='https://pythoninsider.blogspot.com/2023/05/'>\nMay\n</a>\n<span
-        class='post-count' dir='ltr'>(1)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2023/04/'>\nApril\n</a>\n<span class='post-count'
-        dir='ltr'>(1)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li class='archivedate
-        collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span class='zippy'>\n\n
-        \       &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link' href='https://pythoninsider.blogspot.com/2023/03/'>\nMarch\n</a>\n<span
-        class='post-count' dir='ltr'>(1)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2023/02/'>\nFebruary\n</a>\n<span
-        class='post-count' dir='ltr'>(1)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2023/01/'>\nJanuary\n</a>\n<span
-        class='post-count' dir='ltr'>(1)</span>\n</li>\n</ul>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2022/'>\n2022\n</a>\n<span class='post-count'
-        dir='ltr'>(23)</span>\n<ul class='hierarchy'>\n<li class='archivedate collapsed'>\n<a
-        class='toggle' href='javascript:void(0)'>\n<span class='zippy'>\n\n        &#9658;&#160;\n
-        \     \n</span>\n</a>\n<a class='post-count-link' href='https://pythoninsider.blogspot.com/2022/12/'>\nDecember\n</a>\n<span
-        class='post-count' dir='ltr'>(1)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2022/11/'>\nNovember\n</a>\n<span
-        class='post-count' dir='ltr'>(1)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2022/10/'>\nOctober\n</a>\n<span
-        class='post-count' dir='ltr'>(4)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2022/09/'>\nSeptember\n</a>\n<span
-        class='post-count' dir='ltr'>(2)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2022/08/'>\nAugust\n</a>\n<span class='post-count'
-        dir='ltr'>(2)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li class='archivedate
-        collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span class='zippy'>\n\n
-        \       &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link' href='https://pythoninsider.blogspot.com/2022/07/'>\nJuly\n</a>\n<span
-        class='post-count' dir='ltr'>(2)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2022/06/'>\nJune\n</a>\n<span class='post-count'
-        dir='ltr'>(2)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li class='archivedate
-        collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span class='zippy'>\n\n
-        \       &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link' href='https://pythoninsider.blogspot.com/2022/05/'>\nMay\n</a>\n<span
-        class='post-count' dir='ltr'>(3)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2022/04/'>\nApril\n</a>\n<span class='post-count'
-        dir='ltr'>(1)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li class='archivedate
-        collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span class='zippy'>\n\n
-        \       &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link' href='https://pythoninsider.blogspot.com/2022/03/'>\nMarch\n</a>\n<span
-        class='post-count' dir='ltr'>(3)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2022/02/'>\nFebruary\n</a>\n<span
-        class='post-count' dir='ltr'>(1)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2022/01/'>\nJanuary\n</a>\n<span
-        class='post-count' dir='ltr'>(1)</span>\n</li>\n</ul>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2021/'>\n2021\n</a>\n<span class='post-count'
-        dir='ltr'>(24)</span>\n<ul class='hierarchy'>\n<li class='archivedate collapsed'>\n<a
-        class='toggle' href='javascript:void(0)'>\n<span class='zippy'>\n\n        &#9658;&#160;\n
-        \     \n</span>\n</a>\n<a class='post-count-link' href='https://pythoninsider.blogspot.com/2021/12/'>\nDecember\n</a>\n<span
-        class='post-count' dir='ltr'>(2)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2021/11/'>\nNovember\n</a>\n<span
-        class='post-count' dir='ltr'>(2)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2021/10/'>\nOctober\n</a>\n<span
-        class='post-count' dir='ltr'>(2)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2021/09/'>\nSeptember\n</a>\n<span
-        class='post-count' dir='ltr'>(2)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2021/08/'>\nAugust\n</a>\n<span class='post-count'
-        dir='ltr'>(2)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li class='archivedate
-        collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span class='zippy'>\n\n
-        \       &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link' href='https://pythoninsider.blogspot.com/2021/07/'>\nJuly\n</a>\n<span
-        class='post-count' dir='ltr'>(1)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2021/06/'>\nJune\n</a>\n<span class='post-count'
-        dir='ltr'>(3)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li class='archivedate
-        collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span class='zippy'>\n\n
-        \       &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link' href='https://pythoninsider.blogspot.com/2021/05/'>\nMay\n</a>\n<span
-        class='post-count' dir='ltr'>(1)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2021/04/'>\nApril\n</a>\n<span class='post-count'
-        dir='ltr'>(3)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li class='archivedate
-        collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span class='zippy'>\n\n
-        \       &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link' href='https://pythoninsider.blogspot.com/2021/03/'>\nMarch\n</a>\n<span
-        class='post-count' dir='ltr'>(1)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2021/02/'>\nFebruary\n</a>\n<span
-        class='post-count' dir='ltr'>(4)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2021/01/'>\nJanuary\n</a>\n<span
-        class='post-count' dir='ltr'>(1)</span>\n</li>\n</ul>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2020/'>\n2020\n</a>\n<span class='post-count'
-        dir='ltr'>(32)</span>\n<ul class='hierarchy'>\n<li class='archivedate collapsed'>\n<a
-        class='toggle' href='javascript:void(0)'>\n<span class='zippy'>\n\n        &#9658;&#160;\n
-        \     \n</span>\n</a>\n<a class='post-count-link' href='https://pythoninsider.blogspot.com/2020/12/'>\nDecember\n</a>\n<span
-        class='post-count' dir='ltr'>(2)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2020/11/'>\nNovember\n</a>\n<span
-        class='post-count' dir='ltr'>(2)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2020/10/'>\nOctober\n</a>\n<span
-        class='post-count' dir='ltr'>(2)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2020/09/'>\nSeptember\n</a>\n<span
-        class='post-count' dir='ltr'>(3)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2020/08/'>\nAugust\n</a>\n<span class='post-count'
-        dir='ltr'>(3)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li class='archivedate
-        collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span class='zippy'>\n\n
-        \       &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link' href='https://pythoninsider.blogspot.com/2020/07/'>\nJuly\n</a>\n<span
-        class='post-count' dir='ltr'>(4)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2020/06/'>\nJune\n</a>\n<span class='post-count'
-        dir='ltr'>(4)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li class='archivedate
-        collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span class='zippy'>\n\n
-        \       &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link' href='https://pythoninsider.blogspot.com/2020/05/'>\nMay\n</a>\n<span
-        class='post-count' dir='ltr'>(2)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2020/04/'>\nApril\n</a>\n<span class='post-count'
-        dir='ltr'>(4)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li class='archivedate
-        collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span class='zippy'>\n\n
-        \       &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link' href='https://pythoninsider.blogspot.com/2020/03/'>\nMarch\n</a>\n<span
-        class='post-count' dir='ltr'>(3)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2020/02/'>\nFebruary\n</a>\n<span
-        class='post-count' dir='ltr'>(2)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2020/01/'>\nJanuary\n</a>\n<span
-        class='post-count' dir='ltr'>(1)</span>\n</li>\n</ul>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2019/'>\n2019\n</a>\n<span class='post-count'
-        dir='ltr'>(36)</span>\n<ul class='hierarchy'>\n<li class='archivedate collapsed'>\n<a
-        class='toggle' href='javascript:void(0)'>\n<span class='zippy'>\n\n        &#9658;&#160;\n
-        \     \n</span>\n</a>\n<a class='post-count-link' href='https://pythoninsider.blogspot.com/2019/12/'>\nDecember\n</a>\n<span
-        class='post-count' dir='ltr'>(3)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2019/11/'>\nNovember\n</a>\n<span
-        class='post-count' dir='ltr'>(1)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2019/10/'>\nOctober\n</a>\n<span
-        class='post-count' dir='ltr'>(8)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2019/09/'>\nSeptember\n</a>\n<span
-        class='post-count' dir='ltr'>(1)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2019/08/'>\nAugust\n</a>\n<span class='post-count'
-        dir='ltr'>(3)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li class='archivedate
-        collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span class='zippy'>\n\n
-        \       &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link' href='https://pythoninsider.blogspot.com/2019/07/'>\nJuly\n</a>\n<span
-        class='post-count' dir='ltr'>(5)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2019/06/'>\nJune\n</a>\n<span class='post-count'
-        dir='ltr'>(3)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li class='archivedate
-        collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span class='zippy'>\n\n
-        \       &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link' href='https://pythoninsider.blogspot.com/2019/05/'>\nMay\n</a>\n<span
-        class='post-count' dir='ltr'>(2)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2019/03/'>\nMarch\n</a>\n<span class='post-count'
-        dir='ltr'>(7)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li class='archivedate
-        collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span class='zippy'>\n\n
-        \       &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link' href='https://pythoninsider.blogspot.com/2019/02/'>\nFebruary\n</a>\n<span
-        class='post-count' dir='ltr'>(3)</span>\n</li>\n</ul>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2018/'>\n2018\n</a>\n<span class='post-count'
-        dir='ltr'>(24)</span>\n<ul class='hierarchy'>\n<li class='archivedate collapsed'>\n<a
-        class='toggle' href='javascript:void(0)'>\n<span class='zippy'>\n\n        &#9658;&#160;\n
-        \     \n</span>\n</a>\n<a class='post-count-link' href='https://pythoninsider.blogspot.com/2018/12/'>\nDecember\n</a>\n<span
-        class='post-count' dir='ltr'>(2)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2018/10/'>\nOctober\n</a>\n<span
-        class='post-count' dir='ltr'>(2)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2018/09/'>\nSeptember\n</a>\n<span
-        class='post-count' dir='ltr'>(1)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2018/08/'>\nAugust\n</a>\n<span class='post-count'
-        dir='ltr'>(1)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li class='archivedate
-        collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span class='zippy'>\n\n
-        \       &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link' href='https://pythoninsider.blogspot.com/2018/06/'>\nJune\n</a>\n<span
-        class='post-count' dir='ltr'>(2)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2018/05/'>\nMay\n</a>\n<span class='post-count'
-        dir='ltr'>(3)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li class='archivedate
-        collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span class='zippy'>\n\n
-        \       &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link' href='https://pythoninsider.blogspot.com/2018/04/'>\nApril\n</a>\n<span
-        class='post-count' dir='ltr'>(3)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2018/03/'>\nMarch\n</a>\n<span class='post-count'
-        dir='ltr'>(5)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li class='archivedate
-        collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span class='zippy'>\n\n
-        \       &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link' href='https://pythoninsider.blogspot.com/2018/02/'>\nFebruary\n</a>\n<span
-        class='post-count' dir='ltr'>(2)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2018/01/'>\nJanuary\n</a>\n<span
-        class='post-count' dir='ltr'>(3)</span>\n</li>\n</ul>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2017/'>\n2017\n</a>\n<span class='post-count'
-        dir='ltr'>(17)</span>\n<ul class='hierarchy'>\n<li class='archivedate collapsed'>\n<a
-        class='toggle' href='javascript:void(0)'>\n<span class='zippy'>\n\n        &#9658;&#160;\n
-        \     \n</span>\n</a>\n<a class='post-count-link' href='https://pythoninsider.blogspot.com/2017/12/'>\nDecember\n</a>\n<span
-        class='post-count' dir='ltr'>(2)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2017/10/'>\nOctober\n</a>\n<span
-        class='post-count' dir='ltr'>(2)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2017/09/'>\nSeptember\n</a>\n<span
-        class='post-count' dir='ltr'>(3)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2017/08/'>\nAugust\n</a>\n<span class='post-count'
-        dir='ltr'>(2)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li class='archivedate
-        collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span class='zippy'>\n\n
-        \       &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link' href='https://pythoninsider.blogspot.com/2017/07/'>\nJuly\n</a>\n<span
-        class='post-count' dir='ltr'>(3)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2017/06/'>\nJune\n</a>\n<span class='post-count'
-        dir='ltr'>(1)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li class='archivedate
-        collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span class='zippy'>\n\n
-        \       &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link' href='https://pythoninsider.blogspot.com/2017/03/'>\nMarch\n</a>\n<span
-        class='post-count' dir='ltr'>(2)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2017/01/'>\nJanuary\n</a>\n<span
-        class='post-count' dir='ltr'>(2)</span>\n</li>\n</ul>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2016/'>\n2016\n</a>\n<span class='post-count'
-        dir='ltr'>(18)</span>\n<ul class='hierarchy'>\n<li class='archivedate collapsed'>\n<a
-        class='toggle' href='javascript:void(0)'>\n<span class='zippy'>\n\n        &#9658;&#160;\n
-        \     \n</span>\n</a>\n<a class='post-count-link' href='https://pythoninsider.blogspot.com/2016/12/'>\nDecember\n</a>\n<span
-        class='post-count' dir='ltr'>(5)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2016/11/'>\nNovember\n</a>\n<span
-        class='post-count' dir='ltr'>(1)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2016/10/'>\nOctober\n</a>\n<span
-        class='post-count' dir='ltr'>(2)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2016/09/'>\nSeptember\n</a>\n<span
-        class='post-count' dir='ltr'>(2)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2016/08/'>\nAugust\n</a>\n<span class='post-count'
-        dir='ltr'>(1)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li class='archivedate
-        collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span class='zippy'>\n\n
-        \       &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link' href='https://pythoninsider.blogspot.com/2016/07/'>\nJuly\n</a>\n<span
-        class='post-count' dir='ltr'>(1)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2016/06/'>\nJune\n</a>\n<span class='post-count'
-        dir='ltr'>(5)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li class='archivedate
-        collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span class='zippy'>\n\n
-        \       &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link' href='https://pythoninsider.blogspot.com/2016/05/'>\nMay\n</a>\n<span
-        class='post-count' dir='ltr'>(1)</span>\n</li>\n</ul>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2015/'>\n2015\n</a>\n<span class='post-count'
-        dir='ltr'>(14)</span>\n<ul class='hierarchy'>\n<li class='archivedate collapsed'>\n<a
-        class='toggle' href='javascript:void(0)'>\n<span class='zippy'>\n\n        &#9658;&#160;\n
-        \     \n</span>\n</a>\n<a class='post-count-link' href='https://pythoninsider.blogspot.com/2015/12/'>\nDecember\n</a>\n<span
-        class='post-count' dir='ltr'>(2)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2015/11/'>\nNovember\n</a>\n<span
-        class='post-count' dir='ltr'>(1)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2015/09/'>\nSeptember\n</a>\n<span
-        class='post-count' dir='ltr'>(3)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2015/08/'>\nAugust\n</a>\n<span class='post-count'
-        dir='ltr'>(1)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li class='archivedate
-        collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span class='zippy'>\n\n
-        \       &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link' href='https://pythoninsider.blogspot.com/2015/07/'>\nJuly\n</a>\n<span
-        class='post-count' dir='ltr'>(1)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2015/06/'>\nJune\n</a>\n<span class='post-count'
-        dir='ltr'>(1)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li class='archivedate
-        collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span class='zippy'>\n\n
-        \       &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link' href='https://pythoninsider.blogspot.com/2015/05/'>\nMay\n</a>\n<span
-        class='post-count' dir='ltr'>(2)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2015/03/'>\nMarch\n</a>\n<span class='post-count'
-        dir='ltr'>(2)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li class='archivedate
-        collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span class='zippy'>\n\n
-        \       &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link' href='https://pythoninsider.blogspot.com/2015/01/'>\nJanuary\n</a>\n<span
-        class='post-count' dir='ltr'>(1)</span>\n</li>\n</ul>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2014/'>\n2014\n</a>\n<span class='post-count'
-        dir='ltr'>(8)</span>\n<ul class='hierarchy'>\n<li class='archivedate collapsed'>\n<a
-        class='toggle' href='javascript:void(0)'>\n<span class='zippy'>\n\n        &#9658;&#160;\n
-        \     \n</span>\n</a>\n<a class='post-count-link' href='https://pythoninsider.blogspot.com/2014/12/'>\nDecember\n</a>\n<span
-        class='post-count' dir='ltr'>(1)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2014/11/'>\nNovember\n</a>\n<span
-        class='post-count' dir='ltr'>(1)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2014/05/'>\nMay\n</a>\n<span class='post-count'
-        dir='ltr'>(1)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li class='archivedate
-        collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span class='zippy'>\n\n
-        \       &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link' href='https://pythoninsider.blogspot.com/2014/03/'>\nMarch\n</a>\n<span
-        class='post-count' dir='ltr'>(3)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2014/02/'>\nFebruary\n</a>\n<span
-        class='post-count' dir='ltr'>(2)</span>\n</li>\n</ul>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2013/'>\n2013\n</a>\n<span class='post-count'
-        dir='ltr'>(5)</span>\n<ul class='hierarchy'>\n<li class='archivedate collapsed'>\n<a
-        class='toggle' href='javascript:void(0)'>\n<span class='zippy'>\n\n        &#9658;&#160;\n
-        \     \n</span>\n</a>\n<a class='post-count-link' href='https://pythoninsider.blogspot.com/2013/11/'>\nNovember\n</a>\n<span
-        class='post-count' dir='ltr'>(2)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2013/10/'>\nOctober\n</a>\n<span
-        class='post-count' dir='ltr'>(1)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2013/03/'>\nMarch\n</a>\n<span class='post-count'
-        dir='ltr'>(1)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li class='archivedate
-        collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span class='zippy'>\n\n
-        \       &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link' href='https://pythoninsider.blogspot.com/2013/02/'>\nFebruary\n</a>\n<span
-        class='post-count' dir='ltr'>(1)</span>\n</li>\n</ul>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2012/'>\n2012\n</a>\n<span class='post-count'
-        dir='ltr'>(9)</span>\n<ul class='hierarchy'>\n<li class='archivedate collapsed'>\n<a
-        class='toggle' href='javascript:void(0)'>\n<span class='zippy'>\n\n        &#9658;&#160;\n
-        \     \n</span>\n</a>\n<a class='post-count-link' href='https://pythoninsider.blogspot.com/2012/12/'>\nDecember\n</a>\n<span
-        class='post-count' dir='ltr'>(1)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2012/11/'>\nNovember\n</a>\n<span
-        class='post-count' dir='ltr'>(1)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2012/10/'>\nOctober\n</a>\n<span
-        class='post-count' dir='ltr'>(2)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2012/08/'>\nAugust\n</a>\n<span class='post-count'
-        dir='ltr'>(1)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li class='archivedate
-        collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span class='zippy'>\n\n
-        \       &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link' href='https://pythoninsider.blogspot.com/2012/06/'>\nJune\n</a>\n<span
-        class='post-count' dir='ltr'>(2)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2012/05/'>\nMay\n</a>\n<span class='post-count'
-        dir='ltr'>(1)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li class='archivedate
-        collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span class='zippy'>\n\n
-        \       &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link' href='https://pythoninsider.blogspot.com/2012/03/'>\nMarch\n</a>\n<span
-        class='post-count' dir='ltr'>(1)</span>\n</li>\n</ul>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2011/'>\n2011\n</a>\n<span class='post-count'
-        dir='ltr'>(25)</span>\n<ul class='hierarchy'>\n<li class='archivedate collapsed'>\n<a
-        class='toggle' href='javascript:void(0)'>\n<span class='zippy'>\n\n        &#9658;&#160;\n
-        \     \n</span>\n</a>\n<a class='post-count-link' href='https://pythoninsider.blogspot.com/2011/08/'>\nAugust\n</a>\n<span
-        class='post-count' dir='ltr'>(2)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2011/07/'>\nJuly\n</a>\n<span class='post-count'
-        dir='ltr'>(3)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li class='archivedate
-        collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span class='zippy'>\n\n
-        \       &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link' href='https://pythoninsider.blogspot.com/2011/06/'>\nJune\n</a>\n<span
-        class='post-count' dir='ltr'>(1)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2011/05/'>\nMay\n</a>\n<span class='post-count'
-        dir='ltr'>(7)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li class='archivedate
-        collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span class='zippy'>\n\n
-        \       &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link' href='https://pythoninsider.blogspot.com/2011/04/'>\nApril\n</a>\n<span
-        class='post-count' dir='ltr'>(7)</span>\n</li>\n</ul>\n<ul class='hierarchy'>\n<li
-        class='archivedate collapsed'>\n<a class='toggle' href='javascript:void(0)'>\n<span
-        class='zippy'>\n\n        &#9658;&#160;\n      \n</span>\n</a>\n<a class='post-count-link'
-        href='https://pythoninsider.blogspot.com/2011/03/'>\nMarch\n</a>\n<span class='post-count'
-        dir='ltr'>(5)</span>\n</li>\n</ul>\n</li>\n</ul>\n</div>\n</div>\n<div class='clear'></div>\n</div>\n</div><div
-        class='widget Profile' data-version='1' id='Profile1'>\n<h2>Contributors</h2>\n<div
-        class='widget-content'>\n<ul>\n<li><a class='profile-name-link g-profile'
-        href='https://www.blogger.com/profile/14971120963699387108' style='background-image:
-        url(//www.blogger.com/img/logo-16.png);'>A.M. Kuchling</a></li>\n<li><a class='profile-name-link
-        g-profile' href='https://www.blogger.com/profile/02804541126912023065' style='background-image:
-        url(//www.blogger.com/img/logo-16.png);'>Alfonso de la Guarda</a></li>\n<li><a
-        class='profile-name-link g-profile' href='https://www.blogger.com/profile/03855116138400732464'
-        style='background-image: url(//www.blogger.com/img/logo-16.png);'>Anthony
-        Scopatz</a></li>\n<li><a class='profile-name-link g-profile' href='https://www.blogger.com/profile/08838587997498042260'
-        style='background-image: url(//www.blogger.com/img/logo-16.png);'>Antoine
-        P.</a></li>\n<li><a class='profile-name-link g-profile' href='https://www.blogger.com/profile/06955536323236904839'
-        style='background-image: url(//www.blogger.com/img/logo-16.png);'>Benjamin
-        Peterson</a></li>\n<li><a class='profile-name-link g-profile' href='https://www.blogger.com/profile/14604644394514192040'
-        style='background-image: url(//www.blogger.com/img/logo-16.png);'>Brian Curtin</a></li>\n<li><a
-        class='profile-name-link g-profile' href='https://www.blogger.com/profile/14913018830568213369'
-        style='background-image: url(//www.blogger.com/img/logo-16.png);'>Davidmh</a></li>\n<li><a
-        class='profile-name-link g-profile' href='https://www.blogger.com/profile/03794667532189865209'
-        style='background-image: url(//www.blogger.com/img/logo-16.png);'>Donald Stufft</a></li>\n<li><a
-        class='profile-name-link g-profile' href='https://www.blogger.com/profile/01892352754222143463'
-        style='background-image: url(//www.blogger.com/img/logo-16.png);'>Doug Hellmann</a></li>\n<li><a
-        class='profile-name-link g-profile' href='https://www.blogger.com/profile/13577459520968677064'
-        style='background-image: url(//www.blogger.com/img/logo-16.png);'>Ee Durbin</a></li>\n<li><a
-        class='profile-name-link g-profile' href='https://www.blogger.com/profile/06795605825443412201'
-        style='background-image: url(//www.blogger.com/img/logo-16.png);'>Ezio Melotti</a></li>\n<li><a
-        class='profile-name-link g-profile' href='https://www.blogger.com/profile/14973145408214215809'
-        style='background-image: url(//www.blogger.com/img/logo-16.png);'>Georg Brandl</a></li>\n<li><a
-        class='profile-name-link g-profile' href='https://www.blogger.com/profile/02811718172961252565'
-        style='background-image: url(//www.blogger.com/img/logo-16.png);'>Hugo</a></li>\n<li><a
-        class='profile-name-link g-profile' href='https://www.blogger.com/profile/07543015027323408421'
-        style='background-image: url(//www.blogger.com/img/logo-16.png);'>Jesse</a></li>\n<li><a
-        class='profile-name-link g-profile' href='https://www.blogger.com/profile/17574962105063127018'
-        style='background-image: url(//www.blogger.com/img/logo-16.png);'>Kelsey Hightower</a></li>\n<li><a
-        class='profile-name-link g-profile' href='https://www.blogger.com/profile/13232068831778121461'
-        style='background-image: url(//www.blogger.com/img/logo-16.png);'>Larry Hastings</a></li>\n<li><a
-        class='profile-name-link g-profile' href='https://www.blogger.com/profile/07757697862303956313'
-        style='background-image: url(//www.blogger.com/img/logo-16.png);'>Mathieu
-        Leduc-Hamel</a></li>\n<li><a class='profile-name-link g-profile' href='https://www.blogger.com/profile/08761481986934375758'
-        style='background-image: url(//www.blogger.com/img/logo-16.png);'>Michael
-        Markert</a></li>\n<li><a class='profile-name-link g-profile' href='https://www.blogger.com/profile/06351908417200979114'
-        style='background-image: url(//www.blogger.com/img/logo-16.png);'>Mike Driscoll</a></li>\n<li><a
-        class='profile-name-link g-profile' href='https://www.blogger.com/profile/17112379650586333719'
-        style='background-image: url(//www.blogger.com/img/logo-16.png);'>Ned Deily</a></li>\n<li><a
-        class='profile-name-link g-profile' href='https://www.blogger.com/profile/07923137967169776470'
-        style='background-image: url(//www.blogger.com/img/logo-16.png);'>Pablo Galindo</a></li>\n<li><a
-        class='profile-name-link g-profile' href='https://www.blogger.com/profile/17557923197983461835'
-        style='background-image: url(//www.blogger.com/img/logo-16.png);'>Paul Moore</a></li>\n<li><a
-        class='profile-name-link g-profile' href='https://www.blogger.com/profile/17437958274873977298'
-        style='background-image: url(//www.blogger.com/img/logo-16.png);'>Philip Jenvey</a></li>\n<li><a
-        class='profile-name-link g-profile' href='https://www.blogger.com/profile/08002085909817689325'
-        style='background-image: url(//www.blogger.com/img/logo-16.png);'>Sumana Harihareswara</a></li>\n<li><a
-        class='profile-name-link g-profile' href='https://www.blogger.com/profile/10346112333332923135'
-        style='background-image: url(//www.blogger.com/img/logo-16.png);'>Thomas Wouters</a></li>\n<li><a
-        class='profile-name-link g-profile' href='https://www.blogger.com/profile/14824694805745746190'
-        style='background-image: url(//www.blogger.com/img/logo-16.png);'>Unknown</a></li>\n<li><a
-        class='profile-name-link g-profile' href='https://www.blogger.com/profile/12361293458447621754'
-        style='background-image: url(//www.blogger.com/img/logo-16.png);'>Unknown</a></li>\n<li><a
-        class='profile-name-link g-profile' href='https://www.blogger.com/profile/01161413896843370614'
-        style='background-image: url(//www.blogger.com/img/logo-16.png);'>\u0141ukasz
-        Langa</a></li>\n<li><a class='profile-name-link g-profile' href='https://www.blogger.com/profile/10522887977715879728'
-        style='background-image: url(//www.blogger.com/img/logo-16.png);'>\xC9ric
-        Araujo</a></li>\n<li><a class='profile-name-link g-profile' href='https://www.blogger.com/profile/07473216746644389812'
-        style='background-image: url(//www.blogger.com/img/logo-16.png);'>e</a></li>\n<li><a
-        class='profile-name-link g-profile' href='https://www.blogger.com/profile/14658404449913582628'
-        style='background-image: url(//www.blogger.com/img/logo-16.png);'>haypo</a></li>\n<li><a
-        class='profile-name-link g-profile' href='https://www.blogger.com/profile/07627402554307001461'
-        style='background-image: url(//www.blogger.com/img/logo-16.png);'>tp</a></li>\n</ul>\n<div
-        class='clear'></div>\n</div>\n</div><div class='widget HTML' data-version='1'
-        id='HTML3'>\n<h2 class='title'>Copyright</h2>\n<div class='widget-content'>\n<a
-        rel=\"license\" href=\"http://creativecommons.org/licenses/by-nc-sa/3.0/\"><img
-        alt=\"Creative Commons License\" style=\"border-width:0\" src=\"https://lh3.googleusercontent.com/blogger_img_proxy/AEn0k_vNLny9gJ_IQG1Qf4JxKrpmu05hsQ2a9YpNHEhxz5icgnVuJGaLDAXKIV8r2GvIk7_RlCwnA_hN3UkzpssffI9wZ3eCjjwgrXmVrwSgqC4SjC2S_tUe7mTr=s0-d\"></a><br
-        /><span xmlns:dct=\"http://purl.org/dc/terms/\" href=\"http://purl.org/dc/dcmitype/Text\"
-        property=\"dct:title\" rel=\"dct:type\">Python Insider</span> by <a xmlns:cc=\"http://creativecommons.org/ns#\"
-        href=\"http://www.python.org/\" property=\"cc:attributionName\" rel=\"cc:attributionURL\">the
-        Python Core Developers</a> is licensed under a <a rel=\"license\" href=\"http://creativecommons.org/licenses/by-nc-sa/3.0/\">Creative
-        Commons Attribution-NonCommercial-ShareAlike 3.0 Unported License</a>.<br
-        />Based on a work at <a xmlns:dct=\"http://purl.org/dc/terms/\" href=\"http://blog.python.org/\"
-        rel=\"dct:source\">blog.python.org</a>.\n</div>\n<div class='clear'></div>\n</div></div>\n<div
-        id='attribution1'>\n<div class='section' id='attribution'><div class='widget
-        Attribution' data-version='1' id='Attribution1'>\n<div class='widget-content'
-        style='text-align: center;'>\nPowered by <a href='https://www.blogger.com'
-        target='_blank'>Blogger</a>.\n</div>\n<div class='clear'></div>\n</div></div>\n</div>\n</div>\n</aside>\n<div
-        style='clear:both'>&nbsp;</div>\n</div>\n\n<script type=\"text/javascript\"
-        src=\"https://www.blogger.com/static/v1/widgets/3000588928-widgets.js\"></script>\n<script
-        type='text/javascript'>\nwindow['__wavt'] = 'AOuZoY4ly9BmOafHTO2GRrsaLYhZTAbH9A:1753779282144';_WidgetManager._Init('//www.blogger.com/rearrange?blogID\\x3d3941553907430899163','//pythoninsider.blogspot.com/','3941553907430899163');\n_WidgetManager._SetDataContext([{'name':
-        'blog', 'data': {'blogId': '3941553907430899163', 'title': 'Python Insider',
-        'url': 'https://pythoninsider.blogspot.com/', 'canonicalUrl': 'https://pythoninsider.blogspot.com/',
-        'homepageUrl': 'https://pythoninsider.blogspot.com/', 'searchUrl': 'https://pythoninsider.blogspot.com/search',
-        'canonicalHomepageUrl': 'https://pythoninsider.blogspot.com/', 'blogspotFaviconUrl':
-        'https://pythoninsider.blogspot.com/favicon.ico', 'bloggerUrl': 'https://www.blogger.com',
-        'hasCustomDomain': false, 'httpsEnabled': true, 'enabledCommentProfileImages':
-        true, 'gPlusViewType': 'FILTERED_POSTMOD', 'adultContent': false, 'analyticsAccountNumber':
-        '', 'encoding': 'UTF-8', 'locale': 'en', 'localeUnderscoreDelimited': 'en',
-        'languageDirection': 'ltr', 'isPrivate': false, 'isMobile': false, 'isMobileRequest':
-        false, 'mobileClass': '', 'isPrivateBlog': false, 'isDynamicViewsAvailable':
-        false, 'feedLinks': '\\x3clink rel\\x3d\\x22alternate\\x22 type\\x3d\\x22application/atom+xml\\x22
-        title\\x3d\\x22Python Insider - Atom\\x22 href\\x3d\\x22https://pythoninsider.blogspot.com/feeds/posts/default\\x22
-        /\\x3e\\n\\x3clink rel\\x3d\\x22alternate\\x22 type\\x3d\\x22application/rss+xml\\x22
-        title\\x3d\\x22Python Insider - RSS\\x22 href\\x3d\\x22https://pythoninsider.blogspot.com/feeds/posts/default?alt\\x3drss\\x22
-        /\\x3e\\n\\x3clink rel\\x3d\\x22service.post\\x22 type\\x3d\\x22application/atom+xml\\x22
-        title\\x3d\\x22Python Insider - Atom\\x22 href\\x3d\\x22https://www.blogger.com/feeds/3941553907430899163/posts/default\\x22
-        /\\x3e\\n', 'meTag': '', 'adsenseHostId': 'ca-host-pub-1556223355139109',
-        'adsenseHasAds': false, 'adsenseAutoAds': false, 'boqCommentIframeForm': true,
-        'loginRedirectParam': '', 'view': '', 'dynamicViewsCommentsSrc': '//www.blogblog.com/dynamicviews/4224c15c4e7c9321/js/comments.js',
-        'dynamicViewsScriptSrc': '//www.blogblog.com/dynamicviews/aec9a2fc4235c5ac',
-        'plusOneApiSrc': 'https://apis.google.com/js/platform.js', 'disableGComments':
-        true, 'interstitialAccepted': false, 'sharing': {'platforms': [{'name': 'Get
-        link', 'key': 'link', 'shareMessage': 'Get link', 'target': ''}, {'name':
-        'Facebook', 'key': 'facebook', 'shareMessage': 'Share to Facebook', 'target':
-        'facebook'}, {'name': 'BlogThis!', 'key': 'blogThis', 'shareMessage': 'BlogThis!',
-        'target': 'blog'}, {'name': 'X', 'key': 'twitter', 'shareMessage': 'Share
-        to X', 'target': 'twitter'}, {'name': 'Pinterest', 'key': 'pinterest', 'shareMessage':
-        'Share to Pinterest', 'target': 'pinterest'}, {'name': 'Email', 'key': 'email',
-        'shareMessage': 'Email', 'target': 'email'}], 'disableGooglePlus': true, 'googlePlusShareButtonWidth':
-        0, 'googlePlusBootstrap': '\\x3cscript type\\x3d\\x22text/javascript\\x22\\x3ewindow.___gcfg
-        \\x3d {\\x27lang\\x27: \\x27en\\x27};\\x3c/script\\x3e'}, 'hasCustomJumpLinkMessage':
-        false, 'jumpLinkMessage': 'Read more', 'pageType': 'index', 'pageName': '',
-        'pageTitle': 'Python Insider'}}, {'name': 'features', 'data': {}}, {'name':
-        'messages', 'data': {'edit': 'Edit', 'linkCopiedToClipboard': 'Link copied
-        to clipboard!', 'ok': 'Ok', 'postLink': 'Post Link'}}, {'name': 'template',
-        'data': {'name': 'custom', 'localizedName': 'Custom', 'isResponsive': false,
-        'isAlternateRendering': false, 'isCustom': true}}, {'name': 'view', 'data':
-        {'classic': {'name': 'classic', 'url': '?view\\x3dclassic'}, 'flipcard': {'name':
-        'flipcard', 'url': '?view\\x3dflipcard'}, 'magazine': {'name': 'magazine',
-        'url': '?view\\x3dmagazine'}, 'mosaic': {'name': 'mosaic', 'url': '?view\\x3dmosaic'},
-        'sidebar': {'name': 'sidebar', 'url': '?view\\x3dsidebar'}, 'snapshot': {'name':
-        'snapshot', 'url': '?view\\x3dsnapshot'}, 'timeslide': {'name': 'timeslide',
-        'url': '?view\\x3dtimeslide'}, 'isMobile': false, 'title': 'Python Insider',
-        'description': 'Python core development news and information.', 'url': 'https://pythoninsider.blogspot.com/',
-        'type': 'feed', 'isSingleItem': false, 'isMultipleItems': true, 'isError':
-        false, 'isPage': false, 'isPost': false, 'isHomepage': true, 'isArchive':
-        false, 'isLabelSearch': false}}]);\n_WidgetManager._RegisterWidget('_NavbarView',
-        new _WidgetInfo('Navbar1', 'navbar', document.getElementById('Navbar1'), {},
-        'displayModeFull'));\n_WidgetManager._RegisterWidget('_HeaderView', new _WidgetInfo('Header1',
-        'header', document.getElementById('Header1'), {}, 'displayModeFull'));\n_WidgetManager._RegisterWidget('_BlogView',
-        new _WidgetInfo('Blog1', 'main', document.getElementById('Blog1'), {'cmtInteractionsEnabled':
-        false, 'lightboxEnabled': true, 'lightboxModuleUrl': 'https://www.blogger.com/static/v1/jsbin/249874-lbx.js',
-        'lightboxCssUrl': 'https://www.blogger.com/static/v1/v-css/123180807-lightbox_bundle.css'},
-        'displayModeFull'));\n_WidgetManager._RegisterWidget('_HTMLView', new _WidgetInfo('HTML1',
-        'sidebar-right-1', document.getElementById('HTML1'), {}, 'displayModeFull'));\n_WidgetManager._RegisterWidget('_LinkListView',
-        new _WidgetInfo('LinkList1', 'sidebar-right-1', document.getElementById('LinkList1'),
-        {}, 'displayModeFull'));\n_WidgetManager._RegisterWidget('_LinkListView',
-        new _WidgetInfo('LinkList2', 'sidebar-right-1', document.getElementById('LinkList2'),
-        {}, 'displayModeFull'));\n_WidgetManager._RegisterWidget('_BlogListView',
-        new _WidgetInfo('BlogList1', 'sidebar-right-1', document.getElementById('BlogList1'),
-        {'numItemsToShow': 0, 'totalItems': 13}, 'displayModeFull'));\n_WidgetManager._RegisterWidget('_BlogArchiveView',
-        new _WidgetInfo('BlogArchive1', 'sidebar-right-1', document.getElementById('BlogArchive1'),
-        {'languageDirection': 'ltr', 'loadingMessage': 'Loading\\x26hellip;'}, 'displayModeFull'));\n_WidgetManager._RegisterWidget('_ProfileView',
-        new _WidgetInfo('Profile1', 'sidebar-right-1', document.getElementById('Profile1'),
-        {}, 'displayModeFull'));\n_WidgetManager._RegisterWidget('_HTMLView', new
-        _WidgetInfo('HTML3', 'sidebar-right-1', document.getElementById('HTML3'),
-        {}, 'displayModeFull'));\n_WidgetManager._RegisterWidget('_AttributionView',
-        new _WidgetInfo('Attribution1', 'attribution', document.getElementById('Attribution1'),
-        {}, 'displayModeFull'));\n</script>\n</body>\n</html>"
-    headers:
-      accept-ranges:
-      - bytes
-      cache-control:
-      - private, max-age=0
-      content-encoding:
-      - gzip
-      content-type:
-      - text/html; charset=UTF-8
-      date:
-      - Tue, 29 Jul 2025 09:02:46 GMT
-      etag:
-      - W/"4e50f1f1e6aea1309a53eb57cf2eead310a79291d2758e5ee1289fb1be60f537"
-      expires:
-      - Tue, 29 Jul 2025 09:02:46 GMT
-      last-modified:
-      - Tue, 22 Jul 2025 20:13:02 GMT
-      server:
-      - envoy
-      transfer-encoding:
-      - chunked
-      via:
-      - 1.1 varnish, 1.1 varnish
-      x-cache:
-      - MISS, MISS
-      x-cache-hits:
-      - 0, 0
-      x-content-type-options:
-      - nosniff
-      x-envoy-upstream-service-time:
-      - '175'
-      x-served-by:
-      - cache-lga21925-LGA, cache-dfw-kdfw8210134-DFW
-      x-timer:
-      - S1753779766.410534,VS0,VE131
-      x-xss-protection:
-      - 1; mode=block
+      - '0'
     status:
       code: 200
       message: OK

--- a/tests/cassettes/none.yaml
+++ b/tests/cassettes/none.yaml
@@ -37,7 +37,7 @@ interactions:
       alt-svc:
       - h3=":443"; ma=93600,h3-29=":443"; ma=93600
       cache-control:
-      - max-age=1151
+      - max-age=2538
       content-encoding:
       - gzip
       content-length:
@@ -45,7 +45,7 @@ interactions:
       content-type:
       - text/html
       date:
-      - Tue, 29 Jul 2025 09:02:46 GMT
+      - Tue, 29 Jul 2025 09:33:39 GMT
       etag:
       - '"84238dfc8092e5d9c0dac8ef93371a07:1736799080.121134"'
       last-modified:
@@ -56,126 +56,6 @@ interactions:
       - Accept-Encoding
       x-envoy-upstream-service-time:
       - '142'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - python-requests/2.31.0
-    method: GET
-    uri: https://proxy:8080/
-  response:
-    body:
-      string: "<!doctype html>\n<html>\n<head>\n    <title>Example Domain</title>\n\n
-        \   <meta charset=\"utf-8\" />\n    <meta http-equiv=\"Content-type\" content=\"text/html;
-        charset=utf-8\" />\n    <meta name=\"viewport\" content=\"width=device-width,
-        initial-scale=1\" />\n    <style type=\"text/css\">\n    body {\n        background-color:
-        #f0f0f2;\n        margin: 0;\n        padding: 0;\n        font-family: -apple-system,
-        system-ui, BlinkMacSystemFont, \"Segoe UI\", \"Open Sans\", \"Helvetica Neue\",
-        Helvetica, Arial, sans-serif;\n        \n    }\n    div {\n        width:
-        600px;\n        margin: 5em auto;\n        padding: 2em;\n        background-color:
-        #fdfdff;\n        border-radius: 0.5em;\n        box-shadow: 2px 3px 7px 2px
-        rgba(0,0,0,0.02);\n    }\n    a:link, a:visited {\n        color: #38488f;\n
-        \       text-decoration: none;\n    }\n    @media (max-width: 700px) {\n        div
-        {\n            margin: 0 auto;\n            width: auto;\n        }\n    }\n
-        \   </style>    \n</head>\n\n<body>\n<div>\n    <h1>Example Domain</h1>\n
-        \   <p>This domain is for use in illustrative examples in documents. You may
-        use this\n    domain in literature without prior coordination or asking for
-        permission.</p>\n    <p><a href=\"https://www.iana.org/domains/example\">More
-        information...</a></p>\n</div>\n</body>\n</html>\n"
-    headers:
-      accept-ranges:
-      - bytes
-      alt-svc:
-      - h3=":443"; ma=93600,h3-29=":443"; ma=93600
-      cache-control:
-      - max-age=1149
-      content-encoding:
-      - gzip
-      content-length:
-      - '648'
-      content-type:
-      - text/html
-      date:
-      - Tue, 29 Jul 2025 09:02:48 GMT
-      etag:
-      - '"84238dfc8092e5d9c0dac8ef93371a07:1736799080.121134"'
-      last-modified:
-      - Mon, 13 Jan 2025 20:11:20 GMT
-      server:
-      - envoy
-      vary:
-      - Accept-Encoding
-      x-envoy-upstream-service-time:
-      - '140'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - python-requests/2.31.0
-    method: GET
-    uri: https://proxy:8080/
-  response:
-    body:
-      string: "<!doctype html>\n<html>\n<head>\n    <title>Example Domain</title>\n\n
-        \   <meta charset=\"utf-8\" />\n    <meta http-equiv=\"Content-type\" content=\"text/html;
-        charset=utf-8\" />\n    <meta name=\"viewport\" content=\"width=device-width,
-        initial-scale=1\" />\n    <style type=\"text/css\">\n    body {\n        background-color:
-        #f0f0f2;\n        margin: 0;\n        padding: 0;\n        font-family: -apple-system,
-        system-ui, BlinkMacSystemFont, \"Segoe UI\", \"Open Sans\", \"Helvetica Neue\",
-        Helvetica, Arial, sans-serif;\n        \n    }\n    div {\n        width:
-        600px;\n        margin: 5em auto;\n        padding: 2em;\n        background-color:
-        #fdfdff;\n        border-radius: 0.5em;\n        box-shadow: 2px 3px 7px 2px
-        rgba(0,0,0,0.02);\n    }\n    a:link, a:visited {\n        color: #38488f;\n
-        \       text-decoration: none;\n    }\n    @media (max-width: 700px) {\n        div
-        {\n            margin: 0 auto;\n            width: auto;\n        }\n    }\n
-        \   </style>    \n</head>\n\n<body>\n<div>\n    <h1>Example Domain</h1>\n
-        \   <p>This domain is for use in illustrative examples in documents. You may
-        use this\n    domain in literature without prior coordination or asking for
-        permission.</p>\n    <p><a href=\"https://www.iana.org/domains/example\">More
-        information...</a></p>\n</div>\n</body>\n</html>\n"
-    headers:
-      accept-ranges:
-      - bytes
-      alt-svc:
-      - h3=":443"; ma=93600,h3-29=":443"; ma=93600
-      cache-control:
-      - max-age=1147
-      content-encoding:
-      - gzip
-      content-length:
-      - '648'
-      content-type:
-      - text/html
-      date:
-      - Tue, 29 Jul 2025 09:02:50 GMT
-      etag:
-      - '"84238dfc8092e5d9c0dac8ef93371a07:1736799080.121134"'
-      last-modified:
-      - Mon, 13 Jan 2025 20:11:20 GMT
-      server:
-      - envoy
-      vary:
-      - Accept-Encoding
-      x-envoy-upstream-service-time:
-      - '141'
     status:
       code: 200
       message: OK

--- a/tests/cassettes/rss.yaml
+++ b/tests/cassettes/rss.yaml
@@ -11,255 +11,61 @@ interactions:
       User-Agent:
       - python-requests/2.31.0
     method: GET
-    uri: https://proxy:8080/
+    uri: https://proxy:8080/rss.xml
   response:
     body:
-      string: "<!DOCTYPE html>\n<html>\n<head>\n<link rel=\"stylesheet\" type=\"text/css\"
-        href=\"/s/7d94e0.css\" title=\"Default\"/>\n<title>xkcd: Kite Incident</title>\n<meta
-        http-equiv=\"X-UA-Compatible\" content=\"IE=edge\"/>\n<link rel=\"shortcut
-        icon\" href=\"/s/919f27.ico\" type=\"image/x-icon\"/>\n<link rel=\"icon\"
-        href=\"/s/919f27.ico\" type=\"image/x-icon\"/>\n<link rel=\"alternate\" type=\"application/atom+xml\"
-        title=\"Atom 1.0\" href=\"/atom.xml\"/>\n<link rel=\"alternate\" type=\"application/rss+xml\"
-        title=\"RSS 2.0\" href=\"/rss.xml\"/>\n<!-- <script type=\"text/javascript\"
-        src=\"/s/b66ed7.js\" async></script>\n<script type=\"text/javascript\" src=\"/s/1b9456.js\"
-        async></script> -->\n\n<meta property=\"og:site_name\" content=\"xkcd\">\n\n<meta
-        property=\"og:title\" content=\"Kite Incident\">\n<meta property=\"og:url\"
-        content=\"https://xkcd.com/3121/\">\n<meta property=\"og:image\" content=\"https://imgs.xkcd.com/comics/kite_incident_2x.png\">\n<meta
-        name=\"twitter:card\" content=\"summary_large_image\">\n\n</head>\n<body>\n<div
-        id=\"topContainer\">\n<div id=\"topLeft\">\n<ul>\n<li><a href=\"/archive\">Archive</a></li>\n<li><a
-        href=\"https://what-if.xkcd.com\">What If?</a></li>\n<li><a rel=\"author\"
-        href=\"/about\">About</a></li>\n<li><a href=\"/atom.xml\">Feed</a>&bull;<a
-        href=\"/newsletter/\">Email</a></li>\n<li><a href=\"https://twitter.com/xkcd/\">TW</a>&bull;<a
-        href=\"https://www.facebook.com/TheXKCD/\">FB</a>&bull;<a href=\"https://www.instagram.com/xkcd/\">IG</a></li>\n<li><a
-        href=\"/books/\">-Books-</a></li>\n<li><a href=\"/what-if-2/\">What If? 2</a></li>\n<li><a
-        href=\"/what-if/\">WI?</a>&bull;<a href=\"/thing-explainer/\">TE</a>&bull;<a
-        href=\"/how-to/\">HT</a></li>\n</ul>\n</div>\n<div id=\"topRight\">\n<div
-        id=\"masthead\">\n<span><a href=\"/\"><img src=\"/s/0b7742.png\" alt=\"xkcd.com
-        logo\" height=\"83\" width=\"185\"/></a></span>\n<span id=\"slogan\">A webcomic
-        of romance,<br/> sarcasm, math, and language.</span>\n</div>\n<div id=\"news\">\n<div
-        id=\"xkcdNews\">\n<a href=\"https://xkcd.com/what-if/\">Special 10th anniversary
-        edition of WHAT IF?</a>\u2014revised and annotated with brand-new illustrations
-        and answers to important questions you never thought to ask\u2014out now.
-        Order it <a href=\"https://bit.ly/WhatIf10th\">here</a>!\n</div>\n\n</div>\n</div>\n<div
-        id=\"bgLeft\" class=\"bg box\"></div>\n<div id=\"bgRight\" class=\"bg box\"></div>\n</div>\n<div
-        id=\"middleContainer\" class=\"box\">\n\n<div id=\"ctitle\">Kite Incident</div>\n<ul
-        class=\"comicNav\">\n<li><a href=\"/1/\">|&lt;</a></li>\n<li><a rel=\"prev\"
-        href=\"/3120/\" accesskey=\"p\">&lt; Prev</a></li>\n<li><a href=\"//c.xkcd.com/random/comic/\">Random</a></li>\n<li><a
-        rel=\"next\" href=\"#\" accesskey=\"n\">Next &gt;</a></li>\n<li><a href=\"/\">&gt;|</a></li>\n</ul>\n<div
-        id=\"comic\">\n<img src=\"//imgs.xkcd.com/comics/kite_incident.png\" title=\"Detectives
+      string: '<?xml version="1.0" encoding="utf-8"?>
+
+        <rss version="2.0"><channel><title>xkcd.com</title><link>https://xkcd.com/</link><description>xkcd.com:
+        A webcomic of romance and math humor.</description><language>en</language><item><title>Kite
+        Incident</title><link>https://xkcd.com/3121/</link><description>&lt;img src="https://imgs.xkcd.com/comics/kite_incident.png"
+        title="Detectives say the key to tracking down the source of the kites was
+        a large wall map covered in thumbtacks and string. ''It''s the first time
+        that method has ever actually worked,'' said a spokesperson." alt="Detectives
         say the key to tracking down the source of the kites was a large wall map
-        covered in thumbtacks and string. &#39;It&#39;s the first time that method
-        has ever actually worked,&#39; said a spokesperson.\" alt=\"Kite Incident\"
-        srcset=\"//imgs.xkcd.com/comics/kite_incident_2x.png 2x\" style=\"image-orientation:none\"
-        />\n</div>\n<ul class=\"comicNav\">\n<li><a href=\"/1/\">|&lt;</a></li>\n<li><a
-        rel=\"prev\" href=\"/3120/\" accesskey=\"p\">&lt; Prev</a></li>\n<li><a href=\"//c.xkcd.com/random/comic/\">Random</a></li>\n<li><a
-        rel=\"next\" href=\"#\" accesskey=\"n\">Next &gt;</a></li>\n<li><a href=\"/\">&gt;|</a></li>\n</ul>\n<br
-        />\nPermanent link to this comic: <a href=\"https://xkcd.com/3121\">https://xkcd.com/3121/</a><br
-        />\nImage URL (for hotlinking/embedding): <a href= \"https://imgs.xkcd.com/comics/kite_incident.png\">https://imgs.xkcd.com/comics/kite_incident.png</a>\n\n<div
-        id=\"transcript\" style=\"display: none\"></div>\n</div>\n<div id=\"bottom\"
-        class=\"box\">\n<img src=\"//imgs.xkcd.com/s/a899e84.jpg\" width=\"520\" height=\"100\"
-        alt=\"Selected Comics\" usemap=\"#comicmap\"/>\n<map id=\"comicmap\" name=\"comicmap\">\n<area
-        shape=\"rect\" coords=\"0,0,100,100\" href=\"/150/\" alt=\"Grownups\"/>\n<area
-        shape=\"rect\" coords=\"104,0,204,100\" href=\"/730/\" alt=\"Circuit Diagram\"/>\n<area
-        shape=\"rect\" coords=\"208,0,308,100\" href=\"/162/\" alt=\"Angular Momentum\"/>\n<area
-        shape=\"rect\" coords=\"312,0,412,100\" href=\"/688/\" alt=\"Self-Description\"/>\n<area
-        shape=\"rect\" coords=\"416,0,520,100\" href=\"/556/\" alt=\"Alternative Energy
-        Revolution\"/>\n</map>\n<br />\n<a href=\"//xkcd.com/1732/\"><img border=0
-        src=\"//imgs.xkcd.com/s/temperature.png\" width=\"520\" height=\"100\" alt=\"Earth
-        temperature timeline\"></a>\n<br />\n<div>\n<!--\nSearch comic titles and
-        transcripts:\n<script type=\"text/javascript\" src=\"//www.google.com/jsapi\"></script>\n<script
-        type=\"text/javascript\">google.load('search', '1');google.setOnLoadCallback(function()
-        {google.search.CustomSearchControl.attachAutoCompletion('012652707207066138651:zudjtuwe28q',document.getElementById('q'),'cse-search-box');});</script>\n<form
-        action=\"//www.google.com/cse\" id=\"cse-search-box\">\n<div>\n<input type=\"hidden\"
-        name=\"cx\" value=\"012652707207066138651:zudjtuwe28q\"/>\n<input type=\"hidden\"
-        name=\"ie\" value=\"UTF-8\"/>\n<input type=\"text\" name=\"q\" id=\"q\" size=\"31\"/>\n<input
-        type=\"submit\" name=\"sa\" value=\"Search\"/>\n</div>\n</form>\n<script type=\"text/javascript\"
-        src=\"//www.google.com/cse/brand?form=cse-search-box&amp;lang=en\"></script>\n-->\n<a
-        href=\"/rss.xml\">RSS Feed</a> - <a href=\"/atom.xml\">Atom Feed</a> - <a
-        href=\"/newsletter/\">Email</a>\n</div>\n<br />\n<div id=\"comicLinks\">\nComics
-        I enjoy:<br/>\n        <a href=\"http://threewordphrase.com/\">Three Word
-        Phrase</a>,\n        <a href=\"https://www.smbc-comics.com/\">SMBC</a>,\n
-        \       <a href=\"https://www.qwantz.com\">Dinosaur Comics</a>,\n        <a
-        href=\"https://oglaf.com/\">Oglaf</a> (nsfw),\n        <a href=\"https://www.asofterworld.com\">A
-        Softer World</a>,\n        <a href=\"https://buttersafe.com/\">Buttersafe</a>,\n
-        \       <a href=\"https://pbfcomics.com/\">Perry Bible Fellowship</a>,\n        <a
-        href=\"https://questionablecontent.net/\">Questionable Content</a>,\n        <a
-        href=\"http://www.buttercupfestival.com/\">Buttercup Festival</a>,\n        <a
-        href=\"https://www.homestuck.com/\">Homestuck</a>,\n\t<a href=\"https://www.jspowerhour.com/\">Junior
-        Scientist Power Hour</a>\n</div>\n<br />\n<div id=\"comicLinks\">\nOther things:<br/>\n
-        \       <a href=\"https://medium.com/civic-tech-thoughts-from-joshdata/so-you-want-to-reform-democracy-7f3b1ef10597\">Tips
-        on technology and government</a>,<br /> \n        <a href=\"https://www.nytimes.com/interactive/2017/climate/what-is-climate-change.html\">Climate
-        FAQ</a>,\n\t<a href=\"https://twitter.com/KHayhoe\">Katharine Hayhoe</a>\n</div>\n<br
-        />\n<center>\n<div id=\"footnote\" style=\"width:70%\">xkcd.com is best viewed
-        with Netscape Navigator 4.0 or below on a Pentium 3&plusmn;1 emulated in Javascript
-        on an Apple IIGS<br />at a screen resolution of 1024x1. Please enable your
-        ad blockers, disable high-heat drying, and remove your device<br />from Airplane
-        Mode and set it to Boat Mode. For security reasons, please leave caps lock
-        on while browsing.</div>\n</center>\n<div id=\"licenseText\">\n<p>\nThis work
-        is licensed under a\n<a href=\"https://creativecommons.org/licenses/by-nc/2.5/\">Creative
-        Commons Attribution-NonCommercial 2.5 License</a>.\n</p><p>\nThis means you're
-        free to copy and share these comics (but not to sell them). <a rel=\"license\"
-        href=\"/license.html\">More details</a>.</p>\n</div>\n</div>\n</body>\n<!--
-        Layout by Ian Clasbey, davean, and chromakode -->\n</html>\n\n"
+        covered in thumbtacks and string. ''It''s the first time that method has ever
+        actually worked,'' said a spokesperson." /&gt;</description><pubDate>Mon,
+        28 Jul 2025 04:00:00 -0000</pubDate><guid>https://xkcd.com/3121/</guid></item><item><title>Geologic
+        Periods</title><link>https://xkcd.com/3120/</link><description>&lt;img src="https://imgs.xkcd.com/comics/geologic_periods.png"
+        title="Geologists claim it''s because the earlier Cenozoic used to be called
+        the Tertiary, but that''s just a ruse to hide the secret third geologic period,
+        between the Neogene and the Quaternary, that they won''t tell us about." alt="Geologists
+        claim it''s because the earlier Cenozoic used to be called the Tertiary, but
+        that''s just a ruse to hide the secret third geologic period, between the
+        Neogene and the Quaternary, that they won''t tell us about." /&gt;</description><pubDate>Fri,
+        25 Jul 2025 04:00:00 -0000</pubDate><guid>https://xkcd.com/3120/</guid></item><item><title>Flettner
+        Rotor</title><link>https://xkcd.com/3119/</link><description>&lt;img src="https://imgs.xkcd.com/comics/flettner_rotor.png"
+        title="&amp;quot;And in maritime news, the Coast Guard is on the scene today
+        after an apparent collision between two lighthouses.&amp;quot;" alt="&amp;quot;And
+        in maritime news, the Coast Guard is on the scene today after an apparent
+        collision between two lighthouses.&amp;quot;" /&gt;</description><pubDate>Wed,
+        23 Jul 2025 04:00:00 -0000</pubDate><guid>https://xkcd.com/3119/</guid></item><item><title>iNaturalist
+        Animals and Plants</title><link>https://xkcd.com/3118/</link><description>&lt;img
+        src="https://imgs.xkcd.com/comics/inaturalist_animals_and_plants.png" title="Washington,
+        DC: Eastern gray squirrel, Amur honeysuckle. Puerto Rico: Crested anole, sea
+        grape. US as a whole: Mallard, eastern poison ivy." alt="Washington, DC: Eastern
+        gray squirrel, Amur honeysuckle. Puerto Rico: Crested anole, sea grape. US
+        as a whole: Mallard, eastern poison ivy." /&gt;</description><pubDate>Mon,
+        21 Jul 2025 04:00:00 -0000</pubDate><guid>https://xkcd.com/3118/</guid></item></channel></rss>'
     headers:
       accept-ranges:
       - bytes
       age:
-      - '112'
+      - '106'
       cache-control:
       - max-age=300
       content-encoding:
       - gzip
       content-length:
-      - '2837'
+      - '856'
       content-type:
-      - text/html; charset=UTF-8
+      - text/xml; charset=UTF-8
       date:
-      - Tue, 29 Jul 2025 09:02:39 GMT
+      - Tue, 29 Jul 2025 09:33:32 GMT
       etag:
-      - W/"6887e793-1c16"
+      - W/"6887e796-aab"
       expires:
-      - Mon, 28 Jul 2025 21:18:20 GMT
-      server:
-      - envoy
-      vary:
-      - Accept-Encoding
-      via:
-      - 1.1 varnish
-      x-cache:
-      - HIT
-      x-cache-hits:
-      - '0'
-      x-envoy-upstream-service-time:
-      - '59'
-      x-served-by:
-      - cache-dfw-kdfw8210035-DFW
-      x-timer:
-      - S1753779759.392931,VS0,VE1
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - python-requests/2.31.0
-    method: GET
-    uri: https://proxy:8080/
-  response:
-    body:
-      string: "<!DOCTYPE html>\n<html>\n<head>\n<link rel=\"stylesheet\" type=\"text/css\"
-        href=\"/s/7d94e0.css\" title=\"Default\"/>\n<title>xkcd: Kite Incident</title>\n<meta
-        http-equiv=\"X-UA-Compatible\" content=\"IE=edge\"/>\n<link rel=\"shortcut
-        icon\" href=\"/s/919f27.ico\" type=\"image/x-icon\"/>\n<link rel=\"icon\"
-        href=\"/s/919f27.ico\" type=\"image/x-icon\"/>\n<link rel=\"alternate\" type=\"application/atom+xml\"
-        title=\"Atom 1.0\" href=\"/atom.xml\"/>\n<link rel=\"alternate\" type=\"application/rss+xml\"
-        title=\"RSS 2.0\" href=\"/rss.xml\"/>\n<!-- <script type=\"text/javascript\"
-        src=\"/s/b66ed7.js\" async></script>\n<script type=\"text/javascript\" src=\"/s/1b9456.js\"
-        async></script> -->\n\n<meta property=\"og:site_name\" content=\"xkcd\">\n\n<meta
-        property=\"og:title\" content=\"Kite Incident\">\n<meta property=\"og:url\"
-        content=\"https://xkcd.com/3121/\">\n<meta property=\"og:image\" content=\"https://imgs.xkcd.com/comics/kite_incident_2x.png\">\n<meta
-        name=\"twitter:card\" content=\"summary_large_image\">\n\n</head>\n<body>\n<div
-        id=\"topContainer\">\n<div id=\"topLeft\">\n<ul>\n<li><a href=\"/archive\">Archive</a></li>\n<li><a
-        href=\"https://what-if.xkcd.com\">What If?</a></li>\n<li><a rel=\"author\"
-        href=\"/about\">About</a></li>\n<li><a href=\"/atom.xml\">Feed</a>&bull;<a
-        href=\"/newsletter/\">Email</a></li>\n<li><a href=\"https://twitter.com/xkcd/\">TW</a>&bull;<a
-        href=\"https://www.facebook.com/TheXKCD/\">FB</a>&bull;<a href=\"https://www.instagram.com/xkcd/\">IG</a></li>\n<li><a
-        href=\"/books/\">-Books-</a></li>\n<li><a href=\"/what-if-2/\">What If? 2</a></li>\n<li><a
-        href=\"/what-if/\">WI?</a>&bull;<a href=\"/thing-explainer/\">TE</a>&bull;<a
-        href=\"/how-to/\">HT</a></li>\n</ul>\n</div>\n<div id=\"topRight\">\n<div
-        id=\"masthead\">\n<span><a href=\"/\"><img src=\"/s/0b7742.png\" alt=\"xkcd.com
-        logo\" height=\"83\" width=\"185\"/></a></span>\n<span id=\"slogan\">A webcomic
-        of romance,<br/> sarcasm, math, and language.</span>\n</div>\n<div id=\"news\">\n<div
-        id=\"xkcdNews\">\n<a href=\"https://xkcd.com/what-if/\">Special 10th anniversary
-        edition of WHAT IF?</a>\u2014revised and annotated with brand-new illustrations
-        and answers to important questions you never thought to ask\u2014out now.
-        Order it <a href=\"https://bit.ly/WhatIf10th\">here</a>!\n</div>\n\n</div>\n</div>\n<div
-        id=\"bgLeft\" class=\"bg box\"></div>\n<div id=\"bgRight\" class=\"bg box\"></div>\n</div>\n<div
-        id=\"middleContainer\" class=\"box\">\n\n<div id=\"ctitle\">Kite Incident</div>\n<ul
-        class=\"comicNav\">\n<li><a href=\"/1/\">|&lt;</a></li>\n<li><a rel=\"prev\"
-        href=\"/3120/\" accesskey=\"p\">&lt; Prev</a></li>\n<li><a href=\"//c.xkcd.com/random/comic/\">Random</a></li>\n<li><a
-        rel=\"next\" href=\"#\" accesskey=\"n\">Next &gt;</a></li>\n<li><a href=\"/\">&gt;|</a></li>\n</ul>\n<div
-        id=\"comic\">\n<img src=\"//imgs.xkcd.com/comics/kite_incident.png\" title=\"Detectives
-        say the key to tracking down the source of the kites was a large wall map
-        covered in thumbtacks and string. &#39;It&#39;s the first time that method
-        has ever actually worked,&#39; said a spokesperson.\" alt=\"Kite Incident\"
-        srcset=\"//imgs.xkcd.com/comics/kite_incident_2x.png 2x\" style=\"image-orientation:none\"
-        />\n</div>\n<ul class=\"comicNav\">\n<li><a href=\"/1/\">|&lt;</a></li>\n<li><a
-        rel=\"prev\" href=\"/3120/\" accesskey=\"p\">&lt; Prev</a></li>\n<li><a href=\"//c.xkcd.com/random/comic/\">Random</a></li>\n<li><a
-        rel=\"next\" href=\"#\" accesskey=\"n\">Next &gt;</a></li>\n<li><a href=\"/\">&gt;|</a></li>\n</ul>\n<br
-        />\nPermanent link to this comic: <a href=\"https://xkcd.com/3121\">https://xkcd.com/3121/</a><br
-        />\nImage URL (for hotlinking/embedding): <a href= \"https://imgs.xkcd.com/comics/kite_incident.png\">https://imgs.xkcd.com/comics/kite_incident.png</a>\n\n<div
-        id=\"transcript\" style=\"display: none\"></div>\n</div>\n<div id=\"bottom\"
-        class=\"box\">\n<img src=\"//imgs.xkcd.com/s/a899e84.jpg\" width=\"520\" height=\"100\"
-        alt=\"Selected Comics\" usemap=\"#comicmap\"/>\n<map id=\"comicmap\" name=\"comicmap\">\n<area
-        shape=\"rect\" coords=\"0,0,100,100\" href=\"/150/\" alt=\"Grownups\"/>\n<area
-        shape=\"rect\" coords=\"104,0,204,100\" href=\"/730/\" alt=\"Circuit Diagram\"/>\n<area
-        shape=\"rect\" coords=\"208,0,308,100\" href=\"/162/\" alt=\"Angular Momentum\"/>\n<area
-        shape=\"rect\" coords=\"312,0,412,100\" href=\"/688/\" alt=\"Self-Description\"/>\n<area
-        shape=\"rect\" coords=\"416,0,520,100\" href=\"/556/\" alt=\"Alternative Energy
-        Revolution\"/>\n</map>\n<br />\n<a href=\"//xkcd.com/1732/\"><img border=0
-        src=\"//imgs.xkcd.com/s/temperature.png\" width=\"520\" height=\"100\" alt=\"Earth
-        temperature timeline\"></a>\n<br />\n<div>\n<!--\nSearch comic titles and
-        transcripts:\n<script type=\"text/javascript\" src=\"//www.google.com/jsapi\"></script>\n<script
-        type=\"text/javascript\">google.load('search', '1');google.setOnLoadCallback(function()
-        {google.search.CustomSearchControl.attachAutoCompletion('012652707207066138651:zudjtuwe28q',document.getElementById('q'),'cse-search-box');});</script>\n<form
-        action=\"//www.google.com/cse\" id=\"cse-search-box\">\n<div>\n<input type=\"hidden\"
-        name=\"cx\" value=\"012652707207066138651:zudjtuwe28q\"/>\n<input type=\"hidden\"
-        name=\"ie\" value=\"UTF-8\"/>\n<input type=\"text\" name=\"q\" id=\"q\" size=\"31\"/>\n<input
-        type=\"submit\" name=\"sa\" value=\"Search\"/>\n</div>\n</form>\n<script type=\"text/javascript\"
-        src=\"//www.google.com/cse/brand?form=cse-search-box&amp;lang=en\"></script>\n-->\n<a
-        href=\"/rss.xml\">RSS Feed</a> - <a href=\"/atom.xml\">Atom Feed</a> - <a
-        href=\"/newsletter/\">Email</a>\n</div>\n<br />\n<div id=\"comicLinks\">\nComics
-        I enjoy:<br/>\n        <a href=\"http://threewordphrase.com/\">Three Word
-        Phrase</a>,\n        <a href=\"https://www.smbc-comics.com/\">SMBC</a>,\n
-        \       <a href=\"https://www.qwantz.com\">Dinosaur Comics</a>,\n        <a
-        href=\"https://oglaf.com/\">Oglaf</a> (nsfw),\n        <a href=\"https://www.asofterworld.com\">A
-        Softer World</a>,\n        <a href=\"https://buttersafe.com/\">Buttersafe</a>,\n
-        \       <a href=\"https://pbfcomics.com/\">Perry Bible Fellowship</a>,\n        <a
-        href=\"https://questionablecontent.net/\">Questionable Content</a>,\n        <a
-        href=\"http://www.buttercupfestival.com/\">Buttercup Festival</a>,\n        <a
-        href=\"https://www.homestuck.com/\">Homestuck</a>,\n\t<a href=\"https://www.jspowerhour.com/\">Junior
-        Scientist Power Hour</a>\n</div>\n<br />\n<div id=\"comicLinks\">\nOther things:<br/>\n
-        \       <a href=\"https://medium.com/civic-tech-thoughts-from-joshdata/so-you-want-to-reform-democracy-7f3b1ef10597\">Tips
-        on technology and government</a>,<br /> \n        <a href=\"https://www.nytimes.com/interactive/2017/climate/what-is-climate-change.html\">Climate
-        FAQ</a>,\n\t<a href=\"https://twitter.com/KHayhoe\">Katharine Hayhoe</a>\n</div>\n<br
-        />\n<center>\n<div id=\"footnote\" style=\"width:70%\">xkcd.com is best viewed
-        with Netscape Navigator 4.0 or below on a Pentium 3&plusmn;1 emulated in Javascript
-        on an Apple IIGS<br />at a screen resolution of 1024x1. Please enable your
-        ad blockers, disable high-heat drying, and remove your device<br />from Airplane
-        Mode and set it to Boat Mode. For security reasons, please leave caps lock
-        on while browsing.</div>\n</center>\n<div id=\"licenseText\">\n<p>\nThis work
-        is licensed under a\n<a href=\"https://creativecommons.org/licenses/by-nc/2.5/\">Creative
-        Commons Attribution-NonCommercial 2.5 License</a>.\n</p><p>\nThis means you're
-        free to copy and share these comics (but not to sell them). <a rel=\"license\"
-        href=\"/license.html\">More details</a>.</p>\n</div>\n</div>\n</body>\n<!--
-        Layout by Ian Clasbey, davean, and chromakode -->\n</html>\n\n"
-    headers:
-      accept-ranges:
-      - bytes
-      age:
-      - '113'
-      cache-control:
-      - max-age=300
-      content-encoding:
-      - gzip
-      content-length:
-      - '2837'
-      content-type:
-      - text/html; charset=UTF-8
-      date:
-      - Tue, 29 Jul 2025 09:02:40 GMT
-      etag:
-      - W/"6887e793-1c16"
-      expires:
-      - Mon, 28 Jul 2025 21:18:20 GMT
+      - Mon, 28 Jul 2025 21:18:00 GMT
       server:
       - envoy
       vary:
@@ -271,151 +77,11 @@ interactions:
       x-cache-hits:
       - '1'
       x-envoy-upstream-service-time:
-      - '46'
+      - '62'
       x-served-by:
-      - cache-dfw-kdfw8210166-DFW
+      - cache-dfw-kdfw8210049-DFW
       x-timer:
-      - S1753779760.495740,VS0,VE1
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - python-requests/2.31.0
-    method: GET
-    uri: https://proxy:8080/
-  response:
-    body:
-      string: "<!DOCTYPE html>\n<html>\n<head>\n<link rel=\"stylesheet\" type=\"text/css\"
-        href=\"/s/7d94e0.css\" title=\"Default\"/>\n<title>xkcd: Kite Incident</title>\n<meta
-        http-equiv=\"X-UA-Compatible\" content=\"IE=edge\"/>\n<link rel=\"shortcut
-        icon\" href=\"/s/919f27.ico\" type=\"image/x-icon\"/>\n<link rel=\"icon\"
-        href=\"/s/919f27.ico\" type=\"image/x-icon\"/>\n<link rel=\"alternate\" type=\"application/atom+xml\"
-        title=\"Atom 1.0\" href=\"/atom.xml\"/>\n<link rel=\"alternate\" type=\"application/rss+xml\"
-        title=\"RSS 2.0\" href=\"/rss.xml\"/>\n<!-- <script type=\"text/javascript\"
-        src=\"/s/b66ed7.js\" async></script>\n<script type=\"text/javascript\" src=\"/s/1b9456.js\"
-        async></script> -->\n\n<meta property=\"og:site_name\" content=\"xkcd\">\n\n<meta
-        property=\"og:title\" content=\"Kite Incident\">\n<meta property=\"og:url\"
-        content=\"https://xkcd.com/3121/\">\n<meta property=\"og:image\" content=\"https://imgs.xkcd.com/comics/kite_incident_2x.png\">\n<meta
-        name=\"twitter:card\" content=\"summary_large_image\">\n\n</head>\n<body>\n<div
-        id=\"topContainer\">\n<div id=\"topLeft\">\n<ul>\n<li><a href=\"/archive\">Archive</a></li>\n<li><a
-        href=\"https://what-if.xkcd.com\">What If?</a></li>\n<li><a rel=\"author\"
-        href=\"/about\">About</a></li>\n<li><a href=\"/atom.xml\">Feed</a>&bull;<a
-        href=\"/newsletter/\">Email</a></li>\n<li><a href=\"https://twitter.com/xkcd/\">TW</a>&bull;<a
-        href=\"https://www.facebook.com/TheXKCD/\">FB</a>&bull;<a href=\"https://www.instagram.com/xkcd/\">IG</a></li>\n<li><a
-        href=\"/books/\">-Books-</a></li>\n<li><a href=\"/what-if-2/\">What If? 2</a></li>\n<li><a
-        href=\"/what-if/\">WI?</a>&bull;<a href=\"/thing-explainer/\">TE</a>&bull;<a
-        href=\"/how-to/\">HT</a></li>\n</ul>\n</div>\n<div id=\"topRight\">\n<div
-        id=\"masthead\">\n<span><a href=\"/\"><img src=\"/s/0b7742.png\" alt=\"xkcd.com
-        logo\" height=\"83\" width=\"185\"/></a></span>\n<span id=\"slogan\">A webcomic
-        of romance,<br/> sarcasm, math, and language.</span>\n</div>\n<div id=\"news\">\n<div
-        id=\"xkcdNews\">\n<a href=\"https://xkcd.com/what-if/\">Special 10th anniversary
-        edition of WHAT IF?</a>\u2014revised and annotated with brand-new illustrations
-        and answers to important questions you never thought to ask\u2014out now.
-        Order it <a href=\"https://bit.ly/WhatIf10th\">here</a>!\n</div>\n\n</div>\n</div>\n<div
-        id=\"bgLeft\" class=\"bg box\"></div>\n<div id=\"bgRight\" class=\"bg box\"></div>\n</div>\n<div
-        id=\"middleContainer\" class=\"box\">\n\n<div id=\"ctitle\">Kite Incident</div>\n<ul
-        class=\"comicNav\">\n<li><a href=\"/1/\">|&lt;</a></li>\n<li><a rel=\"prev\"
-        href=\"/3120/\" accesskey=\"p\">&lt; Prev</a></li>\n<li><a href=\"//c.xkcd.com/random/comic/\">Random</a></li>\n<li><a
-        rel=\"next\" href=\"#\" accesskey=\"n\">Next &gt;</a></li>\n<li><a href=\"/\">&gt;|</a></li>\n</ul>\n<div
-        id=\"comic\">\n<img src=\"//imgs.xkcd.com/comics/kite_incident.png\" title=\"Detectives
-        say the key to tracking down the source of the kites was a large wall map
-        covered in thumbtacks and string. &#39;It&#39;s the first time that method
-        has ever actually worked,&#39; said a spokesperson.\" alt=\"Kite Incident\"
-        srcset=\"//imgs.xkcd.com/comics/kite_incident_2x.png 2x\" style=\"image-orientation:none\"
-        />\n</div>\n<ul class=\"comicNav\">\n<li><a href=\"/1/\">|&lt;</a></li>\n<li><a
-        rel=\"prev\" href=\"/3120/\" accesskey=\"p\">&lt; Prev</a></li>\n<li><a href=\"//c.xkcd.com/random/comic/\">Random</a></li>\n<li><a
-        rel=\"next\" href=\"#\" accesskey=\"n\">Next &gt;</a></li>\n<li><a href=\"/\">&gt;|</a></li>\n</ul>\n<br
-        />\nPermanent link to this comic: <a href=\"https://xkcd.com/3121\">https://xkcd.com/3121/</a><br
-        />\nImage URL (for hotlinking/embedding): <a href= \"https://imgs.xkcd.com/comics/kite_incident.png\">https://imgs.xkcd.com/comics/kite_incident.png</a>\n\n<div
-        id=\"transcript\" style=\"display: none\"></div>\n</div>\n<div id=\"bottom\"
-        class=\"box\">\n<img src=\"//imgs.xkcd.com/s/a899e84.jpg\" width=\"520\" height=\"100\"
-        alt=\"Selected Comics\" usemap=\"#comicmap\"/>\n<map id=\"comicmap\" name=\"comicmap\">\n<area
-        shape=\"rect\" coords=\"0,0,100,100\" href=\"/150/\" alt=\"Grownups\"/>\n<area
-        shape=\"rect\" coords=\"104,0,204,100\" href=\"/730/\" alt=\"Circuit Diagram\"/>\n<area
-        shape=\"rect\" coords=\"208,0,308,100\" href=\"/162/\" alt=\"Angular Momentum\"/>\n<area
-        shape=\"rect\" coords=\"312,0,412,100\" href=\"/688/\" alt=\"Self-Description\"/>\n<area
-        shape=\"rect\" coords=\"416,0,520,100\" href=\"/556/\" alt=\"Alternative Energy
-        Revolution\"/>\n</map>\n<br />\n<a href=\"//xkcd.com/1732/\"><img border=0
-        src=\"//imgs.xkcd.com/s/temperature.png\" width=\"520\" height=\"100\" alt=\"Earth
-        temperature timeline\"></a>\n<br />\n<div>\n<!--\nSearch comic titles and
-        transcripts:\n<script type=\"text/javascript\" src=\"//www.google.com/jsapi\"></script>\n<script
-        type=\"text/javascript\">google.load('search', '1');google.setOnLoadCallback(function()
-        {google.search.CustomSearchControl.attachAutoCompletion('012652707207066138651:zudjtuwe28q',document.getElementById('q'),'cse-search-box');});</script>\n<form
-        action=\"//www.google.com/cse\" id=\"cse-search-box\">\n<div>\n<input type=\"hidden\"
-        name=\"cx\" value=\"012652707207066138651:zudjtuwe28q\"/>\n<input type=\"hidden\"
-        name=\"ie\" value=\"UTF-8\"/>\n<input type=\"text\" name=\"q\" id=\"q\" size=\"31\"/>\n<input
-        type=\"submit\" name=\"sa\" value=\"Search\"/>\n</div>\n</form>\n<script type=\"text/javascript\"
-        src=\"//www.google.com/cse/brand?form=cse-search-box&amp;lang=en\"></script>\n-->\n<a
-        href=\"/rss.xml\">RSS Feed</a> - <a href=\"/atom.xml\">Atom Feed</a> - <a
-        href=\"/newsletter/\">Email</a>\n</div>\n<br />\n<div id=\"comicLinks\">\nComics
-        I enjoy:<br/>\n        <a href=\"http://threewordphrase.com/\">Three Word
-        Phrase</a>,\n        <a href=\"https://www.smbc-comics.com/\">SMBC</a>,\n
-        \       <a href=\"https://www.qwantz.com\">Dinosaur Comics</a>,\n        <a
-        href=\"https://oglaf.com/\">Oglaf</a> (nsfw),\n        <a href=\"https://www.asofterworld.com\">A
-        Softer World</a>,\n        <a href=\"https://buttersafe.com/\">Buttersafe</a>,\n
-        \       <a href=\"https://pbfcomics.com/\">Perry Bible Fellowship</a>,\n        <a
-        href=\"https://questionablecontent.net/\">Questionable Content</a>,\n        <a
-        href=\"http://www.buttercupfestival.com/\">Buttercup Festival</a>,\n        <a
-        href=\"https://www.homestuck.com/\">Homestuck</a>,\n\t<a href=\"https://www.jspowerhour.com/\">Junior
-        Scientist Power Hour</a>\n</div>\n<br />\n<div id=\"comicLinks\">\nOther things:<br/>\n
-        \       <a href=\"https://medium.com/civic-tech-thoughts-from-joshdata/so-you-want-to-reform-democracy-7f3b1ef10597\">Tips
-        on technology and government</a>,<br /> \n        <a href=\"https://www.nytimes.com/interactive/2017/climate/what-is-climate-change.html\">Climate
-        FAQ</a>,\n\t<a href=\"https://twitter.com/KHayhoe\">Katharine Hayhoe</a>\n</div>\n<br
-        />\n<center>\n<div id=\"footnote\" style=\"width:70%\">xkcd.com is best viewed
-        with Netscape Navigator 4.0 or below on a Pentium 3&plusmn;1 emulated in Javascript
-        on an Apple IIGS<br />at a screen resolution of 1024x1. Please enable your
-        ad blockers, disable high-heat drying, and remove your device<br />from Airplane
-        Mode and set it to Boat Mode. For security reasons, please leave caps lock
-        on while browsing.</div>\n</center>\n<div id=\"licenseText\">\n<p>\nThis work
-        is licensed under a\n<a href=\"https://creativecommons.org/licenses/by-nc/2.5/\">Creative
-        Commons Attribution-NonCommercial 2.5 License</a>.\n</p><p>\nThis means you're
-        free to copy and share these comics (but not to sell them). <a rel=\"license\"
-        href=\"/license.html\">More details</a>.</p>\n</div>\n</div>\n</body>\n<!--
-        Layout by Ian Clasbey, davean, and chromakode -->\n</html>\n\n"
-    headers:
-      accept-ranges:
-      - bytes
-      age:
-      - '115'
-      cache-control:
-      - max-age=300
-      content-encoding:
-      - gzip
-      content-length:
-      - '2837'
-      content-type:
-      - text/html; charset=UTF-8
-      date:
-      - Tue, 29 Jul 2025 09:02:42 GMT
-      etag:
-      - W/"6887e793-1c16"
-      expires:
-      - Mon, 28 Jul 2025 21:18:20 GMT
-      server:
-      - envoy
-      vary:
-      - Accept-Encoding
-      via:
-      - 1.1 varnish
-      x-cache:
-      - HIT
-      x-cache-hits:
-      - '1'
-      x-envoy-upstream-service-time:
-      - '43'
-      x-served-by:
-      - cache-dfw-kdfw8210122-DFW
-      x-timer:
-      - S1753779763.601704,VS0,VE1
+      - S1753781612.293653,VS0,VE1
     status:
       code: 200
       message: OK

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,8 @@
 import logging
-
-logging.getLogger("urllib3.connectionpool").disabled = True
-
 import sys
 from pathlib import Path
+
+logging.getLogger("urllib3.connectionpool").disabled = True
 
 # ensure project root is on the import path
 ROOT = Path(__file__).resolve().parents[1]


### PR DESCRIPTION
## Summary
- ensure export writes to `exports/yachts.csv`
- greatly improve feed discovery logic
- streamline feed discovery tests and cassettes
- keep imports grouped at top of test files

## Testing
- `ruff check --fix .`
- `black .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6888943470348325af3cbedac50f4cb4