### PR TITLE
Validate feeds and handle export edge cases

### DIFF
--- a/src/export/csv.py
+++ b/src/export/csv.py
@@ -31,6 +31,10 @@ def run(db_path: Path = Path("yachts.duckdb")) -> Path:
         if json_path.exists():
             try:
                 records = json.loads(json_path.read_text())
+                if isinstance(records, dict):
+                    records = [records]
+                elif not isinstance(records, list):
+                    raise TypeError("export JSON must be list or dict")
                 df = pd.DataFrame(records)[["name", "length_m"]]
             except Exception as exc:
                 log.warning("failed to load %s: %s", json_path, exc)

--- a/src/scrape/crawl.py
+++ b/src/scrape/crawl.py
@@ -1,8 +1,60 @@
+import json
 import logging
+from collections.abc import Iterable
+from pathlib import Path
+
+import requests
+from jsonschema import ValidationError, validate
 
 log = logging.getLogger(__name__)
 
+FEED_SCHEMA = {
+    "type": "object",
+    "required": ["domain", "timestamp"],
+    "properties": {
+        "domain": {"type": "string"},
+        "timestamp": {"type": "integer"},
+    },
+}
+FEEDS_SCHEMA = {"type": "array", "items": FEED_SCHEMA}
 
-def run() -> None:
-    """Placeholder implementation with logging."""
-    log.info("stub")
+
+def validate_feeds(feeds: list[dict]) -> list[dict]:
+    """Validate discovered feeds against the JSON schema."""
+    try:
+        validate(instance=feeds, schema=FEEDS_SCHEMA)
+    except ValidationError as exc:  # pragma: no cover - error path
+        log.warning("feed schema violation: %s", exc.message)
+        raise ValueError("invalid feed data") from exc
+    return feeds
+
+
+def load_feeds(path: Path) -> list[dict]:
+    """Load and validate feeds from a JSON file."""
+    try:
+        feeds = json.loads(path.read_text())
+    except Exception as exc:  # pragma: no cover - IO issues
+        log.warning("failed to load %s: %s", path, exc)
+        return []
+    try:
+        return validate_feeds(feeds)
+    except ValueError:
+        return []
+
+
+def run(feeds: Iterable[dict] | None = None, feeds_file: Path | None = None) -> None:
+    """Crawl the provided feeds."""
+    if feeds is None:
+        if feeds_file is None:
+            feeds_file = Path("yacht_osint/data/cache/discovered_feeds.json")
+        if feeds_file.exists():
+            feeds = load_feeds(feeds_file)
+        else:
+            feeds = []
+
+    for feed in feeds:
+        if not isinstance(feed, dict) or "domain" not in feed:
+            log.warning("invalid feed entry skipped: %s", feed)
+            continue
+        url = f"https://{feed['domain']}"
+        requests.get(url)

--- a/tests/fixtures/smoke_yachts.csv
+++ b/tests/fixtures/smoke_yachts.csv
@@ -1,0 +1,2 @@
+name,length_m
+A,1

--- a/tests/test_crawl.py
+++ b/tests/test_crawl.py
@@ -1,0 +1,33 @@
+import logging
+from types import SimpleNamespace
+
+import pytest
+
+from src.scrape import crawl
+
+
+def test_crawl_builds_url(monkeypatch):
+    called = []
+
+    def fake_get(url, *a, **k):  # pragma: no cover - simple stub
+        called.append(url)
+        return SimpleNamespace(status_code=200)
+
+    monkeypatch.setattr(crawl.requests, "get", fake_get)
+    feeds = [{"domain": "example.com", "timestamp": 12345}]
+    crawl.run(feeds)
+    assert called == ["https://example.com"]
+
+
+def test_validate_feeds():
+    feeds = [{"domain": "x.com", "timestamp": 1}]
+    assert crawl.validate_feeds(feeds) == feeds
+    with pytest.raises(ValueError):
+        crawl.validate_feeds([{"timestamp": 1}])
+
+
+def test_crawl_skips_invalid(monkeypatch, caplog):
+    monkeypatch.setattr(crawl.requests, "get", lambda *a, **k: None)
+    caplog.set_level(logging.WARNING)
+    crawl.run([{"timestamp": 1}, "nope"])
+    assert "invalid feed entry skipped" in caplog.text

--- a/tests/test_exports.py
+++ b/tests/test_exports.py
@@ -34,8 +34,19 @@ def test_export_empty_db(tmp_path, monkeypatch):
 def test_run_exports_json(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     (tmp_path / "exports").mkdir()
-    (tmp_path / "exports" / "new_data.json").write_text('[{"name": "B", "length_m": 2}]')
+    (tmp_path / "exports" / "new_data.json").write_text('{"name": "B", "length_m": 2}')
     out = export_csv.run(tmp_path / "missing.duckdb")
     df = pd.read_csv(out)
     assert Path("exports/yachts.csv").is_file()
     assert df.iloc[0]["name"] == "B"
+
+
+def test_run_exports_empty_json(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "exports").mkdir()
+    (tmp_path / "exports" / "new_data.json").write_text("[]")
+    out = export_csv.run(tmp_path / "missing.duckdb")
+    df = pd.read_csv(out)
+    assert Path("exports/yachts.csv").is_file()
+    assert list(df.columns) == ["name", "length_m"]
+    assert len(df) == 0

--- a/tests/test_pipeline_no_data.py
+++ b/tests/test_pipeline_no_data.py
@@ -1,0 +1,15 @@
+import pandas as pd
+
+from src.export import csv as export_csv
+from src.scrape import crawl
+
+
+def test_pipeline_no_new_data(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    crawl.run([])
+    (tmp_path / "exports").mkdir()
+    (tmp_path / "exports" / "new_data.json").write_text("[]")
+    out = export_csv.run(tmp_path / "missing.duckdb")
+    df = pd.read_csv(out)
+    assert list(df.columns) == ["name", "length_m"]
+    assert len(df) == 0

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -1,0 +1,16 @@
+from pathlib import Path
+
+from src.export import csv as export_csv
+from src.scrape import crawl
+
+
+def test_smoke_pipeline(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    fixture = Path(__file__).parent / "fixtures" / "smoke_yachts.csv"
+    assert fixture.is_file(), "fixture missing"
+    monkeypatch.setattr(crawl.requests, "get", lambda url: None)
+    crawl.run([{"domain": "example.com", "timestamp": 1}])
+    (tmp_path / "exports").mkdir()
+    (tmp_path / "exports" / "new_data.json").write_text('[{"name": "A", "length_m": 1}]')
+    out = export_csv.run(tmp_path / "missing.duckdb")
+    assert Path(out).read_text() == fixture.read_text()


### PR DESCRIPTION
## Summary
- Validate discovered feeds against a JSON schema and crawl using the `domain` field
- Harden CSV exporter to accept single-record JSON and emit header-only files when no data
- Add smoke and pipeline tests to guard against regressions

## Testing
- `ruff check --fix src/scrape/crawl.py src/export/csv.py tests/test_crawl.py tests/test_exports.py tests/test_pipeline_no_data.py tests/test_smoke.py`
- `black src/scrape/crawl.py src/export/csv.py tests/test_crawl.py tests/test_exports.py tests/test_pipeline_no_data.py tests/test_smoke.py`
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689098f7bebc832598b1f7bb46bf52b0