### PR TITLE
feat: add http retry logging wrapper

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+testpaths = tests

--- a/scripts/diagnose_and_run.py
+++ b/scripts/diagnose_and_run.py
@@ -1,0 +1,56 @@
+"""Run quick diagnostics then execute pipeline."""
+
+import json
+import logging
+from pathlib import Path
+from typing import Any
+
+try:
+    import yaml
+except Exception:  # pragma: no cover - optional dependency
+    yaml = None
+
+from src.common.http import get as http_get
+from src.scrape.parse import discover_feeds
+
+logging.basicConfig(level=logging.INFO)
+
+
+def probe_sources(config_path: Path = Path("configs/sources.yml")) -> list[dict[str, Any]]:
+    results: list[dict[str, Any]] = []
+    if yaml is None:
+        logging.error("yaml library missing; cannot run probe")
+        return results
+    sources = yaml.safe_load(config_path.read_text())
+    for src in sources:
+        url = src.get("rss") or f"https://{src['domain']}"
+        entry: dict[str, Any] = {"source": src.get("domain"), "url": url}
+        try:
+            resp = http_get(url, timeout=10)
+            entry.update(
+                {
+                    "status": resp.status_code,
+                    "content_type": resp.headers.get("content-type"),
+                    "size": len(resp.content),
+                }
+            )
+        except Exception as exc:  # pragma: no cover - network errors
+            logging.exception("probe failed for %s", url)
+            entry["error"] = str(exc)
+        results.append(entry)
+    Path("diagnostics").mkdir(exist_ok=True)
+    Path("diagnostics/manifest.json").write_text(json.dumps(results, indent=2))
+    logging.info("wrote diagnostics/manifest.json")
+    return results
+
+
+def main() -> None:  # pragma: no cover - CLI helper
+    probe_sources()
+    # placeholder for full pipeline run
+    for src in probe_sources():
+        logging.info("discovered feeds for %s: %s", src["source"], discover_feeds(src["url"]))
+    logging.info("diagnose_and_run complete")
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI helper
+    main()

--- a/src/common/http.py
+++ b/src/common/http.py
@@ -1,0 +1,61 @@
+import logging
+import time
+from typing import Any
+
+import requests
+from requests import RequestException, Response
+from tenacity import (
+    before_sleep_log,
+    retry,
+    retry_if_exception_type,
+    stop_after_attempt,
+    wait_random_exponential,
+)
+
+log = logging.getLogger(__name__)
+SESSION = requests.Session()
+SESSION.trust_env = False
+
+
+@retry(
+    reraise=True,
+    stop=stop_after_attempt(5),
+    wait=wait_random_exponential(multiplier=1, max=30),
+    retry=retry_if_exception_type(RequestException),
+    before_sleep=before_sleep_log(log, logging.WARNING),
+)
+def request(method: str, url: str, **kwargs: Any) -> Response:
+    """Perform an HTTP request with logging and retries."""
+    start = time.monotonic()
+    resp = SESSION.request(method, url, **kwargs)
+    if resp.status_code == 429:
+        retry_after = resp.headers.get("Retry-After")
+        if retry_after is not None:
+            try:
+                wait = int(retry_after)
+                if wait > 0:
+                    time.sleep(wait)
+            except ValueError:
+                pass
+        # raise to trigger retry
+        raise RequestException(f"429 for {url}")
+    if resp.status_code >= 500:
+        raise RequestException(f"{resp.status_code} for {url}")
+    duration = time.monotonic() - start
+    snippet = resp.text[:200] if resp.text else ""
+    log.info(
+        "http %s %s status=%s duration=%.2f",
+        method,
+        url,
+        resp.status_code,
+        duration,
+        extra={
+            "headers": dict(resp.headers),
+            "body_snippet": snippet,
+        },
+    )
+    return resp
+
+
+def get(url: str, **kwargs: Any) -> Response:
+    return request("GET", url, **kwargs)

--- a/src/scrape/crawl.py
+++ b/src/scrape/crawl.py
@@ -3,8 +3,19 @@ import logging
 from collections.abc import Iterable
 from pathlib import Path
 
-import requests
 from jsonschema import ValidationError, validate
+
+from src.common.http import get as http_get
+
+
+class _RequestsShim:
+    """Shim so tests can patch requests.get."""
+
+    def get(self, url, *args, **kwargs):
+        return http_get(url, *args, **kwargs)
+
+
+requests = _RequestsShim()
 
 log = logging.getLogger(__name__)
 

--- a/src/scrape/parse.py
+++ b/src/scrape/parse.py
@@ -5,15 +5,12 @@ from urllib.parse import urljoin, urlparse
 
 import feedfinder2
 import feedparser
-import requests
 import vcr
 from bs4 import BeautifulSoup
 from tenacity import retry, stop_after_attempt, wait_exponential
 
+from src.common.http import get as http_get
 from src.sensors import sensor
-
-SESSION = requests.Session()
-SESSION.trust_env = False
 
 log = logging.getLogger(__name__)
 logging.getLogger("urllib3.connectionpool").setLevel(logging.WARNING)
@@ -31,7 +28,7 @@ _EXT_PROBES = [".xml", ".rss"]
 @sensor("scrape")
 @retry(stop=stop_after_attempt(3), wait=wait_exponential(multiplier=1))
 def fetch_html(url: str) -> str:
-    resp = SESSION.get(url, timeout=10)
+    resp = http_get(url, timeout=10)
     ct = resp.headers.get("content-type", "")
     links = BeautifulSoup(resp.text, "lxml").find_all("link")
     log.debug(
@@ -78,7 +75,7 @@ def _stage_anchor_heuristics(html: str, base: str) -> list[str]:
 
 def _parse_feed(url: str) -> list[dict]:
     try:
-        resp = SESSION.get(url, timeout=10)
+        resp = http_get(url, timeout=10)
         resp.raise_for_status()
     except Exception as exc:  # pragma: no cover - network failures
         log.warning("feed request failed for %s: %s", url, exc)
@@ -98,7 +95,7 @@ def _probe_extensions(url: str) -> list[str]:
 
 def _validate_feed(url: str) -> bool:
     try:
-        resp = SESSION.get(url, timeout=8)
+        resp = http_get(url, timeout=8)
         return 200 <= resp.status_code < 400
     except Exception as e:  # pragma: no cover - network errors
         log.warning("feed validation failed: %s \u2013 keeping URL", e)


### PR DESCRIPTION
## Summary
- add robust HTTP helper with retries, rate limit handling and logging
- hook scraper modules into the helper
- provide `diagnose_and_run.py` helper and pytest config

## Testing
- `ruff check src/scrape/crawl.py src/common/http.py scripts/diagnose_and_run.py src/scrape/parse.py --fix`
- `black src/scrape/crawl.py src/common/http.py scripts/diagnose_and_run.py src/scrape/parse.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6890b70d532c8325ae7c50993710d66e