### PR TITLE
feat: add CI Docker image and workflows

### DIFF
--- a/.github/docker/ci.Dockerfile
+++ b/.github/docker/ci.Dockerfile
@@ -1,0 +1,27 @@
+FROM ubuntu:22.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Install Python, Node.js LTS, Playwright deps and tooling
+RUN apt-get update && apt-get install -y curl && \
+    curl -fsSL https://deb.nodesource.com/setup_lts.x | bash - && \
+    apt-get install -y \
+        python3.11 python3.11-distutils python3-pip git nodejs \
+        libasound2 libatk1.0-0 libatk-bridge2.0-0 libgtk-3-0 libgbm-dev \
+        libnotify-dev libnss3 libxss1 libxtst6 ca-certificates wget && \
+    npm install -g playwright && \
+    npx playwright install-deps && \
+    npx playwright install && \
+    rm -rf /var/lib/apt/lists/*
+
+# Set Python 3.11 as default
+RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.11 1 && \
+    ln -s /usr/bin/pip3 /usr/bin/pip
+
+# Install Python dependencies and dev tools
+COPY requirements.txt /tmp/requirements.txt
+RUN python3 -m pip install --upgrade pip && \
+    python3 -m pip install -r /tmp/requirements.txt ruff==0.12.5 black coverage[toml] && \
+    rm /tmp/requirements.txt
+
+WORKDIR /workspace

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -1,0 +1,31 @@
+name: build-ci-image
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: .github/docker/ci.Dockerfile
+          push: true
+          tags: ghcr.io/${{ github.repository_owner }}/yacht-osint-ci:latest
+          cache-from: type=registry,ref=ghcr.io/${{ github.repository_owner }}/yacht-osint-ci:cache
+          cache-to: type=registry,ref=ghcr.io/${{ github.repository_owner }}/yacht-osint-ci:cache,mode=max

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,25 +7,10 @@ on:
 jobs:
   build:
     runs-on: ubuntu-22.04
+    container:
+      image: ghcr.io/${{ github.repository_owner }}/yacht-osint-ci:latest
     steps:
       - uses: actions/checkout@v4
-
-      - uses: actions/setup-python@v5
-        with:
-          python-version: '3.11'
-
-      - uses: actions/cache@v4
-        with:
-          path: ~/.cache/ms-playwright
-          key: playwright-${{ runner.os }}-${{ hashFiles('requirements.txt') }}
-
-      - name: Install Playwright system dependencies
-        run: |
-          pip install playwright          # ensure CLI is available
-          playwright install --with-deps  # installs OS libs
-
-      - name: Install dev tools
-        run: pip install ruff==0.12.5 black coverage[toml]
 
       - name: Quality gate
         run: |
@@ -33,20 +18,11 @@ jobs:
           black --check .
 
       - name: Export CSV
-        working-directory: ${{ github.workspace }}
         run: |
           python -m src.export.csv
-          echo "Exit=$?"
-          find . -maxdepth 2 -type f
-          find . -name yachts.csv
           test -f exports/yachts.csv
 
-      - name: Debug workspace
-        working-directory: ${{ github.workspace }}
-        run: echo "PWD=$(pwd)" && find . -maxdepth 3 -type f
-
       - name: Tests
-        working-directory: ${{ github.workspace }}
         run: pytest -q --cov=src --cov-report=xml
 
       - name: Upload exports


### PR DESCRIPTION
## Summary
- add Ubuntu 22.04 based Docker image preloaded with Python 3.11, Node.js LTS, Playwright and project deps
- build and push the image to GHCR on pushes to main
- run CI jobs inside the pre-built container image

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: missing columns)*
- Attempted to open Issue `ci-fail` but lacked credentials


------
https://chatgpt.com/codex/tasks/task_e_6891fc902ae88325b1cc3af7fffb0509